### PR TITLE
fix(net): restore SG2002 Wi-Fi progress under backpressure

### DIFF
--- a/docs/docs/architecture/net/memory.md
+++ b/docs/docs/architecture/net/memory.md
@@ -95,6 +95,11 @@ ring full 不会 busy-wait 或 drop token：
 queue group 在 blocked 时保持 IRQ mask。protocol owner 消费或释放 ring 空间后精准
 schedule 该 group；没有周期 retry timer。
 
+`ProtocolGroupPort::receive_owned()` 取走 RX-ready completion 后立即通知 queue owner，
+因为 ring slot 此时已可复用。这个通知不能延后到 `ProtocolRxFrame` 析构：协议可能在
+等待 TX 空间时保留 DMA frame，而释放 TX 空间又需要 queue owner 继续运行。
+DMA token 仍只在消费完成后归还；ring 空间通知与 DMA 回收是两个独立的进度事件。
+
 ## 6. DMA synchronization
 
 CPU 读取 RX payload 前使用 `read_with_cpu()`，CPU 写 TX payload时使用

--- a/drivers/net/aic8800/README.md
+++ b/drivers/net/aic8800/README.md
@@ -14,6 +14,19 @@ SDIO 命令编码、CCCR/FBR/CIS、Function 生命周期和 CMD52/CMD53 均由
 模块，仅由 `rdif` feature 编译；默认构建仍只有 Driver Core。构建脚本只在
 构建机下载并校验固定哈希固件，不是目标驱动的网络或运行时依赖。
 
+DC 数据发送与命令发送使用不同的流控规则。`drive_ready()` 在 Function 1 的
+每次数据写入前读取发送额度，`consume_transmit_flow()` 将寄存器低 7 位解释为
+可用固件 buffer 数，保留 2 个 buffer 后才允许发送一帧；额度不足时保留原 TX，
+通过 `WaitForInterruptUntil` 同时等待卡中断和绝对重试截止时间，再重新读取。
+已到达的 RX 在截止时间前仍可排空，不能因等待 TX 额度而屏蔽接收进度。
+额度按帧计数。Function 2 的 DC mailbox 继续直接发送，D80 策略不在本次修改范围内。
+这个区别对应 [Sipeed BSP 的数据流控](https://github.com/sipeed/LicheeRV-Nano-Build/blob/d4003f15b35d43ad4842f427050ab2bba0114fa5/osdrv/extdrv/wireless/aic8800/aic8800_fdrv/aicwf_sdio.c#L351)
+及同文件的数据帧计数逻辑。
+
+`consume_receive_data()` 在 `AicState::Starting` 时不把 `SM_CONNECT_IND` 归给
+新连接：此阶段尚未接受本次连接请求，固件留下的成功或失败指示都不能安装 peer
+或终止初始化。进入本次连接流程后，拒绝状态仍沿原错误路径返回。
+
 源码按领域目录组织：
 
 ```text
@@ -66,3 +79,6 @@ src/
 无需 QEMU 的私有状态机测试放在对应源文件末尾；`tests/std.rs` 只通过公开
 API 验证 crate 契约。真实 SDIO/Wi-Fi、FDT 和硬中断链路必须使用 axtest
 或 SG2002 实板验证。
+
+标准库 CI 通过 `cargo xtask test` 的 `host-test + rdif` profile 执行完整测试，
+包括启动指示归属和低发送额度下的状态转换；宿主状态机结果不替代实板流量验收。

--- a/drivers/net/aic8800/src/device/data_plane.rs
+++ b/drivers/net/aic8800/src/device/data_plane.rs
@@ -318,7 +318,13 @@ impl AicDevice {
         response: SdioResponse,
         now: MonotonicTime,
     ) -> Result<(), AicError> {
-        let credits = flow_credits(expect_byte(response)?);
+        let raw_credits = expect_byte(response)?;
+        #[cfg(feature = "rdif")]
+        {
+            self.data.diagnostic_last_flow = Some(raw_credits);
+            self.data.diagnostic_flow_reads = self.data.diagnostic_flow_reads.saturating_add(1);
+        }
+        let credits = flow_credits(raw_credits);
         let active = self
             .data
             .active_tx
@@ -354,6 +360,11 @@ impl AicDevice {
             .active_tx
             .take()
             .ok_or(AicError::CompletionMismatch)?;
+        #[cfg(feature = "rdif")]
+        {
+            self.data.diagnostic_tx_completions =
+                self.data.diagnostic_tx_completions.saturating_add(1);
+        }
         match active.completion {
             super::owner::TxCompletion::User(token) => self
                 .data

--- a/drivers/net/aic8800/src/device/data_plane.rs
+++ b/drivers/net/aic8800/src/device/data_plane.rs
@@ -242,6 +242,12 @@ impl AicDevice {
                     message_id: SM_CONNECT_IND,
                     payload,
                 } => {
+                    // Startup has not accepted a host connection request. Firmware can
+                    // retain indications across a warm reset; they cannot complete or
+                    // reject a connection owned by this device lifecycle.
+                    if self.lifecycle.state == AicState::Starting {
+                        continue;
+                    }
                     let indication = parse_connect_indication(&payload)?;
                     log::info!(
                         "[wifi] association complete; learned firmware vif={} station={}",
@@ -284,6 +290,14 @@ impl AicDevice {
                             super::control::ControlOperation::Connect(connect)
                                 if connect.phase == super::control::ConnectPhase::Resetting)
                     });
+                    if !resetting {
+                        log::warn!(
+                            "[wifi] station disconnected: reason={} vif={} state={:?}",
+                            indication.reason_code,
+                            indication.interface_index,
+                            self.lifecycle.state
+                        );
+                    }
                     if !resetting && self.lifecycle.control.take().is_some() {
                         self.data.events.push_back(AicEvent::ControlFailed(
                             AicError::Disconnected {

--- a/drivers/net/aic8800/src/device/data_plane.rs
+++ b/drivers/net/aic8800/src/device/data_plane.rs
@@ -13,6 +13,10 @@ use crate::{
 };
 
 const IO_RETRY: Duration = Duration::from_millis(1);
+// The DC data FIFO reports packet buffers, independently of SDIO block size.
+// Keep the BSP's two-buffer reserve; its direct mailbox path is separate.
+// https://github.com/sipeed/LicheeRV-Nano-Build/blob/d4003f15b35d43ad4842f427050ab2bba0114fa5/osdrv/extdrv/wireless/aic8800/aic8800_fdrv/aicwf_sdio.c#L351-L392
+const DC_TX_RESERVED_BUFFERS: u8 = 2;
 const INTERNAL_TX_CAPACITY: usize = 2;
 const ETHERTYPE_EAPOL: [u8; 2] = [0x88, 0x8e];
 
@@ -57,29 +61,10 @@ impl AicDevice {
         }
         self.prepare_next_transmit();
         if self.data.active_tx.is_some() {
-            return match self.data_tx_flow_policy() {
-                DataTxFlowPolicy::Direct => {
-                    let wire_frame = self
-                        .data
-                        .active_tx
-                        .as_ref()
-                        .expect("active TX is present after preparation")
-                        .wire_frame
-                        .clone();
-                    self.emit(
-                        IoPurpose::TransmitData,
-                        write_fifo(
-                            self.data_function(),
-                            self.registers().write_fifo,
-                            wire_frame,
-                        ),
-                    )
-                }
-                DataTxFlowPolicy::CreditGated => self.emit(
-                    IoPurpose::TransmitFlow,
-                    read_byte(self.data_function(), self.registers().flow_control),
-                ),
-            };
+            return self.emit(
+                IoPurpose::TransmitFlow,
+                read_byte(self.data_function(), self.registers().flow_control),
+            );
         }
         AicAction::WaitForInterrupt
     }
@@ -339,7 +324,15 @@ impl AicDevice {
             .active_tx
             .as_ref()
             .ok_or(AicError::CompletionMismatch)?;
-        if credits == 0 || usize::from(credits) * BLOCK_SIZE <= active.wire_frame.len() {
+        let can_transmit = match self.data_tx_flow_policy() {
+            // Each write contains one frame. Read fresh firmware availability
+            // for the next frame instead of reusing this admission budget.
+            DataTxFlowPolicy::FirmwareBuffers => credits > DC_TX_RESERVED_BUFFERS,
+            DataTxFlowPolicy::CreditGated => {
+                credits != 0 && usize::from(credits) * BLOCK_SIZE > active.wire_frame.len()
+            }
+        };
+        if !can_transmit {
             self.lifecycle.retry_at = Some(now.after(IO_RETRY));
             return Ok(());
         }
@@ -923,8 +916,7 @@ mod tests {
         ));
     }
 
-    #[test]
-    fn dc_transmit_starts_without_reading_data_flow_credits() {
+    fn ready_dc() -> AicDevice {
         let mut device = AicDevice::new(ChipVariant::Aic8800DC).unwrap();
         device.lifecycle.state = AicState::Ready;
         device.data.link.install_mac([2, 0, 0, 0, 0, 1]).unwrap();
@@ -935,16 +927,183 @@ mod tests {
             .install_peer(0, 0, [2, 1, 2, 3, 4, 5])
             .unwrap();
         device
-            .data
-            .tx
-            .enqueue(TxToken::new(1), vec![0; 60])
-            .unwrap();
+    }
 
-        let AicAction::SubmitSdio(request) = device.drive_ready(MonotonicTime::default()) else {
-            panic!("expected a direct DC data write")
+    fn sdio_request(action: AicAction) -> SdioRequest {
+        let AicAction::SubmitSdio(request) = action else {
+            panic!("expected an SDIO request, got {action:?}");
         };
-        assert!(
-            matches!(request.kind, SdioRequestKind::Write { function, .. } if function.get() == 1)
+        request
+    }
+
+    fn complete(request: &SdioRequest, response: SdioResponse, now: MonotonicTime) -> AicInput {
+        AicInput {
+            now,
+            event: Some(AicInputEvent::Sdio(SdioCompletion {
+                request_id: request.id,
+                result: Ok(response),
+            })),
+        }
+    }
+
+    fn assert_dc_flow_read(request: &SdioRequest) {
+        assert!(matches!(
+            request.kind,
+            SdioRequestKind::ReadByte { function, address }
+                if function.get() == 1 && address.get() == 0x0a
+        ));
+    }
+
+    #[test]
+    fn dc_data_reserves_firmware_buffers_and_rechecks_each_frame() {
+        let mut device = ready_dc();
+        let mut now = MonotonicTime::default();
+        let first = vec![0x5a; 1514];
+        let second = vec![0xa5; 60];
+        let mut flow = sdio_request(device.advance(AicInput {
+            now,
+            event: Some(AicInputEvent::Tx {
+                token: TxToken::new(11),
+                frame: first.clone(),
+            }),
+        }));
+        assert_dc_flow_read(&flow);
+        assert_eq!(
+            device.advance(AicInput {
+                now,
+                event: Some(AicInputEvent::Tx {
+                    token: TxToken::new(12),
+                    frame: second.clone(),
+                }),
+            }),
+            AicAction::WaitForInterrupt
+        );
+
+        for available in [0, 1, 2, 0x82] {
+            let deadline = now.after(IO_RETRY);
+            assert_eq!(
+                device.advance(complete(&flow, SdioResponse::Byte(available), now)),
+                AicAction::WaitForInterruptUntil(deadline),
+                "low credits must retain the active frame without writing or completing it"
+            );
+            assert_eq!(
+                device.advance(AicInput::tick(now)),
+                AicAction::WaitForInterruptUntil(deadline)
+            );
+            now = deadline;
+            flow = sdio_request(device.advance(AicInput::tick(now)));
+            assert_dc_flow_read(&flow);
+        }
+
+        // Three firmware buffers allow one MTU frame, even though its padded
+        // transport length equals three SDIO blocks. Bit 7 is not a credit.
+        let write = sdio_request(device.advance(complete(&flow, SdioResponse::Byte(0x83), now)));
+        let SdioRequestKind::Write {
+            function,
+            address,
+            bytes,
+            ..
+        } = &write.kind
+        else {
+            panic!("one available firmware buffer must permit an MTU write");
+        };
+        assert_eq!(function.get(), 1);
+        assert_eq!(address.get(), 0x07);
+        assert_eq!(bytes.len(), 1536);
+        assert_eq!(&bytes[32..1532], &first[14..]);
+        assert_eq!(
+            device.advance(complete(&write, SdioResponse::Unit, now)),
+            AicAction::Event(AicEvent::TransmitComplete(TxToken::new(11)))
+        );
+
+        flow = sdio_request(device.advance(AicInput::tick(now)));
+        assert_dc_flow_read(&flow);
+        let deadline = now.after(IO_RETRY);
+        assert_eq!(
+            device.advance(complete(&flow, SdioResponse::Byte(2), now)),
+            AicAction::WaitForInterruptUntil(deadline)
+        );
+        now = deadline;
+        flow = sdio_request(device.advance(AicInput::tick(now)));
+        assert_dc_flow_read(&flow);
+        let write = sdio_request(device.advance(complete(&flow, SdioResponse::Byte(3), now)));
+        let SdioRequestKind::Write { bytes, .. } = &write.kind else {
+            panic!("the second frame must resume after credits recover");
+        };
+        assert_eq!(&bytes[32..78], &second[14..]);
+        assert_eq!(
+            device.advance(complete(&write, SdioResponse::Unit, now)),
+            AicAction::Event(AicEvent::TransmitComplete(TxToken::new(12)))
+        );
+        assert_eq!(
+            device.advance(AicInput::tick(now)),
+            AicAction::WaitForInterrupt
+        );
+    }
+
+    #[test]
+    fn dc_receive_progresses_while_data_waits_for_firmware_buffers() {
+        let mut device = ready_dc();
+        let now = MonotonicTime::default();
+        let flow = sdio_request(device.advance(AicInput {
+            now,
+            event: Some(AicInputEvent::Tx {
+                token: TxToken::new(1),
+                frame: vec![0; 60],
+            }),
+        }));
+        assert_dc_flow_read(&flow);
+        let deadline = now.after(IO_RETRY);
+        assert_eq!(
+            device.advance(complete(&flow, SdioResponse::Byte(2), now)),
+            AicAction::WaitForInterruptUntil(deadline)
+        );
+        let command_count = sdio_request(device.advance(AicInput {
+            now,
+            event: Some(AicInputEvent::Irq(IrqSnapshot {
+                sequence: 1,
+                card_interrupt: true,
+                ..IrqSnapshot::default()
+            })),
+        }));
+        assert!(matches!(
+            command_count.kind,
+            SdioRequestKind::ReadByte { function, address }
+                if function.get() == 2 && address.get() == 0x12
+        ));
+        let data_count =
+            sdio_request(device.advance(complete(&command_count, SdioResponse::Byte(0), now)));
+        assert!(matches!(
+            data_count.kind,
+            SdioRequestKind::ReadByte { function, address }
+                if function.get() == 1 && address.get() == 0x12
+        ));
+        let read = sdio_request(device.advance(complete(&data_count, SdioResponse::Byte(1), now)));
+        assert!(matches!(
+            read.kind,
+            SdioRequestKind::Read { function, address, length, .. }
+                if function.get() == 1 && address.get() == 0x08 && length == BLOCK_SIZE
+        ));
+        let mut fifo = data_fifo(0x42);
+        fifo.resize(BLOCK_SIZE, 0);
+        let received = device.advance(complete(&read, SdioResponse::Data(fifo), now));
+        let AicAction::Event(AicEvent::Receive(frame)) = received else {
+            panic!("RX must be delivered before retrying blocked TX: {received:?}");
+        };
+        assert_eq!(frame[0], 0x42);
+        assert_eq!(frame.last(), Some(&0x42));
+        let count = sdio_request(device.advance(AicInput::tick(now)));
+        assert_eq!(
+            device.advance(complete(&count, SdioResponse::Byte(0), now)),
+            AicAction::WaitForInterruptUntil(deadline),
+            "draining RX must restore the IRQ-enabled wait without polling TX early"
+        );
+        let flow = sdio_request(device.advance(AicInput::tick(deadline)));
+        assert_dc_flow_read(&flow);
+        assert_eq!(
+            device.advance(complete(&flow, SdioResponse::Byte(2), deadline)),
+            AicAction::WaitForInterruptUntil(deadline.after(IO_RETRY)),
+            "receiving a frame does not grant firmware TX credits"
         );
     }
 }

--- a/drivers/net/aic8800/src/device/data_plane.rs
+++ b/drivers/net/aic8800/src/device/data_plane.rs
@@ -654,6 +654,90 @@ mod tests {
     }
 
     #[test]
+    fn startup_connect_indications_cannot_publish_or_fail_a_new_connection() {
+        for status in [1u16, 0] {
+            let mut device = AicDevice::new(ChipVariant::Aic8800DC).unwrap();
+            device.start(MonotonicTime::default()).unwrap();
+            let mut payload = [0; 11];
+            payload[..2].copy_from_slice(&status.to_le_bytes());
+            payload[2..8].copy_from_slice(&[2, 1, 2, 3, 4, 5]);
+            payload[10] = 7;
+            device.io.pending = Some(PendingIo {
+                id: 1,
+                purpose: IoPurpose::ReceiveData(RxPath::Command),
+            });
+
+            let action = device.advance(AicInput {
+                now: MonotonicTime::from_nanos(1),
+                event: Some(AicInputEvent::Sdio(SdioCompletion {
+                    request_id: 1,
+                    result: Ok(SdioResponse::Data(indication_fifo(
+                        SM_CONNECT_IND,
+                        &payload,
+                    ))),
+                })),
+            });
+
+            assert!(
+                matches!(action, AicAction::SubmitSdio(_)),
+                "startup must continue draining the FIFO after an unowned connect indication with \
+                 status {status}: {action:?}"
+            );
+            assert_eq!(device.state(), AicState::Starting);
+            assert_eq!(device.data.link.peer(), None);
+            assert!(device.lifecycle.control.is_none());
+            assert!(device.data.events.is_empty());
+        }
+    }
+
+    #[test]
+    fn active_connect_indication_rejection_remains_a_terminal_failure() {
+        let mut device = AicDevice::new(ChipVariant::Aic8800DC).unwrap();
+        device.lifecycle.state = AicState::Ready;
+        let mut control = super::super::control::build(
+            ControlRequest::Connect {
+                ssid: b"network".to_vec(),
+                pmk: None,
+                entropy: None,
+            },
+            [2, 0, 0, 0, 0, 1],
+            Some(0),
+        )
+        .unwrap();
+        if let super::super::control::ControlOperation::Connect(connect) = &mut control.operation {
+            connect.phase = super::super::control::ConnectPhase::AwaitIndication;
+        }
+        control.commands.clear();
+        device.lifecycle.control = Some(control);
+        device.io.pending = Some(PendingIo {
+            id: 1,
+            purpose: IoPurpose::ReceiveData(RxPath::Command),
+        });
+        let mut payload = [0; 11];
+        payload[..2].copy_from_slice(&1u16.to_le_bytes());
+
+        let action = device.advance(AicInput {
+            now: MonotonicTime::from_nanos(1),
+            event: Some(AicInputEvent::Sdio(SdioCompletion {
+                request_id: 1,
+                result: Ok(SdioResponse::Data(indication_fifo(
+                    SM_CONNECT_IND,
+                    &payload,
+                ))),
+            })),
+        });
+
+        assert!(matches!(
+            action,
+            AicAction::Event(AicEvent::Failed(AicError::FirmwareRejected {
+                message_id: SM_CONNECT_IND,
+                status: 1,
+            }))
+        ));
+        assert_eq!(device.state(), AicState::Failed);
+    }
+
+    #[test]
     fn asynchronous_disconnect_clears_the_learned_peer() {
         let mut device = AicDevice::new(ChipVariant::Aic8800D80).unwrap();
         device.lifecycle.state = AicState::Ready;

--- a/drivers/net/aic8800/src/device/owner.rs
+++ b/drivers/net/aic8800/src/device/owner.rs
@@ -56,6 +56,12 @@ pub(super) struct DataPlaneState {
     pub active_tx: Option<ActiveTx>,
     pub internal_tx: VecDeque<InternalTx>,
     pub link: LinkState,
+    #[cfg(feature = "rdif")]
+    pub diagnostic_last_flow: Option<u8>,
+    #[cfg(feature = "rdif")]
+    pub diagnostic_flow_reads: u64,
+    #[cfg(feature = "rdif")]
+    pub diagnostic_tx_completions: u64,
 }
 
 /// Sole owner of all AIC protocol and data-plane state.
@@ -102,6 +108,12 @@ impl AicDevice {
                 active_tx: None,
                 internal_tx: VecDeque::new(),
                 link: LinkState::new(),
+                #[cfg(feature = "rdif")]
+                diagnostic_last_flow: None,
+                #[cfg(feature = "rdif")]
+                diagnostic_flow_reads: 0,
+                #[cfg(feature = "rdif")]
+                diagnostic_tx_completions: 0,
             },
         })
     }
@@ -131,6 +143,37 @@ impl AicDevice {
     #[cfg(any(feature = "rdif", test))]
     pub(crate) fn card_irq_needed(&self) -> bool {
         self.lifecycle.state == AicState::Ready || self.startup_confirmation_waiting()
+    }
+
+    #[cfg(feature = "rdif")]
+    pub(crate) fn log_tx_diagnostic(&self, sample: u8) {
+        let pending = self
+            .io
+            .pending
+            .as_ref()
+            .map(|pending| (pending.id, pending.purpose));
+        let next = self.io.next.as_ref().map(|(purpose, _)| purpose);
+        let active_tx = self.data.active_tx.as_ref().map(|active| {
+            let token = match &active.completion {
+                TxCompletion::User(token) => Some(token.get()),
+                TxCompletion::Internal(_) => None,
+            };
+            (token, active.wire_frame.len())
+        });
+        log::info!(
+            "[wifi-diag] core sample={sample} state={:?} io={pending:?} next={next:?} \
+             rx_scan={}/{} events={} tx={active_tx:?} flow={:?} flow_reads={} tx_done={} \
+             retry={:?} peer={:?}",
+            self.lifecycle.state,
+            self.io.receive.active,
+            self.io.receive.next_path,
+            self.data.events.len(),
+            self.data.diagnostic_last_flow,
+            self.data.diagnostic_flow_reads,
+            self.data.diagnostic_tx_completions,
+            self.lifecycle.retry_at.map(MonotonicTime::as_nanos),
+            self.data.link.tx_indices(),
+        );
     }
 }
 

--- a/drivers/net/aic8800/src/device/progress.rs
+++ b/drivers/net/aic8800/src/device/progress.rs
@@ -1,6 +1,7 @@
 use alloc::vec::Vec;
 
 use super::*;
+use crate::profile::DataTxFlowPolicy;
 
 #[cfg(test)]
 const NANOS_PER_MILLISECOND: u64 = 1_000_000;
@@ -45,6 +46,21 @@ impl AicDevice {
         }
         if let Some(deadline) = self.lifecycle.retry_at {
             if input.now < deadline {
+                if self.lifecycle.state == AicState::Ready
+                    && self.data.active_tx.is_some()
+                    && self.lifecycle.mailbox.is_none()
+                    && matches!(
+                        self.data_tx_flow_policy(),
+                        DataTxFlowPolicy::FirmwareBuffers
+                    )
+                {
+                    // Credit waits keep CARD_INT enabled. Drain a latched RX
+                    // scan before rearming, without polling TX before its deadline.
+                    if let Some(action) = self.drive_receive_scan() {
+                        return action;
+                    }
+                    return AicAction::WaitForInterruptUntil(deadline);
+                }
                 return AicAction::RetryAt(deadline);
             }
             self.lifecycle.retry_at = None;

--- a/drivers/net/aic8800/src/profile.rs
+++ b/drivers/net/aic8800/src/profile.rs
@@ -34,7 +34,7 @@ pub(crate) enum MailboxFlowPolicy {
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum DataTxFlowPolicy {
-    Direct,
+    FirmwareBuffers,
     CreditGated,
 }
 
@@ -119,7 +119,7 @@ static AIC8800DC_PROFILE: ChipProfile = ChipProfile {
     transport: TransportGeneration::V1,
     transport_header: TransportHeader::Zero,
     mailbox_flow: MailboxFlowPolicy::Direct,
-    data_tx_flow: DataTxFlowPolicy::Direct,
+    data_tx_flow: DataTxFlowPolicy::FirmwareBuffers,
     firmware: FirmwareProfile::Aic8800Dc,
     functions: DC_FUNCTIONS,
 };

--- a/drivers/net/aic8800/src/rdif/owner/output.rs
+++ b/drivers/net/aic8800/src/rdif/owner/output.rs
@@ -58,6 +58,28 @@ impl OwnerOutputs {
         }
     }
 
+    pub(super) fn has_bulk_tx_backlog(&self) -> bool {
+        self.tx_tokens.len() + self.queues.tx_submit.occupied_len() >= 8
+    }
+
+    pub(super) fn log_tx_diagnostic(&self, sample: u8) {
+        log::info!(
+            "[wifi-diag] queues sample={sample} tx_submit={} tx_owned={} tx_complete={} \
+             rx_submit={} rx_complete={} pending_tx={} pending_rx_frame={} pending_rx_complete={} \
+             pending_wifi={} queue_progress={}",
+            self.queues.tx_submit.occupied_len(),
+            self.tx_tokens.len(),
+            self.queues.tx_complete.occupied_len(),
+            self.queues.rx_submit.occupied_len(),
+            self.queues.rx_complete.occupied_len(),
+            self.pending_tx_completion.is_some(),
+            self.pending_rx_frame.is_some(),
+            self.pending_rx_completion.is_some(),
+            self.pending_wifi_progress.is_some(),
+            self.queue_progress,
+        );
+    }
+
     pub(super) fn take_tx_frame(&mut self) -> Option<(TxToken, Vec<u8>)> {
         let buffer = self.queues.tx_submit.try_pop()?;
         let length = buffer.len();

--- a/drivers/net/aic8800/src/rdif/owner/progress.rs
+++ b/drivers/net/aic8800/src/rdif/owner/progress.rs
@@ -56,6 +56,8 @@ pub(crate) struct AicOwner<H: CompletionIrqRearmHost + 'static> {
     mac: Arc<MacAddressState>,
     started: bool,
     card_irq_wait: CardIrqWait,
+    diagnostic_last_nanos: u64,
+    diagnostic_samples: u8,
 }
 
 impl<H: CompletionIrqRearmHost + Send + 'static> AicOwner<H> {
@@ -87,6 +89,8 @@ impl<H: CompletionIrqRearmHost + Send + 'static> AicOwner<H> {
             mac,
             started: false,
             card_irq_wait: CardIrqWait::Masked,
+            diagnostic_last_nanos: 0,
+            diagnostic_samples: 0,
         };
         (owner, wifi.requests_tx, wifi.progress_rx)
     }
@@ -110,6 +114,7 @@ impl<H: CompletionIrqRearmHost + Send + 'static> AicOwner<H> {
         now_nanos: u64,
         rearm_after_step: bool,
     ) -> Result<OwnerProgress, AicRdifError> {
+        self.log_tx_diagnostic(now_nanos);
         if !self.outputs.flush()? {
             return self.finish_progress(
                 OwnerProgress::Wait(OwnerWait::Interrupt),
@@ -141,6 +146,38 @@ impl<H: CompletionIrqRearmHost + Send + 'static> AicOwner<H> {
             }
         }
         self.advance_with_cause(now_nanos, cause, rearm_after_step)
+    }
+
+    fn log_tx_diagnostic(&mut self, now_nanos: u64) {
+        // Observe existing owner progress only; diagnostics never schedule work.
+        // Reserve the three samples for bulk TX rather than startup ARP traffic.
+        if self.diagnostic_samples >= 3
+            || now_nanos.saturating_sub(self.diagnostic_last_nanos) < 1_000_000_000
+            || !self.outputs.has_bulk_tx_backlog()
+        {
+            return;
+        }
+        self.diagnostic_last_nanos = now_nanos;
+        self.diagnostic_samples += 1;
+        let sample = self.diagnostic_samples;
+        let active = self.active.as_ref().map(|active| match active {
+            ActiveOperation::Direct { .. } => "direct",
+            ActiveOperation::Enable { .. } => "enable",
+            ActiveOperation::BlockSize { .. } => "block-size",
+            ActiveOperation::Interrupt { .. } => "interrupt",
+            ActiveOperation::Dma { .. } => "dma",
+            ActiveOperation::Bus { .. } => "bus",
+        });
+        let (irq_sequence, irq_pending) = self.irq_latch.diagnostic();
+        log::info!(
+            "[wifi-diag] owner sample={sample} ns={now_nanos} active={active:?} card_wait={:?} \
+             irq_seq={irq_sequence} irq_pending={irq_pending}",
+            self.card_irq_wait,
+        );
+        self.outputs.log_tx_diagnostic(sample);
+        if let Some(device) = &self.device {
+            device.log_tx_diagnostic(sample);
+        }
     }
 
     pub(crate) fn quiesce(&mut self) -> Result<(), AicRdifError> {

--- a/net/ax-net/src/queue_runtime/executor/mod.rs
+++ b/net/ax-net/src/queue_runtime/executor/mod.rs
@@ -501,7 +501,8 @@ impl QueueGroupExecutor {
         if self.shared.is_disabled() {
             return GroupPollOutcome::Failed;
         }
-        if self.group.irq_control.quiesce().is_err() {
+        if let Err(error) = self.group.irq_control.quiesce() {
+            warn!("network queue {:?}: quiesce failed: {error}", self.group.id);
             self.shared.disable();
             return GroupPollOutcome::Failed;
         }
@@ -549,6 +550,14 @@ impl QueueGroupExecutor {
                 Err(error) => {
                     let (buffer, reason) = error.into_parts();
                     if waits_for_hardware_event(&reason) {
+                        static REPORTED_TX_RETRY: core::sync::atomic::AtomicBool =
+                            core::sync::atomic::AtomicBool::new(false);
+                        if !REPORTED_TX_RETRY.swap(true, Ordering::Relaxed) {
+                            warn!(
+                                "network queue {:?}: TX waiting for hardware: {reason}",
+                                self.group.id
+                            );
+                        }
                         self.pending_tx = Some(TxRequest {
                             buffer,
                             options: request.options,
@@ -695,7 +704,10 @@ impl QueueGroupExecutor {
             Ok(NetRearmResult::RetryAt { deadline_nanos }) => {
                 self.retry_at = Some(deadline_nanos);
             }
-            Err(_) => self.shared.disable(),
+            Err(error) => {
+                warn!("network queue {:?}: rearm failed: {error}", self.group.id);
+                self.shared.disable();
+            }
         }
     }
 

--- a/net/ax-net/src/queue_runtime/executor/mod.rs
+++ b/net/ax-net/src/queue_runtime/executor/mod.rs
@@ -119,6 +119,10 @@ impl ProtocolGroupPort {
             self.rx_recycler.recycle(completion.buffer);
             return Err(NetDeviceError::Io);
         }
+        // Freeing an RX-ready slot can unblock the queue owner independently
+        // of recycling this DMA token. The protocol may retain the frame while
+        // waiting for TX space, which itself requires that owner to run.
+        self.shared.schedule_task();
         Ok(ProtocolRxFrame::new(
             completion,
             Arc::clone(&self.rx_recycler) as Arc<dyn RxBufferRecycler>,

--- a/net/ax-net/src/queue_runtime/executor/mod.rs
+++ b/net/ax-net/src/queue_runtime/executor/mod.rs
@@ -550,14 +550,6 @@ impl QueueGroupExecutor {
                 Err(error) => {
                     let (buffer, reason) = error.into_parts();
                     if waits_for_hardware_event(&reason) {
-                        static REPORTED_TX_RETRY: core::sync::atomic::AtomicBool =
-                            core::sync::atomic::AtomicBool::new(false);
-                        if !REPORTED_TX_RETRY.swap(true, Ordering::Relaxed) {
-                            warn!(
-                                "network queue {:?}: TX waiting for hardware: {reason}",
-                                self.group.id
-                            );
-                        }
                         self.pending_tx = Some(TxRequest {
                             buffer,
                             options: request.options,

--- a/net/ax-net/src/queue_runtime/tests.rs
+++ b/net/ax-net/src/queue_runtime/tests.rs
@@ -575,7 +575,7 @@ fn direct_rx_consumes_dma_backing_before_recycling_the_token() {
 }
 
 #[test]
-fn detached_rx_retains_dma_until_the_owned_frame_is_dropped() {
+fn detached_rx_releases_ring_backpressure_before_recycling_dma() {
     let (mut rx_ready_tx, rx_ready_rx) = spsc_ring(1);
     let (rx_recycle_tx, mut rx_recycle_rx) = spsc_ring(1);
     let (tx_ready_tx, _tx_ready_rx) = spsc_ring(1);
@@ -590,19 +590,24 @@ fn detached_rx_retains_dma_until_the_owned_frame_is_dropped() {
         })
         .unwrap();
 
-    let shared = Arc::new(group_state(STATE_IDLE));
+    let shared = Arc::new(group_state(STATE_POLLING));
     let mut port = ProtocolGroupPort {
         rx_ready: rx_ready_rx,
         rx_recycler: Arc::new(RxRecycler::new(rx_recycle_tx, Arc::clone(&shared), 1)),
         tx_ready: tx_ready_tx,
         tx_free: tx_free_rx,
         tx_spares: Vec::new(),
-        shared,
+        shared: Arc::clone(&shared),
     };
+    // A full RX-ready ring parked the owner with its interrupt masked.
     let frame = port
         .receive_owned()
         .expect("the queued DMA frame must be returned as owned storage");
 
+    assert!(
+        !shared.begin_rearm(),
+        "free RX-ready space must republish work even while DMA is retained"
+    );
     assert!(rx_recycle_rx.pop().is_none());
     frame.read_with(|packet| {
         assert_eq!(packet.len(), 3000);

--- a/net/ax-net/src/router.rs
+++ b/net/ax-net/src/router.rs
@@ -804,6 +804,11 @@ impl Router {
                 }
             }
         }
+        if tx_buffer.is_empty() {
+            // Reuse the hot slots after a drained batch instead of rotating
+            // through the entire allocation for shallow TX queues.
+            tx_buffer.clear();
+        }
         poll_next
     }
 }
@@ -1331,6 +1336,48 @@ mod tests {
         assert_eq!(router.tx_buffer.get_allocated(0, 1)[0].as_bytes().len(), 20);
         assert_eq!(router.devices[0].stats().tx_packets, 0);
         assert_eq!(router.devices[0].stats().tx_dropped, 0);
+    }
+
+    #[test]
+    fn drained_tx_queue_reuses_packet_storage() {
+        use smoltcp::phy::RxToken as _;
+
+        let mut router = Router::new(Arc::new(RwLock::new(RouteTable::new())));
+        router.add_device(InterfaceId::LOOPBACK, Box::new(EmptyDevice));
+        router.add_rule(Rule::new(
+            ipv4_cidr(Ipv4Address::LOCALHOST, 8),
+            None,
+            0,
+            InterfaceId::LOOPBACK,
+            IpAddress::Ipv4(Ipv4Address::LOCALHOST),
+            0,
+        ));
+        let now = Instant::from_millis(0);
+        let mut sockets = SocketSet::new(vec![]);
+        let mut first_slot = None;
+
+        // Storage identity is the cache-reuse contract: successful delivery
+        // alone would not detect rotating through cold slots after each drain.
+        for len in [64, STANDARD_MTU, 64] {
+            let mut packet = vec![0; len];
+            packet[0] = 0x45;
+            packet[2..4].copy_from_slice(&(len as u16).to_be_bytes());
+            packet[12..16].copy_from_slice(&[127, 0, 0, 1]);
+            packet[16..20].copy_from_slice(&[127, 0, 0, 1]);
+            let address = router.transmit(now).unwrap().consume(len, |dst| {
+                dst.copy_from_slice(&packet);
+                dst.as_ptr() as usize
+            });
+            assert_eq!(
+                address,
+                *first_slot.get_or_insert(address),
+                "a drained TX queue must reuse the first packet's storage"
+            );
+            assert!(router.dispatch(now, &mut sockets));
+            let (rx, _tx) = router.receive(now).unwrap();
+            rx.consume(|received| assert_eq!(received, packet));
+        }
+        assert!(router.receive(now).is_none());
     }
 
     #[test]

--- a/net/ax-net/src/router.rs
+++ b/net/ax-net/src/router.rs
@@ -63,6 +63,9 @@ use crate::{
 };
 
 const DEVICE_RX_WORKER_BATCH: usize = 16;
+static IPERF_RX_PACKETS: AtomicU64 = AtomicU64::new(0);
+static IPERF_RX_BAD_CHECKSUM: AtomicU64 = AtomicU64::new(0);
+static IPERF_RX_LAST_ACK: AtomicU64 = AtomicU64::new(0);
 
 /// Per-interface cumulative RX/TX byte and packet counters.
 ///
@@ -471,6 +474,8 @@ pub struct Router {
     ready_rx: VecDeque<OwnedRxPacket>,
     devices: Vec<DeviceHandle>,
     table: SharedRouteTable,
+    trace_reports: u8,
+    trace_next_millis: i64,
 }
 impl Router {
     /// Creates the virtual multi-device endpoint used by smoltcp.
@@ -493,6 +498,8 @@ impl Router {
             ready_rx: VecDeque::with_capacity(SOCKET_BUFFER_SIZE),
             devices: Vec::new(),
             table,
+            trace_reports: 0,
+            trace_next_millis: 0,
         }
     }
 
@@ -580,10 +587,11 @@ impl Router {
     /// Moves device-produced packets into the smoltcp RX buffer.
     pub fn poll(
         &mut self,
-        _timestamp: Instant,
+        timestamp: Instant,
         sockets: &mut SocketSet<'_>,
         mut snoop: impl FnMut(InterfaceId, &[u8]),
     ) -> bool {
+        self.trace_iperf_queues(timestamp, sockets);
         let mut moved_rx = false;
         let Router {
             rx_buffer,
@@ -811,6 +819,50 @@ impl Router {
         }
         poll_next
     }
+
+    fn trace_iperf_queues(&mut self, timestamp: Instant, sockets: &SocketSet<'_>) {
+        if self.trace_reports >= 3 || timestamp.total_millis() < self.trace_next_millis {
+            return;
+        }
+        let active = sockets.iter().any(|(_, socket)| {
+            matches!(socket, smoltcp::socket::Socket::Tcp(tcp)
+                if tcp.remote_endpoint().is_some_and(|peer| peer.port == 5201)
+                    && tcp.send_queue() >= 64 * 1024)
+        });
+        if !active {
+            return;
+        }
+        self.trace_reports += 1;
+        self.trace_next_millis = timestamp.total_millis().saturating_add(1000);
+        warn!(
+            "IPERF_ROUTER_TRACE tx={} owned_rx={} copied_rx={} fanout={}",
+            self.tx_buffer.len(),
+            self.ready_rx.len(),
+            self.rx_buffer.payload_bytes_count(),
+            self.pending_fanout.len()
+        );
+        warn!(
+            "IPERF_ACK_TRACE packets={} bad_checksum={} last_ack={}",
+            IPERF_RX_PACKETS.load(Ordering::Relaxed),
+            IPERF_RX_BAD_CHECKSUM.load(Ordering::Relaxed),
+            IPERF_RX_LAST_ACK.load(Ordering::Relaxed)
+        );
+        for (_, socket) in sockets.iter() {
+            if let smoltcp::socket::Socket::Tcp(tcp) = socket
+                && tcp.remote_endpoint().is_some_and(|peer| peer.port == 5201)
+            {
+                warn!(
+                    "IPERF_TCP_TRACE local={:?} state={:?} tx={} rx={} can_send={} can_recv={}",
+                    tcp.local_endpoint(),
+                    tcp.state(),
+                    tcp.send_queue(),
+                    tcp.recv_queue(),
+                    tcp.can_send(),
+                    tcp.can_recv()
+                );
+            }
+        }
+    }
 }
 
 fn dispatch_link_local_fanout(
@@ -991,6 +1043,13 @@ fn snoop_tcp_packet(buf: &[u8], sockets: &mut SocketSet<'_>) {
     let Ok(tcp_packet) = TcpPacket::new_checked(payload) else {
         return;
     };
+    if tcp_packet.src_port() == 5201 {
+        IPERF_RX_PACKETS.fetch_add(1, Ordering::Relaxed);
+        if !tcp_packet.verify_checksum(&src_addr, &dst_addr) {
+            IPERF_RX_BAD_CHECKSUM.fetch_add(1, Ordering::Relaxed);
+        }
+        IPERF_RX_LAST_ACK.store(tcp_packet.ack_number().0 as u32 as u64, Ordering::Relaxed);
+    }
     let src_addr = (src_addr, tcp_packet.src_port()).into();
     let dst_addr = (dst_addr, tcp_packet.dst_port()).into();
     let is_first = tcp_packet.syn() && !tcp_packet.ack();

--- a/net/ax-net/src/router.rs
+++ b/net/ax-net/src/router.rs
@@ -1317,6 +1317,149 @@ mod tests {
     }
 
     #[test]
+    fn transmit_token_survives_backpressure_and_payload_wrap() {
+        check_tx_token_after_payload_wrap(false);
+    }
+
+    #[test]
+    fn receive_token_survives_backpressure_and_payload_wrap() {
+        check_tx_token_after_payload_wrap(true);
+    }
+
+    fn check_tx_token_after_payload_wrap(reply_to_rx: bool) {
+        use ax_sync::SpinLock;
+        use smoltcp::phy::{Device as _, RxToken as _, TxToken as _};
+
+        #[derive(Default)]
+        struct TxProbe {
+            allowance: usize,
+            packets: Vec<Vec<u8>>,
+        }
+
+        struct BackpressureDevice(Arc<SpinLock<TxProbe>>);
+
+        impl Device for BackpressureDevice {
+            fn name(&self) -> &str {
+                "backpressure"
+            }
+
+            fn recv(
+                &mut self,
+                _: InterfaceId,
+                _: &mut PacketBuffer<InterfaceId>,
+                _: Instant,
+                _: &mut dyn FnMut(&[u8]),
+            ) -> usize {
+                0
+            }
+
+            fn send(&mut self, _: IpAddress, _: &[u8], _: Instant) -> usize {
+                panic!("dispatch must use the fallible TX contract")
+            }
+
+            fn try_send(
+                &mut self,
+                _: IpAddress,
+                packet: &[u8],
+                _: Instant,
+            ) -> crate::device::NetDeviceResult<usize> {
+                let mut probe = self.0.lock_irqsave();
+                if probe.allowance == 0 {
+                    return Err(NetDeviceError::Again);
+                }
+                probe.allowance -= 1;
+                probe.packets.push(packet.to_vec());
+                Ok(packet.len())
+            }
+        }
+
+        fn packet(len: usize, id: u8) -> Vec<u8> {
+            let mut packet = vec![id; len];
+            packet[0] = 0x45;
+            packet[2..4].copy_from_slice(&(len as u16).to_be_bytes());
+            packet[12..16].copy_from_slice(&[10, 0, 0, 2]);
+            packet[16..20].copy_from_slice(&[198, 51, 100, 1]);
+            packet
+        }
+
+        let mut router = Router::new(Arc::new(RwLock::new(RouteTable::new())));
+        let probe = Arc::new(SpinLock::new(TxProbe::default()));
+        router.add_device(IF0, Box::new(BackpressureDevice(Arc::clone(&probe))));
+        router.add_rule(Rule::new(
+            ipv4_cidr(Ipv4Address::UNSPECIFIED, 0),
+            Some(IpAddress::Ipv4(Ipv4Address::new(10, 0, 0, 1))),
+            0,
+            IF0,
+            SRC0,
+            100,
+        ));
+        let now = Instant::from_millis(0);
+        let mut sockets = SocketSet::new(vec![]);
+        let mut expected = vec![];
+
+        // Keep one small packet queued while advancing the payload ring's head.
+        for id in 0..2 {
+            let packet = packet(20, id);
+            router.transmit(now).unwrap().consume(packet.len(), |dst| {
+                dst.copy_from_slice(&packet);
+            });
+            expected.push(packet);
+        }
+        probe.lock_irqsave().allowance = 1;
+        assert!(router.dispatch(now, &mut sockets));
+        assert_eq!(probe.lock_irqsave().packets, expected[..1]);
+
+        for id in 0..SOCKET_BUFFER_SIZE - 1 {
+            let packet = packet(STANDARD_MTU, id as u8);
+            router.transmit(now).unwrap().consume(packet.len(), |dst| {
+                dst.copy_from_slice(&packet);
+            });
+            expected.push(packet);
+            assert!(!router.dispatch(now, &mut sockets));
+        }
+        assert!(router.transmit(now).is_none());
+
+        let incoming = packet(20, 0);
+        router
+            .rx_buffer
+            .enqueue(incoming.len(), rx_metadata(IF0, &incoming))
+            .unwrap()
+            .copy_from_slice(&incoming);
+        assert!(router.receive(now).is_none());
+
+        // With the old byte ring, the next MTU packet needs to wrap, but the
+        // free bytes are split into a 1460-byte tail and a 40-byte head.
+        probe.lock_irqsave().allowance = 1;
+        assert!(router.dispatch(now, &mut sockets));
+        assert_eq!(probe.lock_irqsave().packets, expected[..2]);
+        let token = if reply_to_rx {
+            let (rx, tx) = router.receive(now).unwrap();
+            rx.consume(|packet| assert_eq!(packet, incoming));
+            tx
+        } else {
+            router.transmit(now).unwrap()
+        };
+        let final_packet = packet(STANDARD_MTU, 0xfe);
+        assert_eq!(
+            token.consume(final_packet.len(), |dst| {
+                dst.copy_from_slice(&final_packet);
+                42
+            }),
+            42
+        );
+        expected.push(final_packet);
+
+        probe.lock_irqsave().allowance = expected.len();
+        assert!(router.dispatch(now, &mut sockets));
+        assert_eq!(probe.lock_irqsave().packets, expected);
+        assert!(router.transmit(now).is_some());
+        assert!(!router.dispatch(now, &mut sockets));
+        assert_eq!(router.devices[0].stats().tx_packets, expected.len() as u64);
+        assert_eq!(router.devices[0].stats().tx_errors, 0);
+        assert_eq!(router.devices[0].stats().tx_dropped, 0);
+    }
+
+    #[test]
     fn fanout_retries_only_blocked_ports_without_repeating_accepted_packets() {
         use ax_sync::SpinLock;
 

--- a/net/ax-net/src/router.rs
+++ b/net/ax-net/src/router.rs
@@ -45,7 +45,7 @@ use ax_sync::SpinRwLock as RwLock;
 use smoltcp::{
     iface::SocketSet,
     phy::{DeviceCapabilities, Medium, PacketMeta},
-    storage::PacketMetadata,
+    storage::{PacketMetadata, RingBuffer},
     time::Instant,
     wire::{
         IpAddress, IpCidr, IpProtocol, IpVersion, Ipv4Address, Ipv4Cidr, Ipv4Packet, Ipv6Packet,
@@ -143,26 +143,29 @@ struct RxMetadata {
 type RouterPacketBuffer = smoltcp::storage::PacketBuffer<'static, RxMetadata>;
 type DevicePacketBuffer = smoltcp::storage::PacketBuffer<'static, InterfaceId>;
 
+// Each free slot guarantees a contiguous MTU-sized packet without byte-ring
+// padding or a second metadata allocation when the queue wraps.
+#[derive(Clone)]
+struct TxPacket {
+    len: usize,
+    bytes: [u8; STANDARD_MTU],
+}
+
+impl TxPacket {
+    fn as_bytes(&self) -> &[u8] {
+        &self.bytes[..self.len]
+    }
+}
+
 struct OwnedRxPacket {
     metadata: RxMetadata,
     packet: DeviceRxPacket,
 }
 
-// TX metadata is created before route lookup; dispatch() selects the real
-// egress interface from the packet destination and route table.
-const TX_INTERFACE_PLACEHOLDER: InterfaceId = InterfaceId::new(0);
-
 fn rx_metadata(interface_id: InterfaceId, packet: &[u8]) -> RxMetadata {
     RxMetadata {
         interface_id,
         packet_meta: packet_meta_for_rx_packet(packet),
-    }
-}
-
-fn tx_metadata() -> RxMetadata {
-    RxMetadata {
-        interface_id: TX_INTERFACE_PLACEHOLDER,
-        packet_meta: PacketMeta::default(),
     }
 }
 
@@ -460,7 +463,7 @@ pub(crate) type SharedRouteTable = Arc<RwLock<RouteTable>>;
 /// Virtual smoltcp device that multiplexes all concrete devices.
 pub struct Router {
     rx_buffer: RouterPacketBuffer,
-    tx_buffer: RouterPacketBuffer,
+    tx_buffer: RingBuffer<'static, TxPacket>,
     /// Device indices still awaiting the head TX packet. Devices are append-only;
     /// accepted or permanently failed ports leave this list before the next retry.
     pending_fanout: Vec<usize>,
@@ -476,10 +479,13 @@ impl Router {
             vec![PacketMetadata::EMPTY; SOCKET_BUFFER_SIZE],
             vec![0u8; STANDARD_MTU * SOCKET_BUFFER_SIZE],
         );
-        let tx_buffer = RouterPacketBuffer::new(
-            vec![PacketMetadata::EMPTY; SOCKET_BUFFER_SIZE],
-            vec![0u8; STANDARD_MTU * SOCKET_BUFFER_SIZE],
-        );
+        let tx_buffer = RingBuffer::new(vec![
+            TxPacket {
+                len: 0,
+                bytes: [0; STANDARD_MTU],
+            };
+            SOCKET_BUFFER_SIZE
+        ]);
         Self {
             rx_buffer,
             tx_buffer,
@@ -733,7 +739,8 @@ impl Router {
             table,
             ..
         } = self;
-        while let Ok((_, packet)) = tx_buffer.peek() {
+        while let Some(packet) = tx_buffer.get_allocated(0, 1).first() {
+            let packet = packet.as_bytes();
             let outcome = match IpVersion::of_packet(packet).expect("got invalid IP packet") {
                 IpVersion::Ipv4 => {
                     let packet = smoltcp::wire::Ipv4Packet::new_checked(packet)
@@ -788,7 +795,7 @@ impl Router {
                 DispatchOutcome::Consumed(next) => {
                     poll_next |= next;
                     tx_buffer
-                        .dequeue()
+                        .dequeue_one()
                         .expect("the packet was only peeked while dispatching");
                 }
                 DispatchOutcome::Retry(next) => {
@@ -921,19 +928,21 @@ fn inject_loopback_rx_direct(
 }
 
 /// smoltcp TX token backed by the router's temporary TX buffer.
-pub struct TxToken<'a>(&'a mut RouterPacketBuffer);
+pub struct TxToken<'a>(&'a mut RingBuffer<'static, TxPacket>);
 
 impl smoltcp::phy::TxToken for TxToken<'_> {
     fn consume<R, F>(self, len: usize, f: F) -> R
     where
         F: FnOnce(&mut [u8]) -> R,
     {
-        // TX metadata is ignored: Router::dispatch parses the emitted IP
-        // packet and selects the actual egress interface from the route table.
-        let packet = self
+        // receive()/transmit() checked for a free MTU-sized slot. This token's
+        // exclusive borrow prevents any intervening enqueue before consume().
+        let slot = self
             .0
-            .enqueue(len, tx_metadata())
+            .enqueue_one()
             .expect("This was checked before creating the TxToken");
+        slot.len = len;
+        let packet = &mut slot.bytes[..len];
         let result = f(packet);
         apply_egress_ip_tos(packet);
         result
@@ -1069,7 +1078,10 @@ impl smoltcp::phy::Device for Router {
 
 #[cfg(test)]
 mod tests {
-    use smoltcp::storage::PacketBuffer;
+    use smoltcp::{
+        phy::{Device as _, TxToken as _},
+        storage::PacketBuffer,
+    };
 
     use super::*;
     use crate::device::TxChecksumCapabilities;
@@ -1108,8 +1120,11 @@ mod tests {
             .unwrap();
         sockets.add(tcp);
         interface.poll_egress(now, &mut router, &mut sockets);
-        let (_, packet) = router.tx_buffer.dequeue().expect("TCP SYN must be emitted");
-        let ip = Ipv4Packet::new_checked(&*packet).unwrap();
+        let packet = router
+            .tx_buffer
+            .dequeue_one()
+            .expect("TCP SYN must be emitted");
+        let ip = Ipv4Packet::new_checked(packet.as_bytes()).unwrap();
         let tcp = TcpPacket::new_checked(ip.payload()).unwrap();
         assert!(tcp.syn());
         assert!(tcp.verify_checksum(&ip.src_addr().into(), &ip.dst_addr().into()));
@@ -1122,11 +1137,11 @@ mod tests {
         udp.send_slice(b"checksum", (destination, 4322)).unwrap();
         sockets.add(udp);
         interface.poll_egress(now, &mut router, &mut sockets);
-        let (_, packet) = router
+        let packet = router
             .tx_buffer
-            .dequeue()
+            .dequeue_one()
             .expect("UDP packet must be emitted");
-        let ip = Ipv4Packet::new_checked(&*packet).unwrap();
+        let ip = Ipv4Packet::new_checked(packet.as_bytes()).unwrap();
         let udp = UdpPacket::new_checked(ip.payload()).unwrap();
         assert_ne!(udp.checksum(), 0, "ordinary UDP must generate a checksum");
         assert!(udp.verify_checksum(&ip.src_addr().into(), &ip.dst_addr().into()));
@@ -1300,18 +1315,20 @@ mod tests {
             SRC0,
             100,
         ));
-        let packet = router
-            .tx_buffer
-            .enqueue(20, tx_metadata())
-            .expect("the empty router TX queue has capacity");
-        packet[0] = 0x45;
-        packet[2..4].copy_from_slice(&20u16.to_be_bytes());
-        packet[12..16].copy_from_slice(&[10, 0, 0, 2]);
-        packet[16..20].copy_from_slice(&[198, 51, 100, 1]);
+        router
+            .transmit(Instant::from_millis(0))
+            .expect("the empty router TX queue has capacity")
+            .consume(20, |packet| {
+                packet[0] = 0x45;
+                packet[2..4].copy_from_slice(&20u16.to_be_bytes());
+                packet[12..16].copy_from_slice(&[10, 0, 0, 2]);
+                packet[16..20].copy_from_slice(&[198, 51, 100, 1]);
+            });
 
         let mut sockets = SocketSet::new(vec![]);
         assert!(!router.dispatch(Instant::from_millis(0), &mut sockets));
-        assert_eq!(router.tx_buffer.payload_bytes_count(), 20);
+        assert_eq!(router.tx_buffer.len(), 1);
+        assert_eq!(router.tx_buffer.get_allocated(0, 1)[0].as_bytes().len(), 20);
         assert_eq!(router.devices[0].stats().tx_packets, 0);
         assert_eq!(router.devices[0].stats().tx_dropped, 0);
     }
@@ -1328,7 +1345,7 @@ mod tests {
 
     fn check_tx_token_after_payload_wrap(reply_to_rx: bool) {
         use ax_sync::SpinLock;
-        use smoltcp::phy::{Device as _, RxToken as _, TxToken as _};
+        use smoltcp::phy::RxToken as _;
 
         #[derive(Default)]
         struct TxProbe {
@@ -1547,16 +1564,15 @@ mod tests {
             next_packet[1] = 1;
             for queued in [&packet, &next_packet] {
                 router
-                    .tx_buffer
-                    .enqueue(queued.len(), tx_metadata())
+                    .transmit(Instant::from_millis(0))
                     .unwrap()
-                    .copy_from_slice(queued);
+                    .consume(queued.len(), |dst| dst.copy_from_slice(queued));
             }
             let mut sockets = SocketSet::new(vec![]);
             for completed_port in [0, 2] {
                 assert!(router.dispatch(Instant::from_millis(0), &mut sockets));
-                assert_eq!(router.tx_buffer.peek().unwrap().1, packet);
-                assert_eq!(router.tx_buffer.payload_bytes_count(), packet.len() * 2);
+                assert_eq!(router.tx_buffer.get_allocated(0, 1)[0].as_bytes(), packet);
+                assert_eq!(router.tx_buffer.len(), 2);
                 assert_eq!(
                     probes[completed_port].lock_irqsave().packets,
                     vec![packet.clone()]
@@ -1570,7 +1586,7 @@ mod tests {
                 .failures
                 .push_back(NetDeviceError::Again);
             assert!(!router.dispatch(Instant::from_millis(0), &mut sockets));
-            assert_eq!(router.tx_buffer.peek().unwrap().1, packet);
+            assert_eq!(router.tx_buffer.get_allocated(0, 1)[0].as_bytes(), packet);
             assert_eq!(probes[0].lock_irqsave().attempts, 1);
             assert_eq!(probes[2].lock_irqsave().attempts, 2);
             assert!(router.dispatch(Instant::from_millis(0), &mut sockets));

--- a/scripts/axbuild/src/test/std.rs
+++ b/scripts/axbuild/src/test/std.rs
@@ -151,6 +151,19 @@ const HOST_TEST_FEATURE_PROFILES: &[PackageFeatureProfile] = &[PackageFeaturePro
     expected_tests: &[],
 }];
 
+const AIC8800_FEATURE_PROFILES: &[PackageFeatureProfile] = &[PackageFeatureProfile {
+    name: "host-test+rdif",
+    no_default_features: false,
+    features: &["host-test", "rdif"],
+    name_filter: None,
+    expected_tests: &[
+        "device::data_plane::tests::startup_connect_indications_cannot_publish_or_fail_a_new_connection",
+        "device::data_plane::tests::active_connect_indication_rejection_remains_a_terminal_failure",
+        "public_startup_api_owns_the_sdio_function_lifecycle",
+        "public_options_preserve_bounded_startup_policy",
+    ],
+}];
+
 const ALLOC_FEATURE_PROFILES: &[PackageFeatureProfile] = &[PackageFeatureProfile {
     name: "alloc",
     no_default_features: false,
@@ -556,6 +569,7 @@ fn package_feature_profiles(package: &str) -> Option<&'static [PackageFeaturePro
         | "ax-net"
         | "dma-api"
         | "buddy-slab-allocator" => Some(HOST_TEST_FEATURE_PROFILES),
+        "aic8800" => Some(AIC8800_FEATURE_PROFILES),
         "ax-fs-ng" => Some(AX_FS_NG_FEATURE_PROFILES),
         "ax-io" | "axbacktrace" => Some(ALLOC_FEATURE_PROFILES),
         "ax-hal" => Some(AX_HAL_FEATURE_PROFILES),
@@ -990,6 +1004,7 @@ mod tests {
             "nvme-driver",
             "rdif-block",
             "sdmmc-protocol",
+            "aic8800",
             "axbuild",
         ]
         .map(str::to_string)
@@ -998,6 +1013,7 @@ mod tests {
             .with_profile_discovery("ax-fs-ng", AX_FS_NG_FEATURE_PROFILES)
             .with_profile_discovery("nvme-driver", NVME_FEATURE_PROFILES)
             .with_profile_discovery("sdmmc-protocol", SDMMC_RDIF_FEATURE_PROFILES)
+            .with_profile_discovery("aic8800", AIC8800_FEATURE_PROFILES)
             .with_profile_discovery("axbuild", AXBUILD_FEATURE_PROFILES);
 
         let failed = run_std_tests(&mut runner, &root, &packages).unwrap();
@@ -1023,6 +1039,11 @@ mod tests {
         assert!(invocations.contains(&&CargoTestInvocation::for_profile(
             "sdmmc-protocol",
             &SDMMC_RDIF_FEATURE_PROFILES[0],
+            CargoTestAction::Run,
+        )));
+        assert!(invocations.contains(&&CargoTestInvocation::for_profile(
+            "aic8800",
+            &AIC8800_FEATURE_PROFILES[0],
             CargoTestAction::Run,
         )));
         assert!(invocations.contains(&&CargoTestInvocation::for_profile(

--- a/scripts/test/std_crates.csv
+++ b/scripts/test/std_crates.csv
@@ -55,6 +55,7 @@ ax-input
 ax-ipi
 ax-log
 ax-net
+aic8800
 ax-runtime
 ax-api
 rockchip-jpeg


### PR DESCRIPTION
## 问题与修复

#2227 扩大 TCP 缓冲并保留真实发送背压后，SG2002 Wi-Fi iperf 出现 `Full` panic、传输停止和控制连接 EOF。此前本 PR 只修 Router 容量，实板仍失败；补充 RX-ready 通知后仍出现首批 384/512 KiB 后零吞吐。当前修复已继续下探到 AIC8800DC 数据发送与启动事件的具体协议约束。

- DC 数据发送现在先读 Function 1、寄存器 `0x0a` 的低 7 位固件 buffer 数，保留 2 个 buffer 后才允许写一帧，每帧重新查询。之前误把 DC 命令通道的直接发送规则用于数据帧，绕过固件流控；当前不把 buffer 数换算成 SDIO block 字节数。依据是固定版本 [Sipeed BSP](https://github.com/sipeed/LicheeRV-Nano-Build/blob/d4003f15b35d43ad4842f427050ab2bba0114fa5/osdrv/extdrv/wireless/aic8800/aic8800_fdrv/aicwf_sdio.c#L351)的数据准入与逐帧扣减，以及 [Radxa BSP](https://github.com/radxa-pkg/aic8800/blob/516e3b087763d80c44f5e3b6d2dd63e0d925c91d/src/SDIO/driver_fw/driver/aic8800/aic8800_fdrv/aicwf_sdio.c#L355)的同样规则。Function 2 mailbox 与 D80 原策略保持原样。
- DC 额度不足时保留待发帧及 token，用 `WaitForInterruptUntil` 同时等待 CARD_INT 和已有重试截止时间。截止时间前已到达的 RX 可先排空，避免 `RetryAt` 保持中断屏蔽而饿死接收；额度恢复后才写 FIFO，SDIO 完成后返回原 token。
- `Starting` 阶段尚未接受本次连接请求，此时到来的 `SM_CONNECT_IND` 不得安装 peer 或终止初始化。旧代码会把这种指示中的 `status=1` 当成新连接拒绝，触发运行器中 `usb2-lsusb` 的网络初始化 panic。门禁只限 `Starting`，当前活动连接的拒绝仍按原路径失败。
- Router 使用 64 个预分配 MTU 槽位，使 token 容量检查与实际分配条件相同；队列完全排空后重置索引，复用前部槽位。`Again` 保留包及多出口进度，热路径没有新增整包复制或分配。
- RX-ready 出队后立即通知 queue owner，DMA token 仍由 frame 持有到消费完成，区分环槽位释放与 DMA 回收。该通知修复及回归复用 #2294 的 `1d617e194`，保留来源与原作者归属。
- 保留队列 quiesce/rearm 失败及实际 Wi-Fi 断开的错误信息，移除仅用于调查的 TX Retry 一次探针；补齐 `aic8800` 的 `host-test + rdif` 正式标准库测试 profile 和允许列表，更新驱动与网络内存文档。

没有降低 iperf 负载、改变超时、放宽成功/失败规则或增加用例重试。Sipeed 数据流控中的定时额度重查通过既有显式截止时间执行，未增加设备轮询线程。当前没有测量性能提升比例。

## 确定性回归

测试执行入口均为 `cargo xtask test --since 08c9f1913`。最低层回归同时覆盖数据内容、token 所有权、等待动作和恢复后的顺序，避免以“不 panic”或运行时间阈值替代判定。

| 风险 | 错误实现上的证据 | 修复后的证据 |
| --- | --- | --- |
| Router 连续 MTU 容量 | transmit/receive 两条回归均触发原 `This was checked before creating the TxToken: Full` | FIFO、包内容、满队列返回及恢复均通过 |
| 排空后缓存存储复用 | 第二轮地址前进 1512 字节，复用断言失败 | 64/1500/64 字节反复复用同一槽位，接收内容正确 |
| RX-ready 释放通知 | DMA 仍被持有时，队列工作未重新发布，回归失败 | 工作先发布，消费结束后才归还原 DMA token |
| 启动指示归属 | 旧实现收到 status 1 发布 `Failed(FirmwareRejected)`，仅该回归失败 | 旧成功/失败指示不影响新生命周期，活动连接拒绝仍失败 |
| DC 发送额度 | 两条回归发现旧实现直接 Write，缺少 Function 1 credit read | 0/1/2/0x82 均等待；0x83 允许一帧 1536 字节传输；下一帧重新读取额度，原 token 恰好一次返回 |
| DC 低额度期间接收 | 仅增加额度门禁时返回 `RetryAt`，两条完整等待回归再次失败 | 返回 `WaitForInterruptUntil`；截止时间前 CARD_INT 触发 fn2/fn1 收包，扫描后保留原发送截止时间 |

最终本地标准库测试选择 9 个软件包，全部通过；aic8800 为 113 个单元测试、2 个集成测试，ax-net 为 131 个单元测试、6 个集成测试，axbuild 为 917 个单元测试。原有文档示例按其配置忽略。aic8800、ax-net 和 axbuild 均通过定向 `cargo xtask clippy --package ...`，格式和差异检查通过。

此前已在通知修复提交 `1700c8752` 上运行 RISC-V QEMU `test-tcp-napi-runtime` 和 `apk-curl-equivalence`，两者均通过；后者实际传输 20 MiB 并验证长度及 SHA256。QEMU 不含 AIC8800 SDIO，不能替代当前驱动修复的实板验收。历史 `5f952d0fb` 上的 149 项增量 Clippy、全工作区发布演练及 TCP partial-send 结果仍仅作为历史证据。

## 实板验收

此前 `1700c8752` 的 [实板运行](https://github.com/rcore-os/tgoskits/actions/runs/34125289131/job/101754269222)仍出现初始化拒绝和 iperf 超时。诊断提交 `fd0b63cc3` 的 [实板运行](https://github.com/rcore-os/tgoskits/actions/runs/34172575840/job/101896579343)没有 quiesce/rearm 错误或 TX Retry 探针输出，仍是首批数据后停滞、结果交换 read 返回 0；因此没有把通用 TX Retry 提前返回当作 SG2002 根因，也未合入那项独立改动。

当前 head `99e49117ccd337e80ad38ab2d968a88105c66c39` 的 [SG2002 实板验收](https://github.com/rcore-os/tgoskits/actions/runs/34174230204/job/101901355158)仍失败：其他启动用例通过，iperf 首批发送约 1 MiB 后停滞，随后 JSON 结果交换读到 EOF。日志没有队列 quiesce/rearm 错误或 Wi-Fi 断开。固件流控与启动修复具备确定性协议证据，但尚未消除原始 CI 故障，PR 继续保持草稿；正在增加有限状态诊断定位剩余停滞条件。验收必须以本 PR 精确 head 实际输出 sender/receiver、`STARRY_AKA_WIFI_IPERF_SMOKE_PASSED` 和板卡组通过为依据；重复 PR 事件去重后的绿色状态不能替代。请求未提供对应 issue，没有自动关闭议题的 `Fixes` 条目。


## 系统调用兼容性对照

本次修复 Router TX 容量、RX-ready 释放通知、DC 固件数据流控与启动指示归属。组件红绿分别证明容量不变量与遗漏通知；各系统调用入口的独立系统级红绿尚不完整，因此以下 ABI 对照保留“无法确认”，不把整机 iperf 成功等同所有入口均已对齐。编号依次为 `x86_64 / aarch64 / riscv64 / loongarch64`，基准为 Linux v6.12 的[架构系统调用表](https://github.com/torvalds/linux/blob/v6.12/arch/x86/entry/syscalls/syscall_64.tbl)与[通用系统调用表](https://github.com/torvalds/linux/blob/v6.12/scripts/syscall.tbl)。

共享调用链：`S` 表示 `SocketOps::send` → TCP/UDP/raw socket 发送队列 → `request_poll` → 唯一协议执行器 `poll_protocol_until_idle` → `NetService::poll` → smoltcp `iface.poll` → `Router::{transmit,receive}` → `TxToken::consume` → `Router::tx_buffer` → `dispatch` → 设备队列；TCP 入队经 `send_poller_with` 和 `with_smol_socket`。`R` 表示 `SocketOps::recv` → TCP/UDP/raw socket 的 `recv_poller_with` → 对应 smoltcp 接收队列 → 用户缓冲；接收队列由设备 RX → `Router::poll` → `iface.poll` → `Router::receive` 推进，回复及 ACK 使用 `S` 的 TX 后半段。fd 表引用可共享的 `Arc<Socket>`，socket 持有连接状态和 handle；`SOCKET_SET` 与协议服务属于全局层级。

已取得证据：`E1` 为 Router transmit/receive 两条回归在旧实现均以 `Full` panic，修复后 ax-net 131 个单元测试及 6 个集成测试通过；`E2` 为 RISC-V QEMU `qemu/system/test-tcp-napi-runtime` 通过；`E3` 为 RISC-V QEMU `qemu/system/apk-curl-equivalence` 通过，实际经 virtio-net 下载 20 MiB 并验证长度和 SHA256；`E4` 为容量修复提交 `5f952d0fb` 上的 RISC-V QEMU `qemu/system/bugfix-bug-proc-comm-tcp-partial-send` 通过，63 pass / 0 fail，覆盖 EAGAIN、POLLOUT 和短写。另有 RX-ready 回归在通知修复前失败、修复后通过，保留 DMA token 时已经发布队列进度。通知修复提交 `1700c8752` 重跑 E1、E2、E3 均通过；当前驱动修复另有 DC 流控与启动指示的确定性红绿，AIC113单测与2集成通过；这些证据不等于逐系统调用的完整 ABI 验证。

| 系统调用/编号 | Linux 基准与稳定链接 | Linux 可观察语义 | StarryOS 入口与调用链 | 实现结论 | 测试与证据 |
| --- | --- | --- | --- | --- | --- |
| write：1 / 64 / 64 / 64 | Linux v6.12 [vfs_write](https://github.com/torvalds/linux/blob/v6.12/fs/read_write.c#L624)、[tcp_sendmsg_locked](https://github.com/torvalds/linux/blob/v6.12/net/ipv4/tcp.c#L1242) | 缺少发送空间时等待、短写或 EAGAIN，不能因背压 panic | `sys_write` → fd/长度/地址检查、用户数据复制 → `Socket::write` → `S` | 无法确认 | E1；E2、E3 为系统链路证据 |
| read：0 / 63 / 63 / 63 | Linux v6.12 [ksys_read](https://github.com/torvalds/linux/blob/v6.12/fs/read_write.c#L659)、[tcp_recvmsg_locked](https://github.com/torvalds/linux/blob/v6.12/net/ipv4/tcp.c#L2418) | 返回实际字节数；无数据时等待/EAGAIN；TCP 有序关闭且数据耗尽后返回 0 | `sys_read` → `get_file_like` → `VmBytesMut` → `Socket::read` → `R` | 无法确认 | E1；E2、E3 为系统链路证据 |
| writev：20 / 66 / 66 / 66 | Linux v6.12 [vfs_writev](https://github.com/torvalds/linux/blob/v6.12/fs/read_write.c) | 汇聚写按实际完成字节计数，保留部分完成 | `sys_writev` → fd 查找、iovec/长度验证、数据复制 → `Socket::write` → `S` | 无法确认 | E1 覆盖共享 Router |
| readv：19 / 65 / 65 / 65 | Linux v6.12 [vfs_readv](https://github.com/torvalds/linux/blob/v6.12/fs/read_write.c) | 按 iovec 顺序填充并返回实际总字节数 | `sys_readv` → fd 查找 → `IoVectorBuf` → `Socket::read` → `R` | 无法确认 | E1 覆盖共享 Router |
| pwritev2(offset=-1, flags=0)：328 / 287 / 287 / 287 | Linux v6.12 [pwritev2](https://github.com/torvalds/linux/blob/v6.12/fs/read_write.c) | offset=-1 使用流式写路径，保留背压和短写语义 | `sys_pwritev2` → flag/offset 检查、fd/iovec 验证及复制 → `Socket::write` → `S` | 无法确认 | E1 覆盖共享 Router |
| preadv2(offset=-1, flags=0)：327 / 286 / 286 / 286 | Linux v6.12 [preadv2](https://github.com/torvalds/linux/blob/v6.12/fs/read_write.c) | offset=-1 使用流式读路径，返回实际字节数 | `sys_preadv2` → flag/offset 检查、iovec 导入、fd 查找 → `Socket::read` → `R` | 无法确认 | E1 覆盖共享 Router |
| sendto：44 / 206 / 206 / 206 | Linux v6.12 [__sys_sendto](https://github.com/torvalds/linux/blob/v6.12/net/socket.c#L2056) | O_NONBLOCK 或 MSG_DONTWAIT 控制非阻塞，返回接纳字节数或错误 | `sys_sendto` → `VmBytes` → `send_impl` → socket/地址解析、SendOptions → `S` | 无法确认 | E1；E2、E3 为系统链路证据 |
| recvfrom：45 / 207 / 207 / 207 | Linux v6.12 [__sys_recvfrom](https://github.com/torvalds/linux/blob/v6.12/net/socket.c#L2114) | 返回实际字节数并按需回写来源；非阻塞无数据返回 EAGAIN | `sys_recvfrom` → `VmBytesMut`/RecvName → `recv_impl` → `R` → 来源长度回写 | 无法确认 | E1；E2、E3 为系统链路证据 |
| sendmsg：46 / 211 / 211 / 211 | Linux v6.12 [__sys_sendmsg](https://github.com/torvalds/linux/blob/v6.12/net/socket.c) | msghdr/iovec 数据进入协议发送，保留等待和部分完成 | `sys_sendmsg` → msghdr/cmsg/iovec 导入 → `send_impl` → `S` | 无法确认 | E1 覆盖共享 Router |
| recvmsg：47 / 212 / 212 / 212 | Linux v6.12 [____sys_recvmsg](https://github.com/torvalds/linux/blob/v6.12/net/socket.c#L2639) | 按实际接收计数，回写来源、控制长度和消息标志 | `sys_recvmsg` → msghdr/iovec/CMsgBuilder → `recv_impl` → `R` → `write_recvmsg_outputs` | 无法确认 | E1 覆盖共享 Router |
| sendmmsg：307 / 269 / 269 / 269 | Linux v6.12 [__sys_sendmmsg](https://github.com/torvalds/linux/blob/v6.12/net/socket.c#L2550) | 返回完成消息数；已完成前缀优先于后续错误；回写 msg_len | `sys_sendmmsg` → 逐项导入 → `send_impl` → `S` → `write_mmsg_len` | 无法确认 | E1 覆盖共享 Router |
| recvmmsg：299 / 243 / 243 / 243 | Linux v6.12 [do_recvmmsg](https://github.com/torvalds/linux/blob/v6.12/net/socket.c#L2748) | 返回完成消息数及各项长度；后续错误保留完成前缀 | `sys_recvmmsg` → timeout/socket 检查、逐项导入 → `recv_impl` → `R` → 输出字段/msg_len 回写 | 无法确认 | E1 覆盖共享 Router |
| sendfile(socket 输出)：40 / 71 / 71 / 71 | Linux v6.12 [do_sendfile](https://github.com/torvalds/linux/blob/v6.12/fs/read_write.c) | 文件数据转入 socket，返回已完成字节数并允许短操作 | `sys_sendfile` → fd/append/源位置检查 → `do_send` → `SendFile::write(Direct)` → `Socket::write` → `S` | 无法确认 | E1 覆盖共享 Router |
| splice(pipe↔socket, socket offset=NULL)：275 / 76 / 76 / 76 | Linux v6.12 [splice](https://github.com/torvalds/linux/blob/v6.12/fs/splice.c) | 至少一端是 pipe；按完成字节计数，背压可导致等待或短操作 | `sys_splice` → fd/flag/pipe/offset 检查 → `do_send` → `SendFile::{read,write}(Direct)` → `Socket::{read,write}` → `R`/`S` | 无法确认 | E1 覆盖共享 Router |



当前诊断 head `d6ad28807622c4bf2c38ff77731433fb72e87c80` 的 [实板运行](https://github.com/rcore-os/tgoskits/actions/runs/34175951835) 已触发。仅在已有推进事件上最多采样三次，记录 Router/TCP/ACK 与 AIC 队列、SDIO 活动、固件额度，不增加定时器或补偿轮询。诊断通过 aic8800/ax-net 六项定向 Clippy 和九个软件包的增量标准库测试；验收未完成，临时采样将在根因确认后移除。
