### PR TITLE
chore(repo): switch the Nix development shell to devenv

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,4 +1,3 @@
-# Load this repository's pinned Nix development shell on directory entry.
-# Refresh it explicitly with `nix-direnv-reload`.
-nix_direnv_manual_reload
-use flake
+# Development environment is devenv.nix, not this file.
+# Enter with `devenv shell`, or `devenv allow` after `eval "$(devenv hook $SHELL)"`.
+# Do not `use flake` here: that loads flake.nix and bypasses devenv.yaml.

--- a/.envrc
+++ b/.envrc
@@ -1,3 +1,0 @@
-# Development environment is devenv.nix, not this file.
-# Enter with `devenv shell`, or `devenv allow` after `eval "$(devenv hook $SHELL)"`.
-# Do not `use flake` here: that loads flake.nix and bypasses devenv.yaml.

--- a/.github/workflows/devenv.yml
+++ b/.github/workflows/devenv.yml
@@ -1,0 +1,60 @@
+name: Devenv
+
+on:
+  pull_request:
+    paths:
+      - "devenv.nix"
+      - "devenv.yaml"
+      - "devenv.lock"
+      - "flake.nix"
+      - "flake.lock"
+      - "rust-toolchain.toml"
+      - ".github/workflows/devenv.yml"
+  push:
+    paths:
+      - "devenv.nix"
+      - "devenv.yaml"
+      - "devenv.lock"
+      - "flake.nix"
+      - "flake.lock"
+      - "rust-toolchain.toml"
+      - ".github/workflows/devenv.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: devenv-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    name: nix develop
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Evaluate the devenv-backed development shell
+        run: |
+          set -euo pipefail
+          docker run --rm \
+            --env NIX_CONFIG=$'experimental-features = nix-command flakes\nsandbox = false' \
+            --volume "$PWD:/workspace" \
+            --workdir /workspace \
+            docker.io/nixos/nix:2.33.1 \
+            sh -lc '
+              set -euo pipefail
+              git config --global --add safe.directory /workspace
+              nix develop --accept-flake-config --no-pure-eval -c \
+                bash -lc "
+                  set -euo pipefail
+                  command -v cargo
+                  command -v rustc
+                  rustc --version
+                  test -z \"\${CC-}\"
+                  test -z \"\${RUSTUP_TOOLCHAIN-}\"
+                "
+            '

--- a/.github/workflows/devenv.yml
+++ b/.github/workflows/devenv.yml
@@ -30,14 +30,14 @@ concurrency:
 
 jobs:
   smoke:
-    name: nix develop
+    name: nix develop and devenv shell
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Evaluate the devenv-backed development shell
+      - name: Evaluate flake and devenv CLI shells
         run: |
           set -euo pipefail
           docker run --rm \
@@ -48,13 +48,16 @@ jobs:
             sh -lc '
               set -euo pipefail
               git config --global --add safe.directory /workspace
-              nix develop --accept-flake-config --no-pure-eval -c \
-                bash -lc "
-                  set -euo pipefail
-                  command -v cargo
-                  command -v rustc
-                  rustc --version
-                  test -z \"\${CC-}\"
-                  test -z \"\${RUSTUP_TOOLCHAIN-}\"
-                "
+              smoke="
+                set -euo pipefail
+                command -v cargo
+                command -v rustc
+                rustc --version
+                test -z \"\${CC-}\"
+                test -z \"\${RUSTUP_TOOLCHAIN-}\"
+              "
+              nix develop --accept-flake-config --no-pure-eval -c bash -lc "$smoke"
+              devenv_rev="$(nix eval --raw --impure --expr "(builtins.fromJSON (builtins.readFile ./flake.lock)).nodes.devenv.locked.rev")"
+              nix run --accept-flake-config "github:cachix/devenv/${devenv_rev}" -- \
+                --no-tui shell -- bash -lc "$smoke"
             '

--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,8 @@ __pycache__/
 
 # Tooling artifacts
 .direnv/
+.devenv/
+.devenv.flake.nix
 .ci-cache/
 .codex
 /.agents/*

--- a/devenv.lock
+++ b/devenv.lock
@@ -1,0 +1,66 @@
+{
+  "nodes": {
+    "devenv": {
+      "locked": {
+        "dir": "src/modules",
+        "lastModified": 1788757012,
+        "narHash": "sha256-ILhsVKEZdjjVbzbcM9lx4kX8Jz4JZ/LhZcPcKr/gFvE=",
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "a7014c60a08855bdc9a4fddba220c28087afc21a",
+        "type": "github"
+      },
+      "original": {
+        "dir": "src/modules",
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1788614874,
+        "narHash": "sha256-7QYjT2vHLuX9Z1pdxHXDKCbh1CR3D/2rywB9Tx0MPRg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c043004d1c6985732bcc1cbc5a9c9aecbbb4e0f0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "devenv": "devenv",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1788765185,
+        "narHash": "sha256-pp8lb5CrKjmscZbTK34HuCaq18zDU4Q6zlaD5dS+Hi4=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "ca7f624be3935a5bc46d2c240515491ab8675503",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/devenv.nix
+++ b/devenv.nix
@@ -1,0 +1,150 @@
+{
+  pkgs,
+  lib,
+  config,
+  ...
+}:
+
+let
+  # Wrapper scripts only. Real pkgsCross.cc stays off `packages` so its
+  # setup hooks cannot override host CC for native Rust builds.
+  mkMuslAliases =
+    {
+      name,
+      cc,
+      sourcePrefix,
+      aliasPrefix,
+    }:
+    let
+      tools = [
+        "ar"
+        "c++"
+        "cc"
+        "cpp"
+        "g++"
+        "gcc"
+        "ld"
+        "nm"
+        "objcopy"
+        "objdump"
+        "ranlib"
+        "readelf"
+        "strip"
+      ];
+    in
+    pkgs.symlinkJoin {
+      inherit name;
+      paths = map (
+        tool:
+        pkgs.writeShellScriptBin "${aliasPrefix}-${tool}" ''
+          exec "${cc}/bin/${sourcePrefix}-${tool}" \
+            ${
+              lib.optionalString (builtins.elem tool [
+                "c++"
+                "cc"
+                "g++"
+                "gcc"
+              ]) "-fno-stack-protector"
+            } "$@"
+        ''
+      ) tools;
+    };
+in
+{
+  name = "tgoskits-dev";
+
+  languages.rust = {
+    enable = true;
+    toolchainFile = ./rust-toolchain.toml;
+    # Default Linux linker is clang; this repo unsets CC and lets rustc pick.
+    clangLinker.enable = false;
+  };
+
+  # rust.nix turns this on; we do not want a host cc leaking into cargo.
+  languages.c.enable = false;
+
+  packages = with pkgs; [
+    binutils
+    bzip2
+    cacert
+    cargo-binutils
+    clang
+    cmake
+    curl
+    dosfstools
+    dtc
+    e2fsprogs
+    fakeroot
+    git
+    glib
+    gnumake
+    libslirp
+    libudev-zero
+    meson
+    mtools
+    ninja
+    openssl
+    pkg-config
+    python3
+    qemu
+    qemu-user
+    wget
+    xorriso
+    xz
+    zlib
+    llvmPackages.bintools
+    llvmPackages.libclang
+    llvmPackages.llvm
+    (mkMuslAliases {
+      name = "x86_64-linux-musl-toolchain-aliases";
+      cc = pkgsCross.musl64.stdenv.cc;
+      sourcePrefix = "x86_64-unknown-linux-musl";
+      aliasPrefix = "x86_64-linux-musl";
+    })
+    (mkMuslAliases {
+      name = "aarch64-linux-musl-toolchain-aliases";
+      cc = pkgsCross.aarch64-multiplatform-musl.stdenv.cc;
+      sourcePrefix = "aarch64-unknown-linux-musl";
+      aliasPrefix = "aarch64-linux-musl";
+    })
+  ];
+
+  env.LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
+
+  enterShell =
+    let
+      rust = config.languages.rust.toolchainPackage;
+      crossBins = lib.makeBinPath [
+        pkgs.pkgsCross.aarch64-multiplatform-musl.stdenv.cc
+        pkgs.pkgsCross.musl64.stdenv.cc
+        pkgs.pkgsCross.riscv64.stdenv.cc
+        pkgs.pkgsCross.loongarch64-linux.stdenv.cc
+      ];
+    in
+    ''
+      export project_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+
+      # In-tree crate cache. rust-toolchain.toml is a rustup override;
+      # without this, /run/current-system/sw/bin/cargo compiles with
+      # ~/.rustup and a GC'd Nix lld wrapper.
+      export CARGO_HOME="$project_root/.cargo"
+      mkdir -p "$CARGO_HOME" "$CARGO_HOME/bin"
+      export CARGO="${rust}/bin/cargo"
+      export RUSTC="${rust}/bin/rustc"
+      unset RUSTUP_TOOLCHAIN
+      export PATH="${rust}/bin:$CARGO_HOME/bin:${crossBins}:$PATH"
+      hash -r 2>/dev/null || true
+
+      unset CC CXX AR RANLIB
+      unset CC_x86_64_unknown_linux_gnu
+      unset CXX_x86_64_unknown_linux_gnu
+      unset AR_x86_64_unknown_linux_gnu
+      unset RANLIB_x86_64_unknown_linux_gnu
+
+      echo "TGOSKits devenv"
+      echo "  CARGO_HOME=$CARGO_HOME"
+      echo "  CARGO=$CARGO"
+      echo "  Rust toolchain: languages.rust from rust-toolchain.toml"
+      echo "  Cross compilers: available by target-prefixed command name"
+    '';
+}

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -1,0 +1,10 @@
+# CLI inputs for `devenv shell` / `devenv allow`.
+# Independent of flake.nix; rust-overlay is pulled here, not from flake.lock.
+inputs:
+  nixpkgs:
+    url: github:NixOS/nixpkgs/nixos-unstable
+  rust-overlay:
+    url: github:oxalica/rust-overlay
+    inputs:
+      nixpkgs:
+        follows: nixpkgs

--- a/flake.lock
+++ b/flake.lock
@@ -1,15 +1,111 @@
 {
   "nodes": {
-    "flake-parts": {
+    "cachix": {
       "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib"
+        "devenv": [
+          "devenv"
+        ],
+        "flake-compat": [
+          "devenv",
+          "flake-compat"
+        ],
+        "git-hooks": [
+          "devenv",
+          "git-hooks"
+        ],
+        "nixpkgs": [
+          "devenv",
+          "nixpkgs"
+        ]
       },
       "locked": {
-        "lastModified": 1785627969,
-        "narHash": "sha256-4dtXQk/NMePegK/nWp5NSeuZKLATItOq61lpEvmXqGw=",
+        "lastModified": 1788181969,
+        "narHash": "sha256-OUB6hPlFBB9FRdZgZXSye4lDOg+fbrqKe8ePv2IM7NY=",
+        "owner": "cachix",
+        "repo": "cachix",
+        "rev": "98093e8eea6c1635ef1337a576fa76f3e8bd4f39",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "latest",
+        "repo": "cachix",
+        "type": "github"
+      }
+    },
+    "crate2nix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1772186516,
+        "narHash": "sha256-8s28pzmQ6TOIUzznwFibtW1CMieMUl1rYJIxoQYor58=",
+        "owner": "rossng",
+        "repo": "crate2nix",
+        "rev": "ba5dd398e31ee422fbe021767eb83b0650303a6e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rossng",
+        "repo": "crate2nix",
+        "rev": "ba5dd398e31ee422fbe021767eb83b0650303a6e",
+        "type": "github"
+      }
+    },
+    "devenv": {
+      "inputs": {
+        "cachix": "cachix",
+        "crate2nix": "crate2nix",
+        "flake-compat": "flake-compat",
+        "flake-parts": "flake-parts",
+        "ghostty": "ghostty",
+        "git-hooks": "git-hooks",
+        "nix": "nix",
+        "nixd": "nixd",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      },
+      "locked": {
+        "lastModified": 1788757012,
+        "narHash": "sha256-ILhsVKEZdjjVbzbcM9lx4kX8Jz4JZ/LhZcPcKr/gFvE=",
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "a7014c60a08855bdc9a4fddba220c28087afc21a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "devenv",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1788306937,
+        "narHash": "sha256-lbrI1UYVpFgKSsyrU9oeF7FHfnu8nLD9ja0ou9f2rxk=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "427bf4bd9435fdf21321c8cc628c24efc14c0f7a",
+        "rev": "f16b25b8c3d2809b87925d0b76652d7821a75c68",
         "type": "github"
       },
       "original": {
@@ -18,13 +114,190 @@
         "type": "github"
       }
     },
-    "nixpkgs": {
+    "flake-parts_2": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
       "locked": {
-        "lastModified": 1785828668,
-        "narHash": "sha256-8fsyqeO+mJqvIzeO4xIpgJe/f7MTbbVTEC6RT6WSXNs=",
+        "lastModified": 1788450739,
+        "narHash": "sha256-glZLQlzIn1fXH6PazR2iUmTo7kzzyYSshrWhLS9TqCU=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "31729ca8cbdb4fa927b34e5f4353e6a83f39e993",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "ghostty": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1786026742,
+        "narHash": "sha256-tRtgTg/i3w1nFdRHU2IGekfJN8EyP+HARW4MtoUZyqk=",
+        "owner": "ghostty-org",
+        "repo": "ghostty",
+        "rev": "22d13172cde98a0a4dda05d3d6a3fcb0dd8ed018",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ghostty-org",
+        "repo": "ghostty",
+        "rev": "22d13172cde98a0a4dda05d3d6a3fcb0dd8ed018",
+        "type": "github"
+      }
+    },
+    "git-hooks": {
+      "inputs": {
+        "flake-compat": [
+          "devenv",
+          "flake-compat"
+        ],
+        "nixpkgs": [
+          "devenv",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1788267358,
+        "narHash": "sha256-nt+lUqYVpc9Y6JeMd2WmXzCDojasdadKo0mWcluvY2Y=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "27555e2624241fb116b49095df4caaee85a25691",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "nix": {
+      "inputs": {
+        "flake-compat": [
+          "devenv",
+          "flake-compat"
+        ],
+        "flake-parts": [
+          "devenv",
+          "flake-parts"
+        ],
+        "git-hooks-nix": [
+          "devenv",
+          "git-hooks"
+        ],
+        "nixpkgs": [
+          "devenv",
+          "nixpkgs"
+        ],
+        "nixpkgs-23-11": [
+          "devenv"
+        ],
+        "nixpkgs-regression": [
+          "devenv"
+        ]
+      },
+      "locked": {
+        "lastModified": 1788036898,
+        "narHash": "sha256-3NT3yTvoRT7+rxLDNovpyeTDIJkZlBoO72rcu2x9Y9o=",
+        "owner": "cachix",
+        "repo": "nix",
+        "rev": "b9b81726b38469c55b9706d80d37d6c73cc7f76c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "devenv-2.35",
+        "repo": "nix",
+        "type": "github"
+      }
+    },
+    "nixd": {
+      "inputs": {
+        "flake-parts": [
+          "devenv",
+          "flake-parts"
+        ],
+        "nixpkgs": [
+          "devenv",
+          "nixpkgs"
+        ],
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1788165251,
+        "narHash": "sha256-ITHt6eU6DuwQqlNV1/wehvKYPE6J8sZIlv75CpDjcHI=",
+        "owner": "nix-community",
+        "repo": "nixd",
+        "rev": "e2ca72c353cfbc3d63e942fe9aeae4ec497863bf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixd",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "inputs": {
+        "nixpkgs-src": "nixpkgs-src"
+      },
+      "locked": {
+        "lastModified": 1787753358,
+        "narHash": "sha256-Tl77VbWyAKrOfRNQhL6JbQtb/MLzbYa/1RG1gWWfICk=",
+        "owner": "cachix",
+        "repo": "devenv-nixpkgs",
+        "rev": "256551e45f6303e142ab4a98be1bf243feb77dc0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "rolling",
+        "repo": "devenv-nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1788057806,
+        "narHash": "sha256-DTQSMxzDWmT0zhguthvegnVkn7CFqGCv4IHCzk5ZUpM=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "596e2e3940e09b2abbeb03f75fa1828c57fcd72c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "nixpkgs-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1787394516,
+        "narHash": "sha256-pRGOQSClnXNI2iLUG6DYpsGvYcuw0drOutVZFTJNw90=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e72e4f299401a3689d4b3d5fc6496b11db7064eb",
+        "rev": "c8f90650c15282fa8656a041bfbbd2403997a9a7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1788614874,
+        "narHash": "sha256-7QYjT2vHLuX9Z1pdxHXDKCbh1CR3D/2rywB9Tx0MPRg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c043004d1c6985732bcc1cbc5a9c9aecbbb4e0f0",
         "type": "github"
       },
       "original": {
@@ -34,45 +307,74 @@
         "type": "github"
       }
     },
-    "nixpkgs-lib": {
-      "locked": {
-        "lastModified": 1785031560,
-        "narHash": "sha256-OmshNvn2vupOFpYinLUu+1Dnpu4n7Q5N3ggGVNHpkUI=",
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "rev": "0e79af5e3d4dcfcd676ab5ba3f95d2e3352e078c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
-        "flake-parts": "flake-parts",
-        "nixpkgs": "nixpkgs",
-        "rust-overlay": "rust-overlay"
+        "devenv": "devenv",
+        "flake-parts": "flake-parts_2",
+        "nixpkgs": "nixpkgs_2",
+        "rust-overlay": "rust-overlay_2"
       }
     },
     "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "devenv",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1788332415,
+        "narHash": "sha256-BTFrmyh0oaVDsvA9NNw0YpbbeppTwU0t70iVx672Ew8=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "860d7c835ab91bfc8972b67092f5f2db8e9390a0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "rust-overlay_2": {
       "inputs": {
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1785907205,
-        "narHash": "sha256-Ds1vTi53af4wDMAveSR/K0JnywDslLwmgwhVIiwnNmY=",
+        "lastModified": 1788765185,
+        "narHash": "sha256-pp8lb5CrKjmscZbTK34HuCaq18zDU4Q6zlaD5dS+Hi4=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "c5cb13481d718fac906aa9cfd85f9b60e1a546cb",
+        "rev": "ca7f624be3935a5bc46d2c240515491ab8675503",
         "type": "github"
       },
       "original": {
         "owner": "oxalica",
         "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "devenv",
+          "nixd",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786901030,
+        "narHash": "sha256-WSFCsDSE5ffgD2MqzkM2CYjeFiKhRF/dJUN8uedb6YE=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "27b3b12a8e6375f28ebe122f07d230ca5459bbfa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -4,6 +4,7 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-parts.url = "github:hercules-ci/flake-parts";
+    devenv.url = "github:cachix/devenv";
     rust-overlay = {
       url = "github:oxalica/rust-overlay";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -13,217 +14,21 @@
   outputs =
     inputs@{ flake-parts, ... }:
     flake-parts.lib.mkFlake { inherit inputs; } {
+      imports = [
+        inputs.devenv.flakeModule
+      ];
+
       systems = [
         "x86_64-linux"
         "aarch64-linux"
       ];
 
       perSystem =
-        { system, ... }:
-        let
-          pkgs = import inputs.nixpkgs {
-            inherit system;
-            overlays = [
-              # (import inputs.rust-overlay)
-            ];
-          };
-
-          lib = pkgs.lib;
-
-          optionalPackageByPath =
-            path:
-            let
-              package = lib.attrByPath path null pkgs;
-            in
-            lib.optional (package != null) package;
-
-          llvmPackages = pkgs.llvmPackages;
-          rustBin = inputs.rust-overlay.lib.mkRustBin {
-            # distRoot = "https://mirrors.ustc.edu.cn/rust-static";
-          } pkgs;
-          rustToolchain = rustBin.fromRustupToolchainFile ./rust-toolchain.toml;
-
-          commonPackages =
-            with pkgs;
-            [
-              bashInteractive
-              binutils
-              bzip2
-              cacert
-              clang
-              cmake
-              curl
-              dosfstools
-              e2fsprogs
-              fakeroot
-              file
-              git
-              gnumake
-              meson
-              ninja
-              openssl
-              pkg-config
-              python3
-              qemu
-              rustToolchain
-              # rustup
-              wget
-              xz
-              zlib
-            ]
-            ++ [
-              llvmPackages.bintools
-              llvmPackages.libclang
-              llvmPackages.llvm
-            ]
-            ++ optionalPackageByPath [ "cargo-binutils" ]
-            ++ optionalPackageByPath [ "dtc" ]
-            ++ optionalPackageByPath [ "glib" ]
-            ++ optionalPackageByPath [ "libpixman" ]
-            ++ optionalPackageByPath [ "libslirp" ]
-            ++ optionalPackageByPath [ "libudev-zero" ]
-            ++ optionalPackageByPath [ "mtools" ]
-            ++ optionalPackageByPath [ "qemu-user" ]
-            ++ optionalPackageByPath [ "qemu-user-static" ]
-            ++ optionalPackageByPath [ "xorriso" ];
-
-          crossCompilers =
-            optionalPackageByPath [
-              "pkgsCross"
-              "aarch64-multiplatform-musl"
-              "stdenv"
-              "cc"
-            ]
-            ++ optionalPackageByPath [
-              "pkgsCross"
-              "musl64"
-              "stdenv"
-              "cc"
-            ]
-            ++ optionalPackageByPath [
-              "pkgsCross"
-              "riscv64"
-              "stdenv"
-              "cc"
-            ]
-            ++ optionalPackageByPath [
-              "pkgsCross"
-              "loongarch64-linux"
-              "stdenv"
-              "cc"
-            ];
-
-          mkCrossCompilerAliases =
-            {
-              name,
-              packagePath,
-              sourcePrefix,
-              aliasPrefix,
-            }:
-            let
-              crossCompiler = lib.attrByPath packagePath null pkgs;
-              tools = [
-                "ar"
-                "c++"
-                "cc"
-                "cpp"
-                "g++"
-                "gcc"
-                "ld"
-                "nm"
-                "objcopy"
-                "objdump"
-                "ranlib"
-                "readelf"
-                "strip"
-              ];
-              aliases = map (
-                tool:
-                pkgs.writeShellScriptBin "${aliasPrefix}-${tool}" ''
-                  exec "${crossCompiler}/bin/${sourcePrefix}-${tool}" \
-                    ${
-                      lib.optionalString (builtins.elem tool [
-                        "c++"
-                        "cc"
-                        "g++"
-                        "gcc"
-                      ]) "-fno-stack-protector"
-                    } "$@"
-                ''
-              ) tools;
-            in
-            lib.optional (crossCompiler != null) (
-              pkgs.symlinkJoin {
-                inherit name;
-                paths = aliases;
-              }
-            );
-
-          crossCompilerAliases =
-            mkCrossCompilerAliases {
-              name = "x86_64-linux-musl-toolchain-aliases";
-              packagePath = [
-                "pkgsCross"
-                "musl64"
-                "stdenv"
-                "cc"
-              ];
-              sourcePrefix = "x86_64-unknown-linux-musl";
-              aliasPrefix = "x86_64-linux-musl";
-            }
-            ++ mkCrossCompilerAliases {
-              name = "aarch64-linux-musl-toolchain-aliases";
-              packagePath = [
-                "pkgsCross"
-                "aarch64-multiplatform-musl"
-                "stdenv"
-                "cc"
-              ];
-              sourcePrefix = "aarch64-unknown-linux-musl";
-              aliasPrefix = "aarch64-linux-musl";
-            };
-
-          # Keep cross compilers out of `packages`: their setup hooks would otherwise
-          # override host compiler variables used by native Rust builds.
-          crossCompilerPath = lib.makeBinPath (crossCompilerAliases ++ crossCompilers);
-        in
+        { pkgs, ... }:
         {
-          devShells.default = pkgs.mkShell {
-            name = "tgoskits-dev";
-
-            packages = commonPackages;
-
-            LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
-
-            shellHook = ''
-              export project_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
-
-              # Keep crate metadata in-tree, but never let ~/.rustup or the
-              # system rustup shims win. rust-toolchain.toml is a rustup
-              # override; /run/current-system/sw/bin/cargo will otherwise
-              # compile with ~/.rustup/toolchains/nightly-2026-07-15 and its
-              # GC'd Nix lld wrapper.
-              export CARGO_HOME="$project_root/.cargo"
-              mkdir -p "$CARGO_HOME" "$CARGO_HOME/bin"
-              export CARGO="${rustToolchain}/bin/cargo"
-              export RUSTC="${rustToolchain}/bin/rustc"
-              unset RUSTUP_TOOLCHAIN
-              export PATH="${lib.makeBinPath [ rustToolchain ]}:$CARGO_HOME/bin:${crossCompilerPath}:$PATH"
-              hash -r 2>/dev/null || true
-
-              unset CC CXX AR RANLIB
-              unset CC_x86_64_unknown_linux_gnu
-              unset CXX_x86_64_unknown_linux_gnu
-              unset AR_x86_64_unknown_linux_gnu
-              unset RANLIB_x86_64_unknown_linux_gnu
-
-              echo "TGOSKits dev shell"
-              echo "  CARGO_HOME=$CARGO_HOME"
-              echo "  CARGO=$CARGO"
-              echo "  Rust toolchain: rust-overlay from rust-toolchain.toml"
-              echo "  Cross compilers: available by target-prefixed command name"
-            '';
-          };
+          # Human workflow is `devenv shell` / `devenv allow`.
+          # This only re-exports devenv.nix as `nix develop`.
+          devenv.shells.default.imports = [ ./devenv.nix ];
 
           formatter = pkgs.nixfmt;
         };


### PR DESCRIPTION
## 要解决的问题

本地开发环境原先由 `.envrc` 的 `use flake` 加载 `flake.nix` 里的 `mkShell`。希望改成独立的 `devenv.nix`：平时用 `devenv shell` 或 `devenv allow` 进入，不再让 direnv 去加载 flake。flake 只作为可选包装，不能反过来定义环境。

## 实际改动与设计逻辑

1. 新增 `devenv.nix` / `devenv.yaml` / `devenv.lock`。工具链用 `languages.rust.toolchainFile = ./rust-toolchain.toml`，包列表直接声明。Linux 默认的 clang linker 和 `languages.c` 关掉，避免把 host `CC` 塞回 cargo。
2. `enterShell` 继续把 `CARGO_HOME` 钉在仓库 `.cargo`，钉死 `CARGO`/`RUSTC`，清掉 `RUSTUP_TOOLCHAIN` 和 host `CC`/`CXX`。交叉 musl 只提供别名脚本；真实 `pkgsCross.*.stdenv.cc` 不进 `packages`，只挂 PATH，避免 setup hook 覆盖 native Rust 的编译器变量。
3. 当前锁定的 nixpkgs 上核对过包属性：`libpixman`、`qemu-user-static` 不存在，已删除。其余包直接引用，不再用 `optionalPackageByPath` 静默跳过。
4. `.envrc` 去掉 `use flake`，只保留如何进入 devenv 的说明。自动激活走 `devenv hook` + `devenv allow`，不再绑 direnv。
5. `flake.nix` 通过 `devenv.flakeModule` 导入同一份 `devenv.nix`，给仍要 `nix develop` 的路径用。人用入口以 devenv CLI 为准，输入锁在 `devenv.lock`，不跟 `flake.lock` 混用。CI 未改。

## 验证

- `devenv shell`：`CARGO`/`RUSTC` 为 `rust-minimal-1.100.0-nightly-2026-09-04`，`CC` 与 `RUSTUP_TOOLCHAIN` 未设置，`qemu-system-x86_64`、musl gcc 别名、`riscv64-unknown-linux-gnu-gcc` 在 PATH。
- 用户在该环境中执行 `cargo xtask arceos test qemu --arch riscv64 -g rust -c task-yield`，测试通过。