### PR TITLE
fix(qperf): support QEMU 11.1.1 plugin API v7

### DIFF
--- a/.agents/skills/arch-platform-porting/references/boot-debugging.md
+++ b/.agents/skills/arch-platform-porting/references/boot-debugging.md
@@ -156,6 +156,7 @@ cargo xtask starry board \
 
 ## LoongArch 经验
 
+- `cargo xtask starry perf --arch loongarch64` 必须消费用例的 `uefi` 和 `to_bin` 契约。当前动态内核是 UEFI PE 镜像，不能绕过 OVMF 直接传给 `-kernel`。`perf::qemu::prepare_boot_args` 使用共享 OVMF 缓存、独立 VARS 副本及 `EFI/BOOT/BOOTLOONGARCH64.EFI`；未进入内核且没有样本时先检查这条启动链路，再检查插件 ABI。x86_64 复用同一 ESP 准备逻辑，使用 `BOOTX64.EFI`。
 - LS2K1000 在块硬件上下文激活后重复输出 `failed to lock LS2K1000 LIOINTC when claiming LIOINTC IRQ`，表示硬中断与控制器锁次序反转，不是无害伪中断。按 AArch64 GIC 模式拆分：`rdif_intc` 控制器和配置寄存器归任务，独立 LIOINTC 处理器接口只含中断状态、域、父线路和原子启用状态。硬中断查找或锁住控制器会在被中断任务释放设备保护前因电平中断不断重入。
 - U-Boot FIT 启动中，生产与交接契约保持一致：使用规范体系结构名 `loongarch`；U-Boot 以符合设备树规范的 8 字节对齐地址传递设备树；FIT 提供的设备树通过 UHI 约定传给 someboot，即 `a0 = -2`、`a1 = fdt`。检查 `legacy_hdr_os` 的厂商 `CONFIG_LOONGSON_BOOT_FIXUP` 不能作用于 FIT 映像。
 - 地址转换缓存填充入口和普通异常入口使用不同寄存器，可能需要不同地址形式。需要物理填充向量时，不能复用高地址虚拟符号。

--- a/.github/ci/checks/workspace.toml
+++ b/.github/ci/checks/workspace.toml
@@ -21,3 +21,16 @@ cargo xtask test
 pull_request_command = '''
 cargo xtask test --since "$SINCE_REF"
 '''
+
+[[check]]
+id = "test-qperf"
+name = "qperf QEMU 11.1.1 ABI and sampling"
+runner = "ubuntu-base"
+timeout_minutes = 10
+command = '''
+apps/qperf/prebuild.sh cargo build --release -p qperf -p qperf-analyzer --target-dir tools/qperf/target
+apps/qperf/prebuild.sh cargo test -p qperf --test reg
+python3 tools/qperf/tests/prebuild.py
+python3 tools/qperf/tests/qemu_load.py tools/qperf/target/release/libqperf.so
+python3 tools/qperf/tests/qemu_sample.py tools/qperf/target/release/libqperf.so tools/qperf/target/release/qperf-analyzer
+'''

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6119,30 +6119,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d8f70e07b9c3962945a74e59ca1c511bba65b6419468acc217c457d93f3c740"
 
 [[package]]
-name = "qemu-plugin"
-version = "10.1.0-v2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19df903439a896a96aec394ca3e1b6e0fdbd92b8112aec484cd9a56c9453e806"
-dependencies = [
- "anyhow",
- "lazy_static",
- "libc",
- "libloading",
- "qemu-plugin-sys",
- "thiserror 2.0.20",
- "windows",
-]
-
-[[package]]
-name = "qemu-plugin-sys"
-version = "10.1.0-v2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "626809b8b33148371d3e2754834b68e27ff0bf5a5b326a67d83fccd4e1699cab"
-dependencies = [
- "anyhow",
-]
-
-[[package]]
 name = "qoi"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6158,7 +6134,6 @@ dependencies = [
  "anyhow",
  "bincode",
  "crossbeam-channel",
- "qemu-plugin",
  "zerocopy",
 ]
 

--- a/apps/qperf/README.md
+++ b/apps/qperf/README.md
@@ -1,18 +1,24 @@
 # qperf
 
-`qperf` is packaged as a thin TGOSKits entrypoint. The QEMU plugin and analyzer source is not vendored in this repository; `prebuild.sh` clones `cg24-THU/tgoskit-harness_kit` at commit `762c22725024a065e85b26e0b01121eccea651c0` and reuses that checkout from `target/tgoskit-harness-kit/`.
+`apps/qperf/prebuild.sh` 使用本仓库 `tools/qperf` 中的插件和分析器源码，与
+`cargo xtask starry perf` 共用同一实现。脚本不下载外部 harness kit；执行命令前
+切换到本仓库根目录，因此命令中的 `tools/qperf/...` 相对路径不受调用目录影响。
+插件要求 QEMU 11.1.1 的 API v7；不提供旧 API 的兼容构建。
 
-Build the fixed qperf checkout:
+单独构建插件和分析器时使用以下命令。StarryOS 的完整剖析流程使用
+`cargo xtask starry perf`，不需要预先执行它们。
 
 ```bash
 apps/qperf/prebuild.sh cargo build --manifest-path tools/qperf/Cargo.toml --release
 apps/qperf/prebuild.sh cargo build --manifest-path tools/qperf/analyzer/Cargo.toml --release --features flamegraph
 ```
 
-Run the synthetic folded-stack demo:
+入口回归检查工作目录、参数保留、外部 checkout 隔离及退出状态传播：
 
 ```bash
-apps/qperf/prebuild.sh python3 tools/qperf/examples/long_chain_flamegraph_demo.py --no-svg --output-dir target/qperf-long-chain-demo-smoke
+apps/qperf/prebuild.sh python3 tools/qperf/tests/prebuild.py
 ```
 
-Run `apps/qperf/prebuild.sh` without arguments to print the fixed checkout path.
+不带参数执行 `apps/qperf/prebuild.sh` 会输出本仓库根目录。
+`cargo xtask starry perf` 的报告后处理及 `apps/OScope-harness` 仍使用
+`apps/common/prebuild-harness-kit.sh` 提供的固定外部 checkout；本次入口统一不改变它们。

--- a/apps/qperf/prebuild.sh
+++ b/apps/qperf/prebuild.sh
@@ -2,4 +2,11 @@
 set -euo pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-exec "$script_dir/../common/prebuild-harness-kit.sh" "$@"
+workspace="$(cd "$script_dir/../.." && pwd)"
+
+if [[ $# -gt 0 ]]; then
+    cd "$workspace"
+    exec "$@"
+fi
+
+printf '%s\n' "$workspace"

--- a/docs/docs/build/starry/perf.md
+++ b/docs/docs/build/starry/perf.md
@@ -7,15 +7,18 @@ sidebar_label: "性能剖析"
 
 `cargo xtask starry perf` 构建 StarryOS 并通过 qperf 进行性能剖析，输出火焰图（SVG/HTML/Folded）、Pprof 或 callchain 数据。这是 StarryOS 独有的命令，[ArceOS](../arceos/overview) 和 [Axvisor](../axvisor/overview) 没有。
 
-目前支持 `riscv64`、`loongarch64` 和 `x86_64`。x86_64 使用 StarryOS 的 q35/UEFI
-启动配置，并通过 Ostool 的固定版本和 SHA-256 校验流程复用公共 OVMF 缓存。需要隔离缓存时，
+目前支持 `riscv64`、`loongarch64` 和 `x86_64`，要求 QEMU 11.1.1（Plugin API v7）。
+x86_64 和 LoongArch 按用例的 UEFI 配置启动，并通过 Ostool 的固定版本和 SHA-256
+校验流程复用公共 OVMF 缓存。需要隔离缓存时，
 统一设置 `TGOS_OVMF_DIR`；该目录必须使用 Ostool 的 `<arch>/code.fd`、`vars.fd` 布局。
 建议在 x86_64 上同时使用 `--kernel-filter`，排除 UEFI 固件和用户态地址。
 
-qperf 工具和报告脚本统一通过 `apps/common/prebuild-harness-kit.sh` 获取固定版本的
-harness kit；`cargo xtask starry perf` 与 `apps/qperf`、`apps/OScope-harness` 复用同一
-checkout。需要使用预先准备的只读 checkout 时，设置 `TGOSKIT_HARNESS_KIT_DIR`；该
-目录必须是文档所列固定提交的 Git checkout，且包含 qperf 与报告脚本。
+`cargo xtask starry perf` 的 `build_qperf_tools()` 与 `apps/qperf/prebuild.sh`
+统一使用本仓库 `tools/qperf` 中的插件和分析器源码，不再回退到外部插件源码。
+报告后处理和 `apps/OScope-harness` 仍通过 `apps/common/prebuild-harness-kit.sh`
+获取固定版本的 harness kit。需要使用预先准备的只读 checkout 时，设置
+`TGOSKIT_HARNESS_KIT_DIR`；该目录必须满足 provider 的固定提交和文件完整性校验。
+此变量不改变 qperf 插件和分析器的源码来源。
 
 ## 1. 剖析流程
 
@@ -26,7 +29,7 @@ flowchart TD
     A["cargo xtask starry perf"] --> B["构建 qperf 工具链<br/>qperf + qperf-analyzer + flamegraph"]
     B --> C["构建 StarryOS<br/>注入 qperf feature"]
     C --> D["准备 rootfs + QEMU 配置"]
-    D --> E["运行 QEMU<br/>采集 trace buffer / 指令采样"]
+    D --> E["运行 QEMU<br/>翻译块 / 指令采样"]
     E --> F{"QEMU 是否产出样本?"}
     F -->|"否（早退）"| ERR["bail: 未产出样本"]
     F -->|"是"| G["qperf-analyzer 解析<br/>符号化 + 折叠栈"]
@@ -46,7 +49,7 @@ flowchart TD
 | `--arch <ARCH>` | 目标架构：`riscv64`/`loongarch64`/`x86_64`（默认 `riscv64`） |
 | `--freq <HZ>` | 采样频率（默认 99） |
 | `--format` | 输出格式：`Folded`/`Svg`/`Pprof`/`All`（默认 `All`） |
-| `--mode` | 采样模式：`Tb`（trace buffer，默认）/ `Insn`（指令级） |
+| `--mode` | 采样模式：`Tb`（translation block，默认）/ `Insn`（指令级） |
 | `--max-depth <N>` | 最大调用栈深度（默认 128） |
 | `--timeout <SEC>` | 采集超时（默认 20） |
 | `--output-dir`/`--out <DIR>` | 输出根目录，报告位于 `<DIR>/perf/<arch>/latest` |
@@ -76,11 +79,11 @@ flowchart TD
 
 ## 3. 采样模式
 
-采样模式决定 qperf 从 trace buffer 读取样本，还是按指令级事件收集样本。
+采样模式决定 qperf 在翻译块（translation block）执行回调还是指令执行回调中采样。
 
 | 模式 | 说明 |
 |------|------|
-| `Tb`（trace buffer，默认） | 从 qperf 的内核 trace buffer 读取采样，开销低 |
+| `Tb`（translation block，默认） | 在 QEMU 翻译块执行回调中采样，开销较低 |
 | `Insn`（指令级） | 指令级采样，精度高但开销大 |
 
 ## 4. Callchain 解栈模式

--- a/scripts/axbuild/src/starry/perf/harness.rs
+++ b/scripts/axbuild/src/starry/perf/harness.rs
@@ -31,8 +31,9 @@ pub(super) fn build_qperf_tools(
     root: &Path,
     analyzer_flamegraph: bool,
 ) -> anyhow::Result<QperfTools> {
-    let qperf_root = qperf_source_root(root)?;
+    let qperf_root = root.join("tools/qperf");
     let manifest = qperf_root.join("Cargo.toml");
+    ensure_file(&manifest, "local qperf plugin manifest")?;
     let analyzer_manifest = qperf_root.join("analyzer/Cargo.toml");
     let target_dir = qperf_root.join("target");
     if !analyzer_manifest.exists() {
@@ -80,26 +81,6 @@ pub(super) fn build_qperf_tools(
     ensure_file(&tools.plugin, "qperf plugin")?;
     ensure_file(&tools.analyzer, "qperf analyzer")?;
     Ok(tools)
-}
-
-fn qperf_source_root(root: &Path) -> anyhow::Result<PathBuf> {
-    if let Some(path) = [root.join("apps/qperf"), root.join("tools/qperf")]
-        .into_iter()
-        .find(|path| path.join("Cargo.toml").exists())
-    {
-        return Ok(path);
-    }
-
-    let checkout = ensure_harness_kit_checkout(root)?;
-    let fixed_qperf = checkout.join("tools/qperf");
-    if fixed_qperf.join("Cargo.toml").exists() {
-        return Ok(fixed_qperf);
-    }
-
-    Err(anyhow::anyhow!(
-        "qperf sources not found; expected apps/qperf, tools/qperf, or fixed harness kit \
-         tools/qperf to be present"
-    ))
 }
 
 fn ensure_harness_kit_checkout(root: &Path) -> anyhow::Result<PathBuf> {

--- a/scripts/axbuild/src/starry/perf/qemu.rs
+++ b/scripts/axbuild/src/starry/perf/qemu.rs
@@ -378,6 +378,21 @@ mod tests {
         assert!(validate_arch("aarch64").is_err());
     }
 
+    #[tokio::test]
+    async fn loongarch_uefi_rejects_unconverted_kernel_before_boot() {
+        let temp = tempfile::tempdir().unwrap();
+        let outputs = super::super::outputs::prepare_outputs(
+            temp.path(), "loongarch64", "boot", None, None,
+        ).unwrap();
+        let config = toml::from_str::<super::PerfQemuConfig>(
+            "args = []\nuefi = true\nto_bin = false\nsuccess_regex = []\nfail_regex = []\n",
+        ).unwrap();
+        let error = super::prepare_boot_args(
+            &outputs, &config, "loongarch64", &temp.path().join("kernel.bin"),
+        ).await.unwrap_err();
+        assert!(error.to_string().contains("to_bin = true"));
+    }
+
     #[test]
     fn timeout_keeps_interactive_qemu_in_the_foreground() {
         let prefix = qemu_command_prefix("qemu-system-x86_64", 15, false);

--- a/scripts/axbuild/src/starry/perf/qemu.rs
+++ b/scripts/axbuild/src/starry/perf/qemu.rs
@@ -257,37 +257,44 @@ async fn prepare_boot_args(
     arch: &str,
     kernel_bin: &Path,
 ) -> anyhow::Result<Vec<String>> {
-    if arch != "x86_64" {
+    if !config.uefi {
+        if arch == "x86_64" {
+            bail!("StarryOS x86_64 qperf requires a QEMU config with `uefi = true`");
+        }
         return Ok(vec![
             "-kernel".to_string(),
             kernel_bin.display().to_string(),
         ]);
     }
-    if !config.uefi {
-        bail!("StarryOS x86_64 qperf requires a QEMU config with `uefi = true`");
-    }
     if !config.to_bin {
-        bail!("StarryOS x86_64 qperf requires a QEMU config with `to_bin = true`");
+        bail!("StarryOS {arch} UEFI qperf requires a QEMU config with `to_bin = true`");
     }
 
-    let firmware = crate::support::ovmf::OvmfFirmware::fetch(Arch::X64).await?;
-    prepare_x86_64_uefi_boot(&outputs.dir, kernel_bin, &firmware)
+    let (firmware_arch, boot_filename) = match arch {
+        "x86_64" => (Arch::X64, "BOOTX64.EFI"),
+        "loongarch64" => (Arch::LoongArch64, "BOOTLOONGARCH64.EFI"),
+        "riscv64" => (Arch::Riscv64, "BOOTRISCV64.EFI"),
+        _ => bail!("qperf currently supports StarryOS {SUPPORTED_ARCHES} only"),
+    };
+    let firmware = crate::support::ovmf::OvmfFirmware::fetch(firmware_arch).await?;
+    prepare_uefi_boot(&outputs.dir, kernel_bin, &firmware, boot_filename)
 }
 
-fn prepare_x86_64_uefi_boot(
+fn prepare_uefi_boot(
     output_dir: &Path,
     kernel_bin: &Path,
     firmware: &crate::support::ovmf::OvmfFirmware,
+    boot_filename: &str,
 ) -> anyhow::Result<Vec<String>> {
-    ensure_file(kernel_bin, "StarryOS x86_64 UEFI image")?;
+    ensure_file(kernel_bin, "StarryOS UEFI image")?;
     ensure_file(firmware.code(), "OVMF code image")?;
     ensure_file(firmware.vars(), "OVMF vars template")?;
 
     let esp_dir = output_dir.join("starryos.esp");
     let boot_dir = esp_dir.join("EFI/BOOT");
     fs::create_dir_all(&boot_dir)
-        .with_context(|| format!("failed to create x86_64 UEFI ESP {}", boot_dir.display()))?;
-    let boot_image = boot_dir.join("BOOTX64.EFI");
+        .with_context(|| format!("failed to create UEFI ESP {}", boot_dir.display()))?;
+    let boot_image = boot_dir.join(boot_filename);
     fs::copy(kernel_bin, &boot_image).with_context(|| {
         format!(
             "failed to copy StarryOS UEFI image from {} to {}",
@@ -355,7 +362,7 @@ mod tests {
     use std::fs;
 
     use super::{
-        append_text_filter_params, direct_qemu_args, prepare_x86_64_uefi_boot, qemu_command_prefix,
+        append_text_filter_params, direct_qemu_args, prepare_uefi_boot, qemu_command_prefix,
         validate_arch,
     };
     use crate::{
@@ -381,15 +388,21 @@ mod tests {
     #[tokio::test]
     async fn loongarch_uefi_rejects_unconverted_kernel_before_boot() {
         let temp = tempfile::tempdir().unwrap();
-        let outputs = super::super::outputs::prepare_outputs(
-            temp.path(), "loongarch64", "boot", None, None,
-        ).unwrap();
+        let outputs =
+            super::super::outputs::prepare_outputs(temp.path(), "loongarch64", "boot", None, None)
+                .unwrap();
         let config = toml::from_str::<super::PerfQemuConfig>(
             "args = []\nuefi = true\nto_bin = false\nsuccess_regex = []\nfail_regex = []\n",
-        ).unwrap();
+        )
+        .unwrap();
         let error = super::prepare_boot_args(
-            &outputs, &config, "loongarch64", &temp.path().join("kernel.bin"),
-        ).await.unwrap_err();
+            &outputs,
+            &config,
+            "loongarch64",
+            &temp.path().join("kernel.bin"),
+        )
+        .await
+        .unwrap_err();
         assert!(error.to_string().contains("to_bin = true"));
     }
 
@@ -433,31 +446,39 @@ mod tests {
     }
 
     #[test]
-    fn x86_64_uefi_boot_uses_a_private_vars_copy_and_esp() {
-        let temp = tempfile::tempdir().unwrap();
-        let kernel_bin = temp.path().join("starryos.bin");
-        let code = temp.path().join("code.fd");
-        let vars = temp.path().join("vars.fd");
-        fs::write(&kernel_bin, b"MZ kernel").unwrap();
-        fs::write(&code, b"code").unwrap();
-        fs::write(&vars, b"vars").unwrap();
+    fn uefi_boot_uses_a_private_vars_copy_and_arch_specific_esp() {
+        for boot_filename in ["BOOTX64.EFI", "BOOTLOONGARCH64.EFI", "BOOTRISCV64.EFI"] {
+            let temp = tempfile::tempdir().unwrap();
+            let kernel_bin = temp.path().join("starryos.bin");
+            let code = temp.path().join("code.fd");
+            let vars = temp.path().join("vars.fd");
+            fs::write(&kernel_bin, b"MZ kernel").unwrap();
+            fs::write(&code, b"code").unwrap();
+            fs::write(&vars, b"vars").unwrap();
 
-        let args = prepare_x86_64_uefi_boot(
-            temp.path(),
-            &kernel_bin,
-            &OvmfFirmware::from_paths(code.clone(), vars),
-        )
-        .unwrap();
+            let args = prepare_uefi_boot(
+                temp.path(),
+                &kernel_bin,
+                &OvmfFirmware::from_paths(code.clone(), vars),
+                boot_filename,
+            )
+            .unwrap();
 
-        assert_eq!(
-            fs::read(temp.path().join("starryos.esp/EFI/BOOT/BOOTX64.EFI")).unwrap(),
-            b"MZ kernel"
-        );
-        assert_eq!(
-            fs::read(temp.path().join("starryos.vars.fd")).unwrap(),
-            b"vars"
-        );
-        assert!(args.iter().any(|arg| arg.contains(code.to_str().unwrap())));
-        assert!(!args.iter().any(|arg| arg == "-kernel"));
+            assert_eq!(
+                fs::read(
+                    temp.path()
+                        .join("starryos.esp/EFI/BOOT")
+                        .join(boot_filename)
+                )
+                .unwrap(),
+                b"MZ kernel"
+            );
+            assert_eq!(
+                fs::read(temp.path().join("starryos.vars.fd")).unwrap(),
+                b"vars"
+            );
+            assert!(args.iter().any(|arg| arg.contains(code.to_str().unwrap())));
+            assert!(!args.iter().any(|arg| arg == "-kernel"));
+        }
     }
 }

--- a/tools/qperf/ABI.md
+++ b/tools/qperf/ABI.md
@@ -1,0 +1,88 @@
+# qperf 的 QEMU API v7 适配
+
+qperf 使用 `src/qemu/ffi.rs` 中的最小绑定连接 QEMU 11.1.1。插件只服务现有采样流程，
+不维护通用 QEMU Rust SDK，也不保留 API v4、v5 或 v6 的构建分支。
+
+## 1. ABI 边界
+
+绑定以 QEMU 的 [v11.1.1 头文件](https://github.com/qemu/qemu/blob/v11.1.1/include/plugins/qemu-plugin.h)
+和 [插件实现](https://github.com/qemu/qemu/blob/v11.1.1/plugins/api.c) 为依据。
+此前的 `qemu-plugin 10.1.0-v2` 不支持该 ABI；上游仅有 v6 的提交同样不能加载到要求 v7 的 QEMU。
+
+### 1.1 版本与布局
+
+`PLUGIN_VERSION` 导出 `qemu_plugin_version = 7`。版本不是兼容开关：`Info`、
+`RegisterDescriptor` 及所有回调声明必须同时符合 v7。寄存器描述符包含尾部的
+`is_readonly`；漏掉它会使遍历数组时使用错误步长。读取寄存器返回 `bool`，不是旧版的字节数。
+
+QEMU 把寄存器编号及只读位编码进不透明句柄，零也是有效值。`reg::init()` 复制名称，
+借用句柄并释放 QEMU 返回的 `GArray`，不解引用句柄，也不把它当作宿主内存分配。
+
+### 1.2 外部内存
+
+`ByteArray` 独占 GLib 分配的可扩容缓冲区。寄存器和客户机虚拟内存读取成功后，
+先检查长度再复制到 Rust 切片；失败和成功路径都由析构释放缓冲区。不向 QEMU 传入
+由 Rust 栈数组伪装的可扩容 `GByteArray`，也不直接解引用客户机地址。
+
+## 2. 回调生命周期
+
+`Runtime` 是插件实例的唯一状态所有者。QEMU 的
+[回调实现](https://github.com/qemu/qemu/blob/v11.1.1/plugins/core.c)
+规定 flush 在停止执行后发生，atexit 在执行结束后发生；资源回收依赖这些保证，
+而不只是依赖 Rust 的引用计数。
+
+### 2.1 初始化与执行
+
+`qemu_plugin_install()` 先解析参数、检查目标并创建 `Profiler`，全部可失败准备完成后
+才发布装箱的 `Runtime`。初始化错误返回非零值；Rust 恐慌不跨越 C ABI。
+各 vCPU 的初始化回调枚举寄存器，线程局部的 `REGISTERS` 再按 vCPU 编号区分句柄，
+兼顾多线程 TCG 和一个线程执行多个 vCPU 的情况。退出回调移除对应项。
+
+`on_translate()` 只在 QEMU 保证有效的翻译回调期间读取 TB 和指令指针。
+采样点保存 `Arc<Profiler>` 和 PC，不保留 TB 或指令指针。`on_execute()` 只借用
+采样点；FP 模式注册 `R_REGS`，leaf 模式注册 `NO_REGS`。采样时间锁和统计计数
+仍由 `Profiler` 管理，写线程不会读取 vCPU 寄存器或客户机内存。
+
+### 2.2 回收与退出
+
+`Runtime::sites` 保存稳定分配的采样点，即使容器扩容也不会改变 `userdata` 地址。
+`on_flush()` 在 QEMU 停止所有旧翻译块执行后释放它们。`on_exit()` 取回唯一的
+`Box<Runtime>`；最后一个 `Profiler` 引用释放时，通过 `Shutdown` 消息等待写线程
+排空样本并完成统计输出。没有后台任务在退出后继续使用 QEMU 提供的内存。
+
+其所有权转移过程为：
+
+```mermaid
+flowchart LR
+    A[参数与输出准备] --> B[Runtime 发布给 QEMU]
+    B --> C[翻译回调保管 SampleSite]
+    C --> D[执行回调借用 SampleSite]
+    D --> E[flush 停止执行后清理采样点]
+    E --> C
+    B --> F[atexit 取回 Runtime]
+    F --> G[最后一个 Profiler 引用等待 writer 完成]
+```
+
+## 3. 验证与迁移
+
+`.github/ci/checks/workspace.toml` 的 `test-qperf` 在项目容器中构建本地插件和分析器。
+不通过改动外部 harness kit 或放宽 QEMU 版本检查实现迁移。
+
+### 3.1 回归责任
+
+`tests/qemu_load.py` 直接让 QEMU 加载插件并通过 QMP 退出，保护实际 ABI 和错误传播；
+旧 v5 插件必然因最低 API v7 要求失败。`tests/reg.rs` 保护描述符布局。
+`tests/qemu_sample.py` 在真实 QEMU 中执行双线程 C 工作负载，验证四种采样组合、
+有效样本、零丢失和零采样失败，并要求 FP 栈恢复工作负载的调用者。
+小型 TCG 缓存同时增加翻译块回收压力，但不将它当作性能基准。
+
+### 3.2 用户流程
+
+`cargo xtask starry perf` 还需要在 x86_64、riscv64 和 loongarch64 完成实际内核剖析，
+验证停止标记、原始数据、非空 folded 栈及报告。LoongArch 的 UEFI 镜像必须通过
+OVMF 和 `BOOTLOONGARCH64.EFI` 启动，不能传给直接内核加载器。
+原始样本仍为格式 v3，分析器和报告后处理的输入不变。
+
+回滚绑定到旧 API 会恢复旧 QEMU 的构建要求，不能继续宣称支持 11.1.1。
+本次不涉及持久数据迁移；macOS 动态符号解析保留构建支持，运行验证以 Linux 宿主为准。
+新增 FFI 和回调回收代码需要领域审查后才能合入，运行通过不能替代安全性审查。

--- a/tools/qperf/Cargo.toml
+++ b/tools/qperf/Cargo.toml
@@ -12,8 +12,4 @@ test = false
 anyhow = { workspace = true, features = ["std"] }
 bincode.workspace = true
 crossbeam-channel = "0.5.15"
-qemu-plugin = { version = "10.1.0-v2", default-features = false, features = [
-    "anyhow",
-    "plugin-api-v5",
-] }
 zerocopy = { version = "0.8.26", features = ["derive", "std"] }

--- a/tools/qperf/README.md
+++ b/tools/qperf/README.md
@@ -8,7 +8,8 @@ Based on [QEMU TCG Plugins](https://www.qemu.org/docs/master/devel/tcg-plugins.h
 
 ## Requirements
 
-- QEMU Version 9.2.0 or later (Plugin API Version 4)
+- QEMU 11.1.1（Plugin API v7）。不支持旧插件 API；本地绑定和回调所有权见
+  [API v7 适配](ABI.md)。
 - A kernel text address range passed through `filter_start`/`filter_end` when kernel-only sampling is
   required. Do not infer an x86_64 low-address alias from the high-half address: UEFI and
   identity-mapped code can occupy the same low window.
@@ -27,15 +28,16 @@ To generate DWARF debugging information and enable frame pointers, the kernel im
 ### 1. Build qperf plugin
 
 ```bash
-$ cargo build --release
+apps/qperf/prebuild.sh cargo build --release -p qperf -p qperf-analyzer --target-dir tools/qperf/target
 ```
 
-`target/release/libqperf.so` is what we need.
+从仓库根目录执行上述命令，插件位于 `tools/qperf/target/release/libqperf.so`。
+`apps/qperf` 和 `cargo xtask starry perf` 都使用本地源码，不下载外部插件实现。
 
 ### 2. Install qperf-analyzer
 
 ```bash
-$ cargo install --path analyzer
+cargo install --path tools/qperf/analyzer
 ```
 
 ### 3. Run QEMU with qperf plugin
@@ -85,12 +87,21 @@ There are many visualization options. Recommendations:
 
 - The default build options (`BACKTRACE=y`) should already enable all the debugging options qperf needs.
 - The plugin recognizes QEMU targets `riscv64`, `loongarch64`, and `x86_64`.
-- Prefer `cargo starry perf`; it builds the plugin/analyzer, prepares the matching StarryOS QEMU
+- Prefer `cargo xtask starry perf`; it builds the plugin/analyzer, prepares the matching StarryOS QEMU
   boot flow, supplies kernel ranges, and generates the report artifacts.
 - For an x86_64 kernel boot profile, use:
 
 ```bash
-cargo starry perf --arch x86_64 --kernel-filter --format folded \
+cargo xtask starry perf --arch x86_64 --kernel-filter --format folded \
     --shell-init-cmd "echo QPERF_BOOT_DONE" \
     --stop-marker "QPERF_BOOT_DONE" --timeout 60
+```
+
+加载、退出、参数错误及实际采样回归使用真实 QEMU 11.1.1。用户态采样回归需要
+`qemu-x86_64`、宿主 C 编译器及静态 libc，覆盖 TB/指令采样、双线程及 FP 解栈：
+
+```bash
+python3 tools/qperf/tests/prebuild.py
+python3 tools/qperf/tests/qemu_load.py tools/qperf/target/release/libqperf.so
+python3 tools/qperf/tests/qemu_sample.py tools/qperf/target/release/libqperf.so tools/qperf/target/release/qperf-analyzer
 ```

--- a/tools/qperf/build.rs
+++ b/tools/qperf/build.rs
@@ -1,0 +1,5 @@
+fn main() {
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("macos") {
+        println!("cargo:rustc-link-arg=-Wl,-undefined,dynamic_lookup");
+    }
+}

--- a/tools/qperf/src/lib.rs
+++ b/tools/qperf/src/lib.rs
@@ -1,3 +1,4 @@
 mod profiler;
+mod qemu;
 mod reg;
 mod target;

--- a/tools/qperf/src/profiler.rs
+++ b/tools/qperf/src/profiler.rs
@@ -13,16 +13,11 @@ use std::{
 
 use anyhow::{Context, bail};
 use crossbeam_channel::{Sender, TrySendError, bounded};
-use qemu_plugin::{
-    CallbackFlags, PluginId, TranslationBlock, VCPUIndex,
-    install::{Args, Info, Value},
-    plugin::{HasCallbacks, Register},
-    qemu_plugin_get_registers, qemu_plugin_read_memory_vaddr, qemu_plugin_register_atexit_cb,
-};
 use zerocopy::IntoBytes;
 
 use crate::{
-    reg::AllRegs,
+    qemu::{Args, Value},
+    reg,
     target::{Frame, Reg, Target},
 };
 
@@ -146,6 +141,9 @@ impl TryFrom<&Args> for PluginArgs {
             })
             .transpose()?
             .unwrap_or("qperf.bin".into());
+        if freq == 0 {
+            bail!("frequency must be greater than 0");
+        }
         let max_depth = parse_usize_arg(args, "max_depth")?.unwrap_or(128);
         let queue_size = parse_usize_arg(args, "queue_size")?.unwrap_or(4096);
         let mode = args
@@ -265,7 +263,6 @@ fn parse_bool_arg(args: &Args, name: &str) -> anyhow::Result<Option<bool>> {
                 "0" | "false" | "no" | "off" => Ok(false),
                 _ => bail!("invalid {name}: expected boolean"),
             },
-            _ => bail!("invalid {name}: expected boolean"),
         })
         .transpose()
 }
@@ -277,7 +274,6 @@ struct Stats {
     sample_failures: AtomicU64,
 }
 
-#[derive(Clone)]
 pub struct Profiler {
     target: Target,
     tx: Sender<WriterEvent>,
@@ -293,35 +289,14 @@ pub struct Profiler {
     callchain: CallchainMode,
     started_at: Arc<Instant>,
     last: Arc<Mutex<Instant>>,
-    regs: Arc<AllRegs>,
     stats: Arc<Stats>,
 }
 
-impl Default for Profiler {
-    fn default() -> Self {
-        Self {
-            target: Target::Riscv64,
-            tx: bounded(0).0,
-            intvl: Duration::MAX,
-            max_depth: 128,
-            mode: SamplingMode::Tb,
-            filter_start: None,
-            filter_end: None,
-            filter_alias_start: None,
-            filter_alias_end: None,
-            filter_alias_offset: None,
-            filter_kernel: false,
-            callchain: CallchainMode::Leaf,
-            started_at: Arc::new(Instant::now()),
-            last: Arc::new(Mutex::new(Instant::now())),
-            regs: Arc::default(),
-            stats: Arc::default(),
-        }
-    }
-}
-
 impl Profiler {
-    fn sample(&mut self, cpu: u32, ip: u64) -> qemu_plugin::Result<()> {
+    /// # Safety
+    /// Call only on an initialized vCPU inside a QEMU execution callback, with
+    /// R_REGS enabled when using frame-pointer sampling.
+    pub unsafe fn sample(&self, cpu: u32, ip: u64) -> anyhow::Result<()> {
         let now = Instant::now();
         let Ok(mut last) = self.last.try_lock() else {
             return Ok(());
@@ -334,13 +309,15 @@ impl Profiler {
         let mut ips = Vec::with_capacity(self.max_depth.min(16));
         ips.push(ip);
         let sp = if self.callchain.needs_registers() {
-            self.regs.read(self.target.reg(Reg::Sp)).unwrap_or(0)
+            // SAFETY: The execution callback runs in this vCPU's R_REGS context.
+            unsafe { reg::read(cpu, self.target.reg(Reg::Sp)) }?
         } else {
             0
         };
         let mut fp_value = 0;
         if self.callchain == CallchainMode::Fp {
-            let mut fp = self.regs.read(self.target.reg(Reg::Fp))?;
+            // SAFETY: Same initialized vCPU and R_REGS context as the SP read.
+            let mut fp = unsafe { reg::read(cpu, self.target.reg(Reg::Fp)) }?;
             fp_value = fp;
             let mut seen_fps = BTreeSet::new();
 
@@ -352,10 +329,13 @@ impl Profiler {
                     break;
                 };
                 let mut frame = Frame::default();
-                if qemu_plugin_read_memory_vaddr(frame_address, frame.as_mut_bytes()).is_err() {
+                // SAFETY: This callback has the active vCPU memory context. QEMU
+                // validates guest mappings and reports an unreadable frame.
+                if unsafe { reg::read_memory(frame_address, frame.as_mut_bytes()) }.is_err() {
                     break;
                 };
-                if qemu_plugin_read_memory_vaddr(frame.ip, &mut [0; 8]).is_err() {
+                // SAFETY: Same vCPU context; QEMU validates this candidate PC.
+                if unsafe { reg::read_memory(frame.ip, &mut [0; 8]) }.is_err() {
                     break;
                 }
 
@@ -399,7 +379,7 @@ impl Profiler {
         Ok(())
     }
 
-    fn sample_ip_for(&self, ip: u64) -> Option<u64> {
+    pub fn sample_ip_for(&self, ip: u64) -> Option<u64> {
         if let Some(mapped) = self.canonicalize_ip(ip) {
             return Some(mapped);
         }
@@ -429,68 +409,21 @@ impl Profiler {
     }
 }
 
-impl HasCallbacks for Profiler {
-    fn on_vcpu_init(&mut self, _id: PluginId, _vcpu_id: VCPUIndex) -> qemu_plugin::Result<()> {
-        if self.callchain.needs_registers() {
-            self.regs = Arc::new(qemu_plugin_get_registers()?.into());
-        }
-        Ok(())
+impl Profiler {
+    pub fn needs_registers(&self) -> bool {
+        self.callchain.needs_registers()
     }
 
-    fn on_translation_block_translate(
-        &mut self,
-        _id: PluginId,
-        tb: TranslationBlock,
-    ) -> qemu_plugin::Result<()> {
-        let Some(ip) = self.sample_ip_for(tb.vaddr()) else {
-            return Ok(());
-        };
-
-        match self.mode {
-            SamplingMode::Tb => {
-                let mut this = self.clone();
-                tb.register_execute_callback_flags(
-                    move |cpu| {
-                        if this.sample(cpu, ip).is_err() {
-                            this.stats.sample_failures.fetch_add(1, Ordering::Relaxed);
-                        }
-                    },
-                    callback_flags(self.callchain),
-                );
-            }
-            SamplingMode::Insn => {
-                tb.instructions().for_each(|insn| {
-                    let Some(ip) = self.sample_ip_for(insn.vaddr()) else {
-                        return;
-                    };
-                    let mut this = self.clone();
-                    insn.register_execute_callback_flags(
-                        move |cpu| {
-                            if this.sample(cpu, ip).is_err() {
-                                this.stats.sample_failures.fetch_add(1, Ordering::Relaxed);
-                            }
-                        },
-                        callback_flags(self.callchain),
-                    );
-                });
-            }
-        }
-
-        Ok(())
+    pub fn instruction_sampling(&self) -> bool {
+        self.mode == SamplingMode::Insn
     }
-}
 
-fn callback_flags(callchain: CallchainMode) -> CallbackFlags {
-    if callchain.needs_registers() {
-        CallbackFlags::QEMU_PLUGIN_CB_R_REGS
-    } else {
-        CallbackFlags::QEMU_PLUGIN_CB_NO_REGS
+    pub fn record_failure(&self) {
+        self.stats.sample_failures.fetch_add(1, Ordering::Relaxed);
     }
-}
 
-impl Register for Profiler {
-    fn register(&mut self, id: PluginId, args: &Args, info: &Info) -> qemu_plugin::Result<()> {
-        eprintln!("QPerf loaded: id={id:?} info={info:?}");
+    pub fn start(args: &Args, target_name: &str) -> anyhow::Result<Self> {
+        let target_arch = target_name.parse()?;
         let args = PluginArgs::try_from(args)?;
         eprintln!("QPerf arguments: {args:?}");
         let summary_path = args.out.with_extension("summary.txt");
@@ -504,7 +437,7 @@ impl Register for Profiler {
         let max_depth = args.max_depth;
         let freq = args.freq;
         let callchain = args.callchain;
-        let target = info.target_name.to_string();
+        let target = target_name.to_string();
         spawn(move || {
             let mut shutdown = None;
             while let Ok(event) = rx.recv() {
@@ -568,32 +501,31 @@ impl Register for Profiler {
             }
         });
 
-        let exit_tx = tx.clone();
-        qemu_plugin_register_atexit_cb(id, move |_| {
-            let (done_tx, done_rx) = bounded(0);
-            if exit_tx.send(WriterEvent::Shutdown(done_tx)).is_ok() {
-                let _ = done_rx.recv();
-            }
-        })?;
-
-        self.target = info.target_name.parse()?;
-        self.tx = tx;
-        self.intvl = Duration::from_secs_f64(1.0 / args.freq as f64);
-        self.max_depth = args.max_depth;
-        self.mode = args.mode;
-        self.filter_start = args.filter_start;
-        self.filter_end = args.filter_end;
-        self.filter_alias_start = args.filter_alias_start;
-        self.filter_alias_end = args.filter_alias_end;
-        self.filter_alias_offset = args.filter_alias_offset;
-        self.filter_kernel = args.filter_kernel;
-        self.callchain = args.callchain;
-        self.started_at = Arc::new(Instant::now());
-        self.last = Arc::new(Mutex::new(Instant::now()));
-        self.stats = stats;
-
-        Ok(())
+        Ok(Self {
+            target: target_arch,
+            tx,
+            intvl: Duration::from_secs_f64(1.0 / args.freq as f64),
+            max_depth: args.max_depth,
+            mode: args.mode,
+            filter_start: args.filter_start,
+            filter_end: args.filter_end,
+            filter_alias_start: args.filter_alias_start,
+            filter_alias_end: args.filter_alias_end,
+            filter_alias_offset: args.filter_alias_offset,
+            filter_kernel: args.filter_kernel,
+            callchain: args.callchain,
+            started_at: Arc::new(Instant::now()),
+            last: Arc::new(Mutex::new(Instant::now())),
+            stats,
+        })
     }
 }
 
-qemu_plugin::register!(Profiler::default());
+impl Drop for Profiler {
+    fn drop(&mut self) {
+        let (done_tx, done_rx) = bounded(0);
+        if self.tx.send(WriterEvent::Shutdown(done_tx)).is_ok() {
+            let _ = done_rx.recv();
+        }
+    }
+}

--- a/tools/qperf/src/qemu.rs
+++ b/tools/qperf/src/qemu.rs
@@ -1,0 +1,203 @@
+//! QEMU API v7 entrypoints and callback ownership for this profiler.
+
+pub(super) mod ffi;
+
+use std::{
+    collections::HashMap,
+    ffi::{CStr, c_char, c_int, c_uint, c_void},
+    panic::{AssertUnwindSafe, catch_unwind},
+    sync::{Arc, Mutex},
+};
+
+use anyhow::{Context, bail};
+
+use crate::{profiler::Profiler, reg};
+
+#[derive(Debug)]
+pub enum Value {
+    Integer(i64),
+    String(String),
+}
+
+pub struct Args {
+    pub parsed: HashMap<String, Value>,
+}
+
+impl Args {
+    fn parse(raw: &[String]) -> anyhow::Result<Self> {
+        let mut parsed = HashMap::new();
+        for argument in raw {
+            let (key, value) = argument.split_once('=').context("expected key=value")?;
+            let value = match value.parse() {
+                Ok(integer) => Value::Integer(integer),
+                Err(_) => Value::String(value.to_owned()),
+            };
+            parsed.insert(key.to_owned(), value);
+        }
+        Ok(Self { parsed })
+    }
+}
+
+struct Runtime {
+    profiler: Arc<Profiler>,
+    // Arc allocations keep userdata stable when this vector reallocates.
+    sites: Mutex<Vec<Arc<SampleSite>>>,
+}
+
+struct SampleSite {
+    profiler: Arc<Profiler>,
+    ip: u64,
+}
+
+#[unsafe(export_name = "qemu_plugin_version")]
+pub static PLUGIN_VERSION: c_int = ffi::API_VERSION;
+
+/// Install the profiler after QEMU has checked the exported API version.
+///
+/// # Safety
+/// QEMU supplies a live `Info`, and `argc` live, NUL-terminated entries in `argv`.
+/// Neither the info block nor its strings are retained after this call.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qemu_plugin_install(
+    id: u64,
+    info: *const ffi::Info,
+    argc: c_int,
+    argv: *const *const c_char,
+) -> c_int {
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        if info.is_null() || argc < 0 || (argc != 0 && argv.is_null()) {
+            bail!("invalid QEMU install arguments");
+        }
+        // SAFETY: QEMU keeps info and its target string live throughout installation.
+        let info = unsafe { &*info };
+        if info.target_name.is_null()
+            || info.version.min > PLUGIN_VERSION
+            || info.version.cur < PLUGIN_VERSION
+        {
+            bail!("QEMU does not support qperf's plugin API v{PLUGIN_VERSION}");
+        }
+        // SAFETY: The target string is non-null, terminated, and owned by QEMU.
+        let target = unsafe { CStr::from_ptr(info.target_name) }.to_str()?;
+        let mut raw = Vec::new();
+        for index in 0..argc as usize {
+            // SAFETY: The loader supplies argc initialized pointers, checked above.
+            let arg = unsafe { *argv.add(index) };
+            if arg.is_null() {
+                bail!("null QEMU plugin argument");
+            }
+            // SAFETY: Each non-null argv entry is a live NUL-terminated string.
+            raw.push(unsafe { CStr::from_ptr(arg) }.to_str()?.to_owned());
+        }
+        let args = Args::parse(&raw)?;
+        let profiler = Arc::new(Profiler::start(&args, target)?);
+        eprintln!("QPerf loaded: target={target} plugin_api={PLUGIN_VERSION}");
+        let runtime = Box::into_raw(Box::new(Runtime {
+            profiler,
+            sites: Mutex::default(),
+        }))
+        .cast();
+        // SAFETY: Runtime has a stable allocation. Only on_exit reclaims it, once
+        // execution has stopped. All callbacks have the v7 userdata signatures.
+        // Registration is infallible; no failure path follows this publication.
+        unsafe {
+            ffi::qemu_plugin_register_vcpu_init_cb(id, on_vcpu_init, runtime);
+            ffi::qemu_plugin_register_vcpu_exit_cb(id, on_vcpu_exit, runtime);
+            ffi::qemu_plugin_register_vcpu_tb_trans_cb(id, on_translate, runtime);
+            ffi::qemu_plugin_register_flush_cb(id, on_flush, runtime);
+            ffi::qemu_plugin_register_atexit_cb(id, on_exit, runtime);
+        }
+        Ok::<(), anyhow::Error>(())
+    }));
+    match result {
+        Ok(Ok(())) => 0,
+        Ok(Err(error)) => {
+            eprintln!("qperf install failed: {error:#}");
+            -1
+        }
+        Err(_) => {
+            eprintln!("qperf install panicked");
+            -1
+        }
+    }
+}
+
+unsafe extern "C" fn on_vcpu_init(cpu: c_uint, userdata: *mut c_void) {
+    // SAFETY: Installation owns this Runtime until atexit, after vCPU callbacks.
+    let runtime = unsafe { &*userdata.cast::<Runtime>() };
+    if runtime.profiler.needs_registers() {
+        // SAFETY: QEMU invokes this on the initialized vCPU's own thread.
+        if let Err(error) = unsafe { reg::init(cpu) } {
+            eprintln!("qperf register initialization failed: {error:#}");
+            std::process::abort();
+        }
+    }
+}
+
+unsafe extern "C" fn on_vcpu_exit(cpu: c_uint, _userdata: *mut c_void) {
+    reg::clear(cpu);
+}
+
+unsafe extern "C" fn on_translate(tb: *mut ffi::TranslationBlock, userdata: *mut c_void) {
+    // SAFETY: Runtime remains owned until atexit. The TB and its instructions are
+    // valid only in this callback; none of their pointers escape it.
+    let runtime = unsafe { &*userdata.cast::<Runtime>() };
+    let profiler = &runtime.profiler;
+    let flags = if profiler.needs_registers() {
+        ffi::R_REGS
+    } else {
+        ffi::NO_REGS
+    };
+    let mut sites = runtime.sites.lock().expect("qperf site registry poisoned");
+    let mut add_site = |ip| {
+        let ip = profiler.sample_ip_for(ip)?;
+        let site = Arc::new(SampleSite {
+            profiler: profiler.clone(),
+            ip,
+        });
+        let ptr = Arc::as_ptr(&site).cast_mut().cast();
+        sites.push(site);
+        Some(ptr)
+    };
+    // SAFETY: QEMU supplies the live TB; indices are bounded by its instruction
+    // count. Sites are retained until flush/atexit, when QEMU stops execution.
+    unsafe {
+        if profiler.instruction_sampling() {
+            for index in 0..ffi::qemu_plugin_tb_n_insns(tb) {
+                let insn = ffi::qemu_plugin_tb_get_insn(tb, index);
+                if let Some(site) = add_site(ffi::qemu_plugin_insn_vaddr(insn)) {
+                    ffi::qemu_plugin_register_vcpu_insn_exec_cb(insn, on_execute, flags, site);
+                }
+            }
+        } else if let Some(site) = add_site(ffi::qemu_plugin_tb_vaddr(tb)) {
+            ffi::qemu_plugin_register_vcpu_tb_exec_cb(tb, on_execute, flags, site);
+        }
+    }
+}
+
+unsafe extern "C" fn on_execute(cpu: c_uint, userdata: *mut c_void) {
+    // SAFETY: This site belongs to an installed TB/insn. QEMU stops all execution
+    // before the flush callback releases the sites; atexit follows execution.
+    let site = unsafe { &*userdata.cast::<SampleSite>() };
+    // SAFETY: This runs on the current vCPU with R_REGS whenever FP is enabled.
+    if unsafe { site.profiler.sample(cpu, site.ip) }.is_err() {
+        site.profiler.record_failure();
+    }
+}
+
+unsafe extern "C" fn on_flush(userdata: *mut c_void) {
+    // SAFETY: QEMU guarantees all CPUs are stopped and old TBs cannot execute.
+    let runtime = unsafe { &*userdata.cast::<Runtime>() };
+    runtime
+        .sites
+        .lock()
+        .expect("qperf site registry poisoned")
+        .clear();
+}
+
+unsafe extern "C" fn on_exit(userdata: *mut c_void) {
+    // SAFETY: QEMU calls atexit exactly once after execution finishes. This takes
+    // back the sole Box transferred at installation; no callback may use it again.
+    let runtime = unsafe { Box::from_raw(userdata.cast::<Runtime>()) };
+    drop(runtime);
+    // Dropping the final Profiler Arc drains and waits for its writer via Shutdown.
+}

--- a/tools/qperf/src/qemu/ffi.rs
+++ b/tools/qperf/src/qemu/ffi.rs
@@ -1,0 +1,111 @@
+//! The subset of QEMU 11.1.1's plugin API v7 used by qperf.
+//!
+//! Source: https://github.com/qemu/qemu/blob/v11.1.1/include/plugins/qemu-plugin.h
+//! Keep callback signatures and the complete register descriptor layout in sync.
+
+use std::ffi::{c_char, c_int, c_uint, c_void};
+
+pub const API_VERSION: c_int = 7;
+pub const NO_REGS: c_uint = 0;
+pub const R_REGS: c_uint = 1;
+
+#[repr(C)]
+pub struct Info {
+    pub target_name: *const c_char,
+    pub version: Version,
+    pub system_emulation: bool,
+    pub mode: Mode,
+}
+
+#[repr(C)]
+pub struct Version {
+    pub min: c_int,
+    pub cur: c_int,
+}
+
+#[repr(C)]
+pub union Mode {
+    pub system: System,
+}
+
+// This union member is valid only when system_emulation is true.
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct System {
+    pub smp_vcpus: c_int,
+    pub max_vcpus: c_int,
+}
+
+#[repr(C)]
+pub struct TranslationBlock {
+    _opaque: [u8; 0],
+}
+
+#[repr(C)]
+pub struct Instruction {
+    _opaque: [u8; 0],
+}
+
+#[repr(C)]
+pub struct Register {
+    _opaque: [u8; 0],
+}
+
+#[repr(C)]
+pub struct RegisterDescriptor {
+    pub handle: *mut Register,
+    pub name: *const c_char,
+    pub feature: *const c_char,
+    pub is_readonly: bool,
+}
+
+#[repr(C)]
+pub struct GArray {
+    pub data: *mut c_char,
+    pub len: c_uint,
+}
+
+#[repr(C)]
+pub struct GByteArray {
+    pub data: *mut u8,
+    pub len: c_uint,
+}
+
+type VcpuCallback = unsafe extern "C" fn(c_uint, *mut c_void);
+type Callback = unsafe extern "C" fn(*mut c_void);
+type TranslateCallback = unsafe extern "C" fn(*mut TranslationBlock, *mut c_void);
+
+// QEMU and its GLib dependency resolve these symbols when loading the plugin.
+unsafe extern "C" {
+    pub fn qemu_plugin_register_vcpu_init_cb(id: u64, cb: VcpuCallback, userdata: *mut c_void);
+    pub fn qemu_plugin_register_vcpu_exit_cb(id: u64, cb: VcpuCallback, userdata: *mut c_void);
+    pub fn qemu_plugin_register_vcpu_tb_trans_cb(
+        id: u64,
+        cb: TranslateCallback,
+        userdata: *mut c_void,
+    );
+    pub fn qemu_plugin_register_flush_cb(id: u64, cb: Callback, userdata: *mut c_void);
+    pub fn qemu_plugin_register_atexit_cb(id: u64, cb: Callback, userdata: *mut c_void);
+    pub fn qemu_plugin_register_vcpu_tb_exec_cb(
+        tb: *mut TranslationBlock,
+        cb: VcpuCallback,
+        flags: c_uint,
+        userdata: *mut c_void,
+    );
+    pub fn qemu_plugin_register_vcpu_insn_exec_cb(
+        insn: *mut Instruction,
+        cb: VcpuCallback,
+        flags: c_uint,
+        userdata: *mut c_void,
+    );
+    pub fn qemu_plugin_tb_vaddr(tb: *const TranslationBlock) -> u64;
+    pub fn qemu_plugin_tb_n_insns(tb: *const TranslationBlock) -> usize;
+    pub fn qemu_plugin_tb_get_insn(tb: *const TranslationBlock, index: usize) -> *mut Instruction;
+    pub fn qemu_plugin_insn_vaddr(insn: *const Instruction) -> u64;
+    pub fn qemu_plugin_get_registers() -> *mut GArray;
+    pub fn qemu_plugin_read_register(register: *mut Register, output: *mut GByteArray) -> bool;
+    pub fn qemu_plugin_read_memory_vaddr(addr: u64, output: *mut GByteArray, len: usize) -> bool;
+    pub fn g_array_free(array: *mut GArray, free_segment: c_int) -> *mut c_char;
+    pub fn g_byte_array_new() -> *mut GByteArray;
+    pub fn g_byte_array_free(array: *mut GByteArray, free_segment: c_int) -> *mut u8;
+}

--- a/tools/qperf/src/reg.rs
+++ b/tools/qperf/src/reg.rs
@@ -1,32 +1,128 @@
-use std::collections::BTreeMap;
+use std::{cell::RefCell, collections::BTreeMap, ffi::CStr, ptr::NonNull};
 
-use anyhow::{Context, anyhow};
-use qemu_plugin::RegisterDescriptor;
+use anyhow::{Context, bail};
 
-#[derive(Default)]
-pub struct AllRegs(BTreeMap<String, RegisterDescriptor<'static>>);
+use crate::qemu::ffi;
 
-impl AllRegs {
-    pub fn read(&self, name: &str) -> anyhow::Result<u64> {
-        let value = self
-            .0
+type RegisterMap = BTreeMap<String, *mut ffi::Register>;
+
+thread_local! {
+    // QEMU register handles belong to the vCPU context that enumerated them.
+    // A single-threaded TCG executor may host more than one vCPU.
+    static REGISTERS: RefCell<BTreeMap<u32, RegisterMap>> = const {
+        RefCell::new(BTreeMap::new())
+    };
+}
+
+/// # Safety
+/// Call only from QEMU's vCPU initialization callback on that vCPU's thread.
+pub unsafe fn init(cpu: u32) -> anyhow::Result<()> {
+    clear(cpu);
+    // SAFETY: We are in vCPU init. QEMU returns an owned GArray of complete v7
+    // descriptors; their names and handles remain owned by QEMU.
+    let array = unsafe { ffi::qemu_plugin_get_registers() };
+    let array = NonNull::new(array).context("QEMU returned a null register array")?;
+    let result = (|| {
+        // SAFETY: The owned GArray is live until g_array_free below.
+        let array = unsafe { array.as_ref() };
+        let mut registers = BTreeMap::new();
+        for index in 0..array.len as usize {
+            // SAFETY: QEMU allocated len descriptors with their full v7 stride,
+            // including is_readonly. Each index is in bounds and aligned.
+            let descriptor = unsafe { &*array.data.cast::<ffi::RegisterDescriptor>().add(index) };
+            if descriptor.name.is_null() {
+                bail!("QEMU returned a null register name");
+            }
+            // SAFETY: QEMU's descriptor names are live NUL-terminated strings.
+            let name = unsafe { CStr::from_ptr(descriptor.name) }
+                .to_str()?
+                .to_owned();
+            // QEMU encodes a register number in this opaque handle; zero is a
+            // valid handle, not a null allocation. It is never dereferenced here.
+            registers.insert(name, descriptor.handle);
+        }
+        REGISTERS.with(|current| current.borrow_mut().insert(cpu, registers));
+        Ok(())
+    })();
+    // SAFETY: The caller owns this array. Names were copied, handles are borrowed
+    // from QEMU, and neither points into the array allocation being freed.
+    unsafe { ffi::g_array_free(array.as_ptr(), 1) };
+    result
+}
+
+pub fn clear(cpu: u32) {
+    REGISTERS.with(|registers| registers.borrow_mut().remove(&cpu));
+}
+
+/// # Safety
+/// Call on the initialized vCPU thread inside an execution callback with R_REGS.
+pub unsafe fn read(cpu: u32, name: &str) -> anyhow::Result<u64> {
+    REGISTERS.with(|registers| {
+        let registers = registers.borrow();
+        let registers = registers
+            .get(&cpu)
+            .context("vCPU registers not initialized")?;
+        let handle = registers
             .get(name)
-            .context(format!("Register {name} not found"))?
-            .read()?;
+            .with_context(|| format!("register {name} not found"))?;
+        let output = ByteArray::new()?;
+        // SAFETY: The handle belongs to this vCPU and the callback has requested
+        // R_REGS. GLib owns the resizable output buffer until its guard is dropped.
+        if !unsafe { ffi::qemu_plugin_read_register(*handle, output.0.as_ptr()) } {
+            bail!("failed to read register {name}");
+        }
+        let mut bytes = [0; 8];
+        output.copy_to(&mut bytes)?;
+        Ok(u64::from_le_bytes(bytes))
+    })
+}
 
-        value
-            .try_into()
-            .map(u64::from_le_bytes)
-            .map_err(|v| anyhow!("Unexpected size for register {name}: {}", v.len()))
+/// # Safety
+/// Call only from QEMU's current-vCPU execution callback, never from the writer.
+pub unsafe fn read_memory(addr: u64, output: &mut [u8]) -> anyhow::Result<()> {
+    if output.is_empty() {
+        return Ok(());
+    }
+    let buffer = ByteArray::new()?;
+    // SAFETY: This is the current vCPU context. QEMU validates guest addresses;
+    // the positive length and GLib-owned buffer satisfy its allocation contract.
+    if !unsafe { ffi::qemu_plugin_read_memory_vaddr(addr, buffer.0.as_ptr(), output.len()) } {
+        bail!("failed to read guest memory at {addr:#x}");
+    }
+    buffer.copy_to(output)
+}
+
+struct ByteArray(NonNull<ffi::GByteArray>);
+
+impl ByteArray {
+    fn new() -> anyhow::Result<Self> {
+        // SAFETY: GLib initialization is provided by the QEMU process. Ownership
+        // of the fresh array transfers to this guard, including on read failure.
+        NonNull::new(unsafe { ffi::g_byte_array_new() })
+            .map(Self)
+            .context("failed to allocate a GLib byte array")
+    }
+
+    fn copy_to(&self, output: &mut [u8]) -> anyhow::Result<()> {
+        // SAFETY: This guard uniquely owns the live GLib array.
+        let array = unsafe { self.0.as_ref() };
+        if array.len as usize != output.len() || array.data.is_null() {
+            bail!(
+                "QEMU returned {} bytes, expected {}",
+                array.len,
+                output.len()
+            );
+        }
+        // SAFETY: A successful QEMU read initialized the exact checked length.
+        // The GLib allocation and caller's slice are disjoint and remain live.
+        unsafe { std::ptr::copy_nonoverlapping(array.data, output.as_mut_ptr(), output.len()) };
+        Ok(())
     }
 }
 
-impl From<Vec<RegisterDescriptor<'static>>> for AllRegs {
-    fn from(regs: Vec<RegisterDescriptor<'static>>) -> Self {
-        let map = regs
-            .into_iter()
-            .map(|reg| (reg.name.clone(), reg))
-            .collect();
-        AllRegs(map)
+impl Drop for ByteArray {
+    fn drop(&mut self) {
+        // SAFETY: The guard owns this array and its segment; no references escape.
+        unsafe { ffi::g_byte_array_free(self.0.as_ptr(), 1) };
     }
 }

--- a/tools/qperf/tests/prebuild.py
+++ b/tools/qperf/tests/prebuild.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Exercise the local qperf entrypoint without downloading a harness checkout."""
+
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[3]
+PREBUILD = ROOT / "apps/qperf/prebuild.sh"
+
+
+class PrebuildTests(unittest.TestCase):
+    def run_prebuild(self, *args):
+        with tempfile.TemporaryDirectory(prefix="qperf-entrypoint-") as directory:
+            env = os.environ.copy()
+            # An external checkout must neither be validated nor fetched.
+            env["TGOSKIT_HARNESS_KIT_DIR"] = str(Path(directory) / "absent")
+            return subprocess.run(
+                [str(PREBUILD), *args], cwd=directory, env=env,
+                capture_output=True, text=True, timeout=10,
+            )
+
+    def test_prints_local_root_from_another_directory(self):
+        result = self.run_prebuild()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, str(ROOT) + "\n")
+
+    def test_runs_relative_commands_at_local_root(self):
+        result = self.run_prebuild(
+            "sh", "-c", 'test -f tools/qperf/Cargo.toml && printf "%s" "$1"',
+            "qperf-test", "argument with spaces",
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, "argument with spaces")
+
+    def test_propagates_command_failure(self):
+        result = self.run_prebuild("sh", "-c", "exit 23")
+        self.assertEqual(result.returncode, 23, result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/qperf/tests/qemu_load.py
+++ b/tools/qperf/tests/qemu_load.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Check the real plugin ABI and orderly shutdown without booting a guest."""
+
+import argparse
+import json
+from pathlib import Path
+import subprocess
+import tempfile
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("plugin", type=Path)
+    parser.add_argument("--qemu", default="qemu-system-x86_64")
+    args = parser.parse_args()
+    plugin = args.plugin.resolve(strict=True)
+    version = subprocess.check_output([args.qemu, "--version"], text=True)
+    if version.splitlines()[0] != "QEMU emulator version 11.1.1":
+        raise RuntimeError(f"expected QEMU 11.1.1, got {version.splitlines()[0]}")
+
+    with tempfile.TemporaryDirectory(prefix="qperf-load-") as directory:
+        for mode, callchain in [("tb", "leaf"), ("insn", "fp")]:
+            raw = Path(directory) / f"{mode}-{callchain}.bin"
+            command = [
+                args.qemu, "-machine", "q35", "-accel", "tcg", "-S",
+                "-nodefaults", "-display", "none", "-monitor", "none",
+                "-qmp", "stdio", "-plugin",
+                f"{plugin},out={raw},mode={mode},callchain={callchain}",
+            ]
+            requests = "".join(json.dumps(request) + "\n" for request in [
+                {"execute": "qmp_capabilities", "id": "capabilities"},
+                {"execute": "quit", "id": "quit"},
+            ])
+            result = subprocess.run(
+                command, input=requests, capture_output=True, text=True, timeout=30
+            )
+            if result.returncode != 0:
+                raise RuntimeError(f"QEMU exited {result.returncode}:\n{result.stderr}")
+            replies = [json.loads(line) for line in result.stdout.splitlines()]
+            if not any(reply.get("id") == "quit" and "return" in reply for reply in replies):
+                raise RuntimeError(f"QMP quit was not acknowledged: {result.stdout}")
+            summary = dict(
+                line.split(" = ", 1)
+                for line in raw.with_suffix(".summary.txt").read_text().splitlines()
+            )
+            if not raw.is_file() or summary["sample_failures"] != "0":
+                raise RuntimeError(f"plugin output/shutdown failed: {summary}")
+            if summary["callchain_method"] != callchain:
+                raise RuntimeError(f"plugin arguments were not applied: {summary}")
+            print(f"PASS: QEMU 11.1.1 loads and closes qperf ({mode}/{callchain})")
+
+        for argument in ["freq=0", "mode=invalid", "callchain=invalid", "max_depth=0"]:
+            raw = Path(directory) / "rejected.bin"
+            result = subprocess.run([
+                args.qemu, "-machine", "q35", "-accel", "tcg", "-S",
+                "-nodefaults", "-display", "none", "-monitor", "none",
+                "-plugin", f"{plugin},out={raw},{argument}",
+            ], capture_output=True, text=True, timeout=30)
+            if result.returncode <= 0 or "qperf install failed:" not in result.stderr:
+                raise RuntimeError(f"invalid argument was not cleanly rejected: {result.stderr}")
+            if raw.exists():
+                raise RuntimeError("invalid arguments created a sample file")
+            print(f"PASS: rejects {argument} before publishing callbacks")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/qperf/tests/qemu_sample.py
+++ b/tools/qperf/tests/qemu_sample.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Exercise sampling, register reads and unwinding in real QEMU Linux user mode."""
+
+import argparse
+from pathlib import Path
+import subprocess
+import tempfile
+
+
+def run(command):
+    result = subprocess.run(command, capture_output=True, text=True, timeout=60)
+    if result.returncode != 0:
+        raise RuntimeError(f"{command} exited {result.returncode}:\n{result.stderr}")
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("plugin", type=Path)
+    parser.add_argument("analyzer", type=Path)
+    args = parser.parse_args()
+    plugin = args.plugin.resolve(strict=True)
+    analyzer = args.analyzer.resolve(strict=True)
+    with tempfile.TemporaryDirectory(prefix="qperf-sampling-") as directory:
+        root = Path(directory)
+        workload = root / "workload"
+        run([
+            "cc", "-static", "-no-pie", "-O1", "-g", "-fno-omit-frame-pointer",
+            "-fno-optimize-sibling-calls", "-pthread",
+            str(Path(__file__).with_name("workload.c")), "-o", str(workload),
+        ])
+        for mode in ["tb", "insn"]:
+            for callchain in ["leaf", "fp"]:
+                raw = root / f"{mode}-{callchain}.bin"
+                result = run([
+                    "qemu-x86_64", "-tb-size", "1", "-plugin",
+                    f"{plugin},out={raw},freq=1000,mode={mode},callchain={callchain}",
+                    str(workload),
+                ])
+                if "QPERF_WORKLOAD_DONE" not in result.stdout:
+                    raise RuntimeError("guest workload did not complete")
+                summary = dict(
+                    line.split(" = ", 1)
+                    for line in raw.with_suffix(".summary.txt").read_text().splitlines()
+                )
+                if int(summary["samples"]) == 0 or int(summary["sample_failures"]) != 0:
+                    raise RuntimeError(f"sampling failed: {summary}")
+                if int(summary["dropped_samples"]) != 0:
+                    raise RuntimeError(f"sampling lost records: {summary}")
+                folded = raw.with_suffix(".folded")
+                run([str(analyzer), "--elf", str(workload), str(raw), str(folded)])
+                stacks = [line for line in folded.read_text().splitlines() if "workload_leaf" in line]
+                if not stacks:
+                    raise RuntimeError("no samples resolve to the actual guest workload")
+                if callchain == "fp" and not any("workload_thread" in stack for stack in stacks):
+                    raise RuntimeError("FP unwinding did not recover the workload caller")
+                print(f"PASS: {mode}/{callchain}: {summary['samples']} samples, guest symbols resolved")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/qperf/tests/reg.rs
+++ b/tools/qperf/tests/reg.rs
@@ -1,7 +1,25 @@
 #[path = "../src/target.rs"]
 mod target;
 
+#[path = "../src/qemu/ffi.rs"]
+pub mod ffi;
+
 use target::{Frame, Reg, Target};
+
+#[test]
+fn qemu_v7_register_descriptor_includes_readonly_flag() {
+    use std::mem::{offset_of, size_of};
+
+    // C ABI: three pointers followed by a bool and trailing pointer alignment.
+    let pointer = size_of::<*mut ()>();
+    assert_eq!(offset_of!(ffi::RegisterDescriptor, name), pointer);
+    assert_eq!(offset_of!(ffi::RegisterDescriptor, feature), 2 * pointer);
+    assert_eq!(
+        offset_of!(ffi::RegisterDescriptor, is_readonly),
+        3 * pointer
+    );
+    assert_eq!(size_of::<ffi::RegisterDescriptor>(), 4 * pointer);
+}
 
 #[test]
 fn parses_qemu_x86_64_target() {

--- a/tools/qperf/tests/workload.c
+++ b/tools/qperf/tests/workload.c
@@ -1,0 +1,33 @@
+#include <pthread.h>
+#include <stdint.h>
+#include <stdio.h>
+
+__attribute__((noinline)) static uintptr_t workload_leaf(void)
+{
+    volatile uintptr_t value = 1;
+    for (unsigned int i = 0; i < 2000000; ++i) {
+        value = value * 33 + i;
+    }
+    return value;
+}
+
+__attribute__((noinline)) static void *workload_thread(void *unused)
+{
+    (void)unused;
+    return (void *)workload_leaf();
+}
+
+int main(void)
+{
+    pthread_t thread;
+    void *result;
+    if (pthread_create(&thread, NULL, workload_thread, NULL) != 0) {
+        return 1;
+    }
+    void *expected = workload_thread(NULL);
+    if (pthread_join(thread, &result) != 0 || result != expected) {
+        return 2;
+    }
+    puts("QPERF_WORKLOAD_DONE");
+    return 0;
+}


### PR DESCRIPTION
## 问题

仓库内 qperf 使用插件 API v5，外部包装入口还会取得另一份旧源码。QEMU 11.1.1 最低要求 API **v7**，真实加载回归报告：

```text
plugin requires API version 5, but this QEMU supports only a minimum version of 7
```

最初考虑的 `qemu-rs` v6 提交也不满足该版本要求。本 PR 改为维护 qperf 实际使用的最小 v7 绑定，不通过仅修改导出版本号冒充兼容，也不保留旧 API 构建分支。

## 改动及依据

- 按 [QEMU v11.1.1 头文件](https://github.com/qemu/qemu/blob/v11.1.1/include/plugins/qemu-plugin.h) 适配回调的 `userdata`、寄存器读取的 `bool` 返回值及包含 `is_readonly` 的完整描述符布局；移除不支持 v7 的 `qemu-plugin` 依赖。用本机头文件生成 bindgen 参考输出，对照核验实际声明。
- `Runtime` 保管稳定分配的采样点；执行回调只借用它们，flush 停止旧翻译块执行后再释放，atexit 取回实例并等待写线程完成样本和统计输出。寄存器按线程及 vCPU 编号隔离，GLib 缓冲区在成功和失败路径均释放；零值寄存器句柄仍有效。
- `apps/qperf/prebuild.sh` 和 `cargo xtask starry perf` 统一使用本仓库 `tools/qperf`。外部 harness kit 只保留在原有报告后处理和 OScope 流程中，不修改其仓库或固定提交。
- 修复验证时发现的 LoongArch 启动链路：该架构当前默认内核是 UEFI PE 镜像，不能通过 `-kernel` 直接启动。按已有 `uefi`/`to_bin` 配置复用公共 OVMF 缓存、独立 VARS 副本和架构对应 ESP 文件名，与 x86_64 共用准备逻辑。
- 新增真实 QEMU 加载、参数失败传播、双线程采样和 FP 解栈回归，接入 Workspace 的 `test-qperf` 容器检查。更新入口说明、API 所有权设计及平台调试参考。原始样本格式仍为 v3，分析器和报告输入不变。

详细边界及回收依据见 `tools/qperf/ABI.md`。

## 回归与本地验证

已变基到 `origin/dev` 的 `08c9f191312eb9a32369d259cb1d6c45c430800f`。

- 加载回归：旧 v5 插件确定性失败；新插件 TB/leaf、insn/FP 加载和 QMP 退出通过，4 个非法参数场景均以非零状态拒绝。
- 入口回归：修改前 3 项失败，修改后 3 项通过，覆盖异目录执行、外部 checkout 隔离、参数和退出码传播。
- LoongArch 回归：`loongarch_uefi_rejects_unconverted_kernel_before_boot` 在旧实现失败，修复后同一测试通过；ESP 测试验证架构文件名和私有 VARS。
- `cargo fmt --all -- --check`：通过。
- `cargo xtask clippy --package axbuild --package qperf`：2/2 通过。
- `cargo xtask test --since origin/dev`：918 个 axbuild 测试通过。
- `cargo xtask sync-lint --since origin/dev`：通过。
- `cargo publish --workspace --dry-run --no-verify`：干净提交上通过，没有实际发布。
- `python3 scripts/test/check_ci_routing.py`：通过；使用 Python 3.12 执行 CI planner/impact 等测试，68 项通过。
- qperf 的 Rust 目标/ABI 测试 2 项通过；真实 `qemu-x86_64` 双线程 C 工作负载的 TB/insn × leaf/FP 四种组合全部通过，FP 栈恢复 `workload_leaf` 的调用者。

项目没有独立的 qperf 构建/测试 xtask 子命令，因此插件本身沿用 `apps/qperf/prebuild.sh cargo ...` 入口；所有 StarryOS 构建和采样均通过 `cargo xtask starry perf`。

## 端到端采样

正式验收使用 QEMU 11.1.1 和默认 TCG 缓存。六个用例均观察到 `QPERF_BOOT_DONE`，通过 `qmp_quit` 退出，未发生超时截断；原始样本、非空 folded 栈和报告均已生成，`bad_records`、`dropped_samples`、`sample_failures` 均为零，且存在多层 FP 栈。

| 架构 | 模式 | 样本数 |
| --- | --- | ---: |
| x86_64 | TB / FP | 1177 |
| riscv64 | TB / FP | 1354 |
| loongarch64 | TB / FP | 830 |
| x86_64 | insn / FP | 3459 |
| riscv64 | insn / FP | 4911 |
| loongarch64 | insn / FP | 3036 |

对应命令形态：

```bash
cargo xtask starry perf --arch <ARCH> --smp 2 \
  --kernel-filter --format folded --mode <tb|insn> --perf-callchain fp \
  --shell-init-cmd 'echo QPERF_BOOT_DONE' --stop-marker QPERF_BOOT_DONE \
  --timeout 90 --no-host-time --output-dir <独立输出目录>
```

这些样本仅用于证明采样链路，不是硬件性能对比。

## 剩余边界

- 额外把 x86_64 双核 insn/FP 的 TCG 缓存限制为 1 MiB 时，内核出现 `failed to determine root device from available block devices` panic。工具仍保留 panic 前样本并生成报告，因此该压力运行**不记为通过**；相同双核采样在默认缓存下已通过。没有为掩盖这一压力失败修改内核、放宽用例断言或添加无限重试。
- macOS 保留动态符号解析构建支持，但本次运行证据来自 Linux 宿主；未执行实体板卡测试。
- 新增 FFI 和回调回收边界需要领域审查后合入；运行通过不能替代安全性审查。
