### PR TITLE
fix(rsext4): retain recovery state after writable journal replay

### DIFF
--- a/fs/rsext4/src/ext4/mount.rs
+++ b/fs/rsext4/src/ext4/mount.rs
@@ -649,7 +649,11 @@ impl Ext4FileSystem {
                             &recovered_journal_blocks,
                         )?;
                         fs.clear_recovery_state();
-                    } else if !options.readonly && block_dev.is_use_journal() {
+                    }
+                    // Replay finishes the previous mount's recovery. A writable
+                    // journal owner must advertise recovery again before it can
+                    // commit new transactions, including on this replay path.
+                    if !options.readonly && block_dev.is_use_journal() {
                         fs.set_recovery_state();
                     }
                 }

--- a/fs/rsext4/tests/crc_integrity.rs
+++ b/fs/rsext4/tests/crc_integrity.rs
@@ -892,7 +892,7 @@ fn uncommitted_journal_tail_is_discarded_during_recovery() {
         .expect("mount should discard uncommitted journal tail");
     assert_eq!(
         fs.superblock.s_feature_incompat & Ext4Superblock::EXT4_FEATURE_INCOMPAT_RECOVER,
-        0
+        Ext4Superblock::EXT4_FEATURE_INCOMPAT_RECOVER
     );
     umount(fs, &mut remount_dev).expect("umount failed");
 
@@ -936,7 +936,7 @@ fn uncommitted_journal_tail_does_not_read_payload_blocks() {
         Ext4FileSystem::mount(&mut remount_dev).expect("uncommitted payload should not be read");
     assert_eq!(
         fs.superblock.s_feature_incompat & Ext4Superblock::EXT4_FEATURE_INCOMPAT_RECOVER,
-        0
+        Ext4Superblock::EXT4_FEATURE_INCOMPAT_RECOVER
     );
     umount(fs, &mut remount_dev).expect("umount failed");
 }
@@ -1080,7 +1080,7 @@ fn empty_descriptor_header_is_discarded_during_recovery() {
         .expect("mount should discard empty descriptor tail");
     assert_eq!(
         fs.superblock.s_feature_incompat & Ext4Superblock::EXT4_FEATURE_INCOMPAT_RECOVER,
-        0
+        Ext4Superblock::EXT4_FEATURE_INCOMPAT_RECOVER
     );
     umount(fs, &mut remount_dev).expect("umount failed");
 }

--- a/fs/rsext4/tests/linux_image_repro.rs
+++ b/fs/rsext4/tests/linux_image_repro.rs
@@ -2624,8 +2624,32 @@ fn replay_checksum_journal_from_debugfs(checksum_version: u8) {
     {
         let dev = FileBlockDevice::open(image.clone());
         let mut dev = Jbd2Dev::initial_jbd2dev(0, dev, true);
-        let fs =
+        let mut fs =
             Ext4FileSystem::mount(&mut dev).expect("mount image with pending checksummed journal");
+        let mounted_header = dumpe2fs_header(&image, "writable mount after journal replay");
+        assert!(
+            mounted_header.contains("needs_recovery"),
+            "writable replay must persist needs_recovery before returning\n{mounted_header}"
+        );
+
+        mkdir(&mut dev, &mut fs, "/after-replay").expect("write after journal replay");
+        fs.sync_filesystem(&mut dev).expect("sync post-replay metadata");
+        // Snapshot only persisted bytes, without clean unmount or checkpointing.
+        // Linux must recover the new transaction without interactive repair.
+        let crash_image = temp_dir.join("after-replay-crash.img");
+        std::fs::copy(&image, &crash_image).expect("snapshot synced writable mount");
+        let output = Command::new("e2fsck")
+            .arg("-p")
+            .arg(&crash_image)
+            .output()
+            .expect("automatically recover post-replay snapshot");
+        assert!(
+            e2fsck_status_ok(&output, true),
+            "post-replay sync must allow automatic recovery\n{}",
+            command_text(&output)
+        );
+        assert_debugfs_path_exists(&crash_image, "/after-replay");
+        e2fsck_readonly_clean(&crash_image, "post-replay crash recovery");
         umount(fs, &mut dev).expect("umount image after replay");
     }
 

--- a/fs/rsext4/tests/linux_image_repro.rs
+++ b/fs/rsext4/tests/linux_image_repro.rs
@@ -2633,7 +2633,8 @@ fn replay_checksum_journal_from_debugfs(checksum_version: u8) {
         );
 
         mkdir(&mut dev, &mut fs, "/after-replay").expect("write after journal replay");
-        fs.sync_filesystem(&mut dev).expect("sync post-replay metadata");
+        fs.sync_filesystem(&mut dev)
+            .expect("sync post-replay metadata");
         // Snapshot only persisted bytes, without clean unmount or checkpointing.
         // Linux must recover the new transaction without interactive repair.
         let crash_image = temp_dir.join("after-replay-crash.img");


### PR DESCRIPTION
## 问题与修复

PR #1775 的 OrangePi 验证发现：Starry 运行后重启 Linux，e2fsck 报告 `Superblock needs_recovery flag is clear, but journal has data`，需要手工恢复。当前 `dev` 的 rsext4 在日志重放成功后清除 recovery 标志，而重新设置该标志位于 `else if` 分支，导致本次可写挂载继续提交日志时，磁盘超级块仍未声明需要恢复。

本 PR 基于 `dev@20fdd580b53930dfa5db95703013c9511ed62f5b` 独立修复该问题：将可写 journal 挂载的状态设置改为重放后的独立检查，保证挂载返回前持久化 recovery 标志。只读和禁用 journal 的路径继续遵循各自原有契约，正常卸载仍清除 recovery 标志。

## 回归与验证

- 纠正三个已有 journal tail 测试的可写挂载断言；旧实现均以实际值 `0`、期望值 `4` 失败，修复后全部通过。
- 扩展两个已有 Linux 镜像测试，覆盖 compat checksum 和 csum v3：检查可写重放后的磁盘标志，再创建目录、sync、复制未卸载的磁盘快照，由 `e2fsck -p` 自动恢复并核验目录和文件系统一致性。旧实现两项均在磁盘 recovery 标志检查处失败，修复后通过。
- `cargo xtask test --since origin/dev`：受影响的 8 个软件包全部通过。
- `cargo xtask clippy --package rsext4`：3/3 通过。
- `cargo xtask starry test qemu --arch x86_64 -c qemu/syscall-test-sync`：实际选中并执行 `SYS_sync` 用例，1/1 通过；该用例验证运行时同步入口，不替代上述崩溃恢复测试。
- `cargo fmt --all -- --check`、`git diff --check`、`cargo xtask sync-lint --since origin/dev`：通过。
- `cargo publish --workspace --dry-run --no-verify`：本地运行中，尚未取得终态。

## 验证边界

本次没有实体板卡复验。PR #1775 后续另一次板卡会话中断后出现同样的 fsck 表象，其最后挂载者和持久化过程尚未确认，因此本 PR 只声明修复已确定的可写重放状态错误，不声明所有板卡恢复路径均已闭环。
