### PR TITLE
fix(net): prevent Wi-Fi transmit and receive starvation

### DIFF
--- a/drivers/net/aic8800/src/rdif/owner/progress.rs
+++ b/drivers/net/aic8800/src/rdif/owner/progress.rs
@@ -43,6 +43,28 @@ enum CardIrqWait {
     Armed,
 }
 
+impl CardIrqWait {
+    fn complete_event(
+        &mut self,
+        transmit_completed: bool,
+        output_blocked: bool,
+    ) -> Option<OwnerProgress> {
+        if transmit_completed {
+            // A busy TX queue must not keep CARD_INT masked across successive
+            // SDIO writes. Return to the owner rearm boundary after publishing
+            // each completion so pending RX is sampled before the next TX.
+            *self = Self::Armed;
+        }
+        if output_blocked {
+            Some(OwnerProgress::Wait(OwnerWait::Interrupt))
+        } else if transmit_completed {
+            Some(OwnerProgress::Ready)
+        } else {
+            None
+        }
+    }
+}
+
 /// Sole task-context owner of the SDIO card, controller transactions and AIC core.
 pub(crate) struct AicOwner<H: CompletionIrqRearmHost + 'static> {
     card: SdioCard<H>,
@@ -363,10 +385,11 @@ impl<H: CompletionIrqRearmHost + Send + 'static> AicOwner<H> {
                     return Ok(Some(OwnerProgress::Ready));
                 }
                 AicAction::Event(event) => {
-                    if self.outputs.consume_event(event)? {
-                        return Ok(Some(OwnerProgress::Wait(OwnerWait::Interrupt)));
-                    }
-                    return Ok(None);
+                    let transmit_completed = matches!(event, AicEvent::TransmitComplete(_));
+                    let output_blocked = self.outputs.consume_event(event)?;
+                    return Ok(self
+                        .card_irq_wait
+                        .complete_event(transmit_completed, output_blocked));
                 }
                 AicAction::Idle => {
                     let ready = self.device()?.state() == AicState::Ready;
@@ -549,6 +572,31 @@ mod tests {
     use alloc::string::ToString;
 
     use super::*;
+
+    #[test]
+    fn transmit_completion_yields_to_card_irq_before_next_sdio_submission() {
+        for output_blocked in [false, true] {
+            let mut wait = CardIrqWait::Masked;
+            let progress = wait.complete_event(true, output_blocked);
+
+            assert!(
+                progress.is_some(),
+                "a completed TX must return to the rearm boundary before dequeuing more TX"
+            );
+            assert!(card_irq_rearm_allowed(true, false, wait));
+            assert!(!card_irq_rearm_allowed(true, true, wait));
+            assert!(!card_irq_rearm_allowed(false, false, wait));
+        }
+
+        let mut wait = CardIrqWait::Masked;
+        assert_eq!(wait.complete_event(false, false), None);
+        assert_eq!(wait, CardIrqWait::Masked);
+        assert_eq!(
+            wait.complete_event(false, true),
+            Some(OwnerProgress::Wait(OwnerWait::Interrupt))
+        );
+        assert_eq!(wait, CardIrqWait::Masked);
+    }
 
     #[test]
     fn card_interrupt_stays_masked_until_sdio_enumeration_completes() {

--- a/net/ax-net/src/lib.rs
+++ b/net/ax-net/src/lib.rs
@@ -99,7 +99,7 @@ use self::{
     addr::mask_from_prefix,
     device::{EthernetDevice, LoopbackDevice},
     listen_table::ListenTable,
-    poll_runtime::ProtocolPollRuntime,
+    poll_runtime::{ProtocolPollBudget, ProtocolPollRuntime},
     router::{RouteTable, Router, Rule, SharedRouteTable},
     service::{NetControl, NetInterface, Service},
     wrapper::SocketSetWrapper,
@@ -635,9 +635,17 @@ pub fn init_vsock(mut vsock_devs: device::VsockDeviceList) {
     }
 }
 
-fn poll_protocol_until_idle() {
+fn poll_protocol_until_idle(budget: &mut ProtocolPollBudget) {
     loop {
-        if !get_service().poll(&mut SOCKET_SET.inner.lock()) {
+        let more = get_service().poll(&mut SOCKET_SET.inner.lock());
+        if budget.consume(ax_hal::time::monotonic_time_nanos()) {
+            // Device owners share this CPU with the protocol executor. Deliver
+            // readiness and release CPU ownership with all network locks dropped.
+            drain_deferred_poll_wakes();
+            ax_task::yield_now();
+            budget.reset(ax_hal::time::monotonic_time_nanos());
+        }
+        if !more {
             return;
         }
     }
@@ -799,6 +807,7 @@ fn start_protocol_executor(owner_cpu: usize) {
 }
 
 fn protocol_executor_main() {
+    let mut budget = ProtocolPollBudget::new(ax_hal::time::monotonic_time_nanos());
     loop {
         if let Some(delay) = next_poll_delay() {
             let _ = PROTOCOL_POLL.wait_timeout(delay);
@@ -807,7 +816,7 @@ fn protocol_executor_main() {
         }
         drain_deferred_poll_wakes();
         let completed = PROTOCOL_POLL.requested_generation();
-        poll_protocol_until_idle();
+        poll_protocol_until_idle(&mut budget);
         PROTOCOL_POLL.complete(completed);
         drain_deferred_poll_wakes();
         if PROTOCOL_POLL.finish_cycle(|| DEFERRED_POLL_WAKE_PENDING.load(Ordering::Acquire)) {

--- a/net/ax-net/src/poll_runtime.rs
+++ b/net/ax-net/src/poll_runtime.rs
@@ -7,6 +7,35 @@ use core::{
 
 use ax_task::WaitQueue;
 
+/// Bounds consecutive protocol polls across immediately runnable generations.
+/// The limits follow Linux's softirq restart/time budget; neither a pending
+/// socket nor an expired soft deadline grants unbounded CPU ownership.
+pub(super) struct ProtocolPollBudget {
+    remaining: usize,
+    deadline_nanos: u64,
+}
+
+impl ProtocolPollBudget {
+    const MAX_POLLS: usize = 10;
+    const MAX_NANOS: u64 = 2_000_000;
+
+    pub(super) fn new(now_nanos: u64) -> Self {
+        Self {
+            remaining: Self::MAX_POLLS,
+            deadline_nanos: now_nanos.saturating_add(Self::MAX_NANOS),
+        }
+    }
+
+    pub(super) fn consume(&mut self, now_nanos: u64) -> bool {
+        self.remaining = self.remaining.saturating_sub(1);
+        self.remaining == 0 || now_nanos >= self.deadline_nanos
+    }
+
+    pub(super) fn reset(&mut self, now_nanos: u64) {
+        *self = Self::new(now_nanos);
+    }
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) struct PollGeneration(u64);
 
@@ -95,6 +124,27 @@ impl ProtocolPollRuntime {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn immediate_protocol_work_yields_within_a_bounded_number_of_polls() {
+        let mut budget = ProtocolPollBudget::new(0);
+        for poll in 1..ProtocolPollBudget::MAX_POLLS {
+            assert!(!budget.consume(0), "yielded before poll budget at {poll}");
+        }
+        assert!(
+            budget.consume(0),
+            "immediate work monopolizes the owner CPU"
+        );
+        budget.reset(7);
+        assert!(!budget.consume(7));
+    }
+
+    #[test]
+    fn expensive_protocol_work_yields_at_the_time_budget() {
+        let mut budget = ProtocolPollBudget::new(19);
+        assert!(!budget.consume(19 + ProtocolPollBudget::MAX_NANOS - 1));
+        assert!(budget.consume(19 + ProtocolPollBudget::MAX_NANOS));
+    }
 
     #[test]
     fn synchronous_flush_never_takes_protocol_ownership() {

--- a/scripts/axbuild/src/starry/test/tests.rs
+++ b/scripts/axbuild/src/starry/test/tests.rs
@@ -258,7 +258,7 @@ fn write_test_image_config(workspace_root: &Path) {
 
 #[cfg(unix)]
 #[test]
-fn aka_wifi_smoke_runs_one_connectivity_transfer() {
+fn aka_wifi_smoke_requires_sustained_progress_and_propagates_iperf_failure() {
     let fake_bin = tempdir().unwrap();
     let invocation_log = fake_bin.path().join("iperf3-invocations");
     let ip = fake_bin.path().join("ip");
@@ -267,7 +267,8 @@ fn aka_wifi_smoke_runs_one_connectivity_transfer() {
     fs::write(&ip, "#!/bin/sh\necho '2: wlan0    inet 192.0.2.2/24'\n").unwrap();
     fs::write(
         &iperf3,
-        "#!/bin/sh\nprintf '%s\\n' \"$*\" >>\"$IPERF_INVOCATION_LOG\"\n",
+        "#!/bin/sh\nprintf '%s\\n' \"$*\" >\"$IPERF_INVOCATION_LOG\"\nprintf '%s\\n' \
+         \"$IPERF_OUTPUT\"\nexit \"$IPERF_STATUS\"\n",
     )
     .unwrap();
     for executable in [&ip, &iperf3] {
@@ -276,24 +277,54 @@ fn aka_wifi_smoke_runs_one_connectivity_transfer() {
 
     let script = Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("../../test-suit/starryos/board-aka-00-sg2002/wifi-iperf-smoke/iperf-smoke.sh");
-    let output = Command::new("/bin/sh")
-        .arg(script)
-        .arg("192.0.2.1")
-        .env(
-            "PATH",
-            format!("{}:/usr/bin:/bin", fake_bin.path().display()),
-        )
-        .env("IPERF_INVOCATION_LOG", &invocation_log)
-        .output()
-        .unwrap();
-
-    assert!(
-        output.status.success(),
-        "smoke script failed:\n{}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert_eq!(
-        fs::read_to_string(invocation_log).unwrap(),
-        "-c 192.0.2.1 -t 3 -O 1 -P 1 -l 128K\n"
-    );
+    let report = |stalled: bool| {
+        let mut report = "[  5] 0.00-4.00 sec 0 Bytes 0 bits/sec (omitted)\n".to_owned();
+        for second in 0..20 {
+            let transferred = if second == 10 || (stalled && (8..12).contains(&second)) {
+                0
+            } else {
+                512
+            };
+            report.push_str(&format!(
+                "[  5] {second}.00-{}.00 sec {transferred} KBytes 0 bits/sec\n",
+                second + 1
+            ));
+        }
+        report.push_str("[  5] 0.00-20.00 sec 8 MBytes 3.36 Mbits/sec sender\n");
+        report.push_str("[  5] 0.00-20.10 sec 8 MBytes 3.34 Mbits/sec receiver\n");
+        report
+    };
+    for (name, report, status, expected) in [
+        ("progress with one empty interval", report(false), "0", true),
+        ("successful exit after a stall", report(true), "0", false),
+        ("no report", String::new(), "0", false),
+        ("iperf error after progress", report(false), "1", false),
+    ] {
+        let output = Command::new("/bin/sh")
+            .arg(&script)
+            .arg("192.0.2.1")
+            .env(
+                "PATH",
+                format!("{}:/usr/bin:/bin", fake_bin.path().display()),
+            )
+            .env("IPERF_INVOCATION_LOG", &invocation_log)
+            .env("IPERF_OUTPUT", report)
+            .env("IPERF_STATUS", status)
+            .output()
+            .unwrap();
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert_eq!(output.status.success(), expected, "{name}: {stdout}");
+        assert_eq!(
+            stdout.contains("STARRY_AKA_WIFI_IPERF_SMOKE_PASSED"),
+            expected
+        );
+        assert_eq!(
+            stdout.contains("STARRY_AKA_WIFI_IPERF_SMOKE_FAILED"),
+            !expected
+        );
+        assert_eq!(
+            fs::read_to_string(&invocation_log).unwrap(),
+            "-c 192.0.2.1 -t 20 -O 2 -P 1 -l 128K\n"
+        );
+    }
 }

--- a/scripts/axbuild/src/test/std.rs
+++ b/scripts/axbuild/src/test/std.rs
@@ -277,6 +277,16 @@ const SDMMC_RDIF_FEATURE_PROFILES: &[PackageFeatureProfile] = &[
     },
 ];
 
+const AIC8800_FEATURE_PROFILES: &[PackageFeatureProfile] = &[PackageFeatureProfile {
+    name: "host-test+rdif",
+    no_default_features: false,
+    features: &["host-test", "rdif"],
+    name_filter: None,
+    expected_tests: &[
+        "rdif::owner::progress::tests::transmit_completion_yields_to_card_irq_before_next_sdio_submission",
+    ],
+}];
+
 const AXBUILD_FEATURE_PROFILES: &[PackageFeatureProfile] = &[PackageFeatureProfile {
     name: "default",
     no_default_features: false,
@@ -563,6 +573,7 @@ fn package_feature_profiles(package: &str) -> Option<&'static [PackageFeaturePro
         "ax-driver" => Some(AX_DRIVER_FEATURE_PROFILES),
         "nvme-driver" => Some(NVME_FEATURE_PROFILES),
         "sdmmc-protocol" => Some(SDMMC_RDIF_FEATURE_PROFILES),
+        "aic8800" => Some(AIC8800_FEATURE_PROFILES),
         "axbuild" => Some(AXBUILD_FEATURE_PROFILES),
         "axvisor" => Some(FS_FEATURE_PROFILES),
         _ => None,

--- a/scripts/test/std_crates.csv
+++ b/scripts/test/std_crates.csv
@@ -25,6 +25,7 @@ rdif-def
 rdif-eth
 rd-net
 realtek-rtl8125
+aic8800
 ax-sched
 axvm
 virtualization-tests

--- a/test-suit/starryos/board-aka-00-sg2002/wifi-iperf-smoke/iperf-smoke.sh
+++ b/test-suit/starryos/board-aka-00-sg2002/wifi-iperf-smoke/iperf-smoke.sh
@@ -24,6 +24,35 @@ fi
 
 command -v iperf3 >/dev/null 2>&1 || fail
 
-iperf3 -c "$server_ip" -t 3 -O 1 -P 1 -l 128K || fail
+report=$(mktemp) || fail
+trap 'rm -f "$report"' EXIT
+iperf3 -c "$server_ip" -t 20 -O 2 -P 1 -l 128K >"$report" 2>&1
+status=$?
+cat "$report"
+[ "$status" -eq 0 ] || fail
+
+# A completed 128 KiB write can straddle a reporting interval. Allow that
+# jitter, but reject three seconds without progress after the warm-up.
+awk '
+    /omitted/ { next }
+    !sub(/^\[[[:space:]]*[0-9]+\][[:space:]]*/, "") { next }
+    $NF == "receiver" { received = ($3 + 0 > 0); next }
+    $NF == "sender" { next }
+    $1 ~ /^[0-9]+\.[0-9]+-[0-9]+\.[0-9]+$/ && $2 == "sec" {
+        split($1, interval, "-")
+        if ($3 + 0 > 0) {
+            stalled = 0
+            progressed = 1
+        } else {
+            stalled += interval[2] - interval[1]
+        }
+        if (stalled >= 3) {
+            print "Wi-Fi transfer stalled for at least three seconds"
+            exit 1
+        }
+        end = interval[2]
+    }
+    END { if (!progressed || !received || end < 19) exit 1 }
+' "$report" || fail
 
 echo STARRY_AKA_WIFI_IPERF_SMOKE_PASSED


### PR DESCRIPTION
## 问题与根因

修复 [AKA-00 SG2002 Wi-Fi CI 失败](https://github.com/rcore-os/tgoskits/actions/runs/34126575337/job/101903086475)及其后续持续传输停顿。DHCP、脚本下载和 TCP 建连均成功，但 iperf3 只有最初几个区间有数据，随后反复出现零传输；仅检查退出状态会把这种结果判为通过。

定位到两处独立的进展问题：

1. AIC8800 发布 `TransmitComplete` 后立即提交下一笔 SDIO 发送，没有返回卡中断重新启用的边界。TX 队列持续非空时，`CARD_INT` 长时间屏蔽，接收与 TCP ACK 被延迟。
2. `ax-net` 的协议执行器没有连续工作预算。软件 TX 队列满时，smoltcp 仍可能因待发送数据返回立即轮询期限，外层循环持续占用同一 CPU。板卡是单核 RR 调度，队列所有者经常只能等约 50 ms 的时间片结束才继续处理一批工作。修复第一处之后，20 秒传输的接收吞吐仍只有约 0.22 Mbit/s，数据包到达间隔中位数为 49.5 ms。

## 修改与边界

- AIC8800 在发布发送完成后返回已有的重新启用中断边界；保留输出背压、协议就绪和没有活动 SDIO 事务的限制。
- 在 `ax-net` **现有的唯一协议执行任务**中加入连续轮询次数和时间预算：以 10 次轮询或 2 ms 为让步条件，在一次协议轮询返回后检查预算。预算跨越立即可运行的循环，避免外层零期限重置预算。
- 预算耗尽时先释放所有网络锁、交付延后的就绪通知，再让出 CPU；恢复后继续由同一个执行者推进协议。同步 flush 的代际完成仍在本轮协议排空后发布。
- 预算参考[荔枝派 BSP Linux 5.10 的 softirq 实现](https://github.com/sipeed/LicheeRV-Nano-Build/blob/d4003f15b35d43ad4842f427050ab2bba0114fa5/linux_5.10/kernel/softirq.c#L207-L220)。调度策略保留在 OS 网络运行时；可移植 AIC8800 驱动不新增 OS 线程、调度器依赖、休眠接口或周期设备轮询。
- 板卡冒烟改为 2 秒预热、20 秒传输，保留单流和 128 KiB 写入。允许单个统计区间因写入跨界而为空，但正式传输连续 3 秒无进展、缺少有效接收结果、测试提前结束或 iperf3 返回错误都会失败。
- AIC8800 接入 std 测试列表，以 `host-test,rdif` 执行完整测试，并检查卡中断回归确实被发现。

## 回归与实机证据

确定性红绿验证：

- 卡中断状态转换：旧逻辑无法在下一笔 TX 前返回重新启用边界，同一测试修复后通过。
- 协议预算：取消预算限制时，次数和时间两项测试均失败（ax-net 132 通过、2 失败）；恢复限制后 134 项通过。
- 冒烟失败传播：旧脚本将成功退出但连续零传输的报告判为成功，回归失败；增加检查后通过，并覆盖短暂空区间、预热、空报告和 iperf3 错误。

同一块板卡、同一 AP、官方 iperf3 3.21 服务，均使用 `-t 20 -O 2 -P 1 -l 128K`：

| 实现 | 接收吞吐 | 服务端数据包到达间隔中位数 | 正式统计区间 |
| --- | --- | --- | --- |
| 仅修复卡中断 | 0.221 Mbit/s | 49.5 ms | 反复连续约 4 秒零传输 |
| 卡中断与协议预算均修复 | 4.57 Mbit/s | 0.55 ms | 20 个一秒区间均有传输 |

吞吐数值是本次实机观测，不作为固定性能门限。

本地验证：

- `cargo xtask test --since origin/dev`：9 个受影响的 std 测试软件包全部通过；包含 AIC8800 113 项、ax-net 134 项、axbuild 918 项。
- `cargo xtask clippy --package aic8800 --package ax-net --package axbuild`：7 项检查全部通过。
- `cargo xtask sync-lint --since origin/dev`：通过。
- Starry x86_64 QEMU：`qemu/bugfix-bug-tcp-send-no-epoll-notify`、`qemu/bugfix-bug-proc-comm-tcp-partial-send` 均通过，验证就绪通知和阻塞发送未回归。
- `cargo xtask starry test board --board aka-00-sg2002`：最终提交 `6cc54f0fa7` 的 boot、tennis-yolo、usb2-lsusb、wifi-iperf-smoke 共 4 项通过；带进展检查的 20 秒 Wi-Fi 传输接收吞吐为 4.45 Mbit/s。
- `cargo fmt -- --check`、`git diff --check`、`cargo publish --workspace --dry-run --no-verify`：通过。

服务器另有 iperf3 上游接收超时计时缺陷（[esnet/iperf#1946](https://github.com/esnet/iperf/pull/1946)），已按要求升级到官方 3.21。升级解决服务器过早断连，以上两处内核修复解决卡中断与 CPU 调度造成的持续传输停顿。
