### PR TITLE
perf(buddy-slab-allocator): skip the full-list walk when no cross-CPU free is pending

### DIFF
--- a/memory/ax-alloc/src/buddy_slab.rs
+++ b/memory/ax-alloc/src/buddy_slab.rs
@@ -8,7 +8,7 @@ use core::{
 
 use ax_sync::SpinLock;
 use buddy_slab_allocator::{
-    GlobalAllocator as InnerAllocator, SizeClass, SlabAllocResult, SlabAllocator,
+    GlobalAllocator as InnerAllocator, RemoteFreeHint, SizeClass, SlabAllocResult, SlabAllocator,
     SlabDeallocResult, SlabPoolTrait, SlabTrait, interface::BuddySlabIf,
 };
 
@@ -34,6 +34,7 @@ static SLAB_POOL: SlabPool = SlabPool;
 struct PercpuSlab<const PAGE_SIZE: usize = 0x1000> {
     cpu_id: Option<u16>,
     inner: SpinLock<SlabAllocator<PAGE_SIZE>>,
+    remote_hint: RemoteFreeHint,
 }
 
 impl<const PAGE_SIZE: usize> PercpuSlab<PAGE_SIZE> {
@@ -41,6 +42,7 @@ impl<const PAGE_SIZE: usize> PercpuSlab<PAGE_SIZE> {
         Self {
             cpu_id: None,
             inner: SpinLock::new(SlabAllocator::new()),
+            remote_hint: RemoteFreeHint::new(),
         }
     }
 
@@ -52,6 +54,7 @@ impl<const PAGE_SIZE: usize> PercpuSlab<PAGE_SIZE> {
         );
         self.cpu_id = Some(cpu_id);
         *self.inner.get_mut() = SlabAllocator::new();
+        self.remote_hint.clear();
     }
 
     fn cpu_id_checked(&self) -> u16 {
@@ -70,7 +73,9 @@ impl<const PAGE_SIZE: usize> SlabTrait for PercpuSlab<PAGE_SIZE> {
     }
 
     fn alloc(&self, layout: Layout) -> buddy_slab_allocator::AllocResult<SlabAllocResult> {
-        self.inner.lock_irqsave().alloc(layout)
+        self.inner
+            .lock_irqsave()
+            .alloc_hinted(layout, Some(&self.remote_hint))
     }
 
     fn add_slab(&self, size_class: SizeClass, base: usize, bytes: usize) {
@@ -81,6 +86,10 @@ impl<const PAGE_SIZE: usize> SlabTrait for PercpuSlab<PAGE_SIZE> {
 
     fn dealloc_local(&self, ptr: NonNull<u8>, layout: Layout) -> SlabDeallocResult {
         self.inner.lock_irqsave().dealloc(ptr, layout)
+    }
+
+    fn remote_free_hint(&self) -> Option<&RemoteFreeHint> {
+        Some(&self.remote_hint)
     }
 }
 

--- a/memory/buddy-slab-allocator/src/lib.rs
+++ b/memory/buddy-slab-allocator/src/lib.rs
@@ -18,7 +18,7 @@ pub use buddy::{BuddyAllocator, ManagedSection};
 
 pub mod slab;
 pub use slab::{
-    PerCpuSlab, SizeClass, SlabAllocResult, SlabAllocator, SlabDeallocResult,
+    PerCpuSlab, RemoteFreeHint, SizeClass, SlabAllocResult, SlabAllocator, SlabDeallocResult,
     SlabPoolDeallocResult, SlabPoolTrait, SlabTrait, StaticSlabPool,
 };
 

--- a/memory/buddy-slab-allocator/src/slab/cache.rs
+++ b/memory/buddy-slab-allocator/src/slab/cache.rs
@@ -122,6 +122,9 @@ pub struct SlabCache {
     empty: ListHead,
     /// Number of empty slabs cached (we keep at most 1).
     empty_count: usize,
+    /// Full-list nodes walked while looking for remote frees.
+    #[cfg(feature = "host-test")]
+    full_walk_steps: usize,
 }
 
 /// Result of a per-cache deallocation.
@@ -140,19 +143,36 @@ impl SlabCache {
             full: ListHead::empty(SlabListState::Full),
             empty: ListHead::empty(SlabListState::Empty),
             empty_count: 0,
+            #[cfg(feature = "host-test")]
+            full_walk_steps: 0,
         }
+    }
+
+    /// Full-list nodes this cache has walked looking for remote frees.
+    #[cfg(feature = "host-test")]
+    pub fn full_walk_steps(&self) -> usize {
+        self.full_walk_steps
     }
 
     /// Try to allocate one object.  Returns `Some(obj_addr)` or `None` if no slabs available.
     pub fn alloc_object<const PAGE_SIZE: usize>(&mut self) -> Option<usize> {
+        self.alloc_object_hinted::<PAGE_SIZE>(|| true)
+    }
+
+    /// Like [`Self::alloc_object`], walking the full list only if `remote_pending`
+    /// reports a cross-CPU free. It is asked only once the partial slab is spent,
+    /// because asking consumes the announcement.
+    pub(crate) fn alloc_object_hinted<const PAGE_SIZE: usize>(
+        &mut self,
+        remote_pending: impl FnOnce() -> bool,
+    ) -> Option<usize> {
         // 1. Try the first partial slab (drain remote frees first).
         if let Some(addr) = self.try_alloc_from_partial::<PAGE_SIZE>() {
             return Some(addr);
         }
 
         // 2. A full slab may have gained free objects via lock-free remote frees.
-        if let Some(base) = self.reclaim_full_with_remote_frees() {
-            unsafe { self.partial.push_front(base) };
+        if remote_pending() && self.reclaim_full_with_remote_frees() {
             return self.try_alloc_from_partial::<PAGE_SIZE>();
         }
 
@@ -168,21 +188,29 @@ impl SlabCache {
         None
     }
 
-    /// Drain remote frees from the first full slab that has them and move it
-    /// back to the partial list.
-    fn reclaim_full_with_remote_frees(&mut self) -> Option<usize> {
+    /// Drain remote frees from every full slab that has them and move those
+    /// slabs back to the partial list. One announcement can cover several slabs.
+    fn reclaim_full_with_remote_frees(&mut self) -> bool {
+        let mut reclaimed = false;
         let mut base = self.full.first;
         while base != 0 {
+            #[cfg(feature = "host-test")]
+            {
+                self.full_walk_steps += 1;
+            }
             let next = unsafe { (*(base as *const SlabPageHeader)).list_next };
             let hdr = unsafe { &mut *(base as *mut SlabPageHeader) };
             if hdr.has_remote_frees() {
                 hdr.drain_remote_frees(base);
-                unsafe { self.full.remove(base) };
-                return Some(base);
+                unsafe {
+                    self.full.remove(base);
+                    self.partial.push_front(base);
+                }
+                reclaimed = true;
             }
             base = next;
         }
-        None
+        reclaimed
     }
 
     /// Attempt allocation from the first partial slab.

--- a/memory/buddy-slab-allocator/src/slab/mod.rs
+++ b/memory/buddy-slab-allocator/src/slab/mod.rs
@@ -10,7 +10,11 @@ pub mod cache;
 pub mod page;
 pub mod size_class;
 
-use core::{alloc::Layout, ptr::NonNull};
+use core::{
+    alloc::Layout,
+    ptr::NonNull,
+    sync::atomic::{AtomicU16, Ordering},
+};
 
 use ax_sync::{RawSpinLockGuard, SpinLock};
 use cache::{CacheDeallocResult, SlabCache};
@@ -47,6 +51,49 @@ pub enum SlabPoolDeallocResult {
     FreeSlab { base: usize, pages: usize },
 }
 
+/// Size classes that took a cross-CPU free since the owner last walked their
+/// full list. It sits outside the slab lock so the lock-free free path can set
+/// it, letting the owner skip the linear walk when nothing was announced.
+pub struct RemoteFreeHint(AtomicU16);
+
+const _: () = assert!(
+    SizeClass::COUNT <= u16::BITS as usize,
+    "RemoteFreeHint needs one bit per size class",
+);
+
+impl RemoteFreeHint {
+    /// Create a hint with no pending class.
+    pub const fn new() -> Self {
+        Self(AtomicU16::new(0))
+    }
+
+    /// Announce a remote free queued for `size_class`.
+    #[inline]
+    pub fn mark(&self, size_class: SizeClass) {
+        self.0.fetch_or(1 << size_class.index(), Ordering::Release);
+    }
+
+    /// Clear `size_class`'s flag and report whether it was set. Clearing before
+    /// the walk keeps a racing free from being lost: it marks the class again.
+    #[inline]
+    pub fn take(&self, size_class: SizeClass) -> bool {
+        let bit = 1 << size_class.index();
+        self.0.fetch_and(!bit, Ordering::AcqRel) & bit != 0
+    }
+
+    /// Forget every pending class.
+    #[inline]
+    pub fn clear(&self) {
+        self.0.store(0, Ordering::Release);
+    }
+}
+
+impl Default for RemoteFreeHint {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// Object-safe slab interface used by [`crate::GlobalAllocator`] EII hooks.
 pub trait SlabTrait: Sync {
     /// Logical CPU id this slab belongs to.
@@ -64,10 +111,20 @@ pub trait SlabTrait: Sync {
     /// Free an object on the owner CPU path.
     fn dealloc_local(&self, ptr: NonNull<u8>, layout: Layout) -> SlabDeallocResult;
 
+    /// Hint this slab publishes remote frees into; `None` walks on every allocation.
+    fn remote_free_hint(&self) -> Option<&RemoteFreeHint> {
+        None
+    }
+
     /// Free an object on the remote CPU path.
     fn dealloc_remote(&self, ptr: NonNull<u8>) {
         let owner_cpu = u16::try_from(self.cpu_id()).expect("CPU id exceeds slab owner range");
-        unsafe { SlabPageHeader::remote_free_object(ptr, owner_cpu, self.page_size()) };
+        let queued = unsafe { SlabPageHeader::queue_remote_free(ptr, owner_cpu, self.page_size()) };
+        if let Some(size_class) = queued
+            && let Some(hint) = self.remote_free_hint()
+        {
+            hint.mark(size_class);
+        }
     }
 }
 
@@ -134,6 +191,7 @@ pub struct SlabAllocator<const PAGE_SIZE: usize = 0x1000> {
 pub struct PerCpuSlab<const PAGE_SIZE: usize = 0x1000> {
     cpu_id: u16,
     inner: SpinLock<SlabAllocator<PAGE_SIZE>>,
+    remote_hint: RemoteFreeHint,
 }
 
 /// Default static slab-pool wrapper used by EII integrators.
@@ -148,6 +206,7 @@ impl<const PAGE_SIZE: usize> PerCpuSlab<PAGE_SIZE> {
         Self {
             cpu_id,
             inner: SpinLock::new(SlabAllocator::new()),
+            remote_hint: RemoteFreeHint::new(),
         }
     }
 
@@ -161,6 +220,7 @@ impl<const PAGE_SIZE: usize> PerCpuSlab<PAGE_SIZE> {
     /// Reset the inner slab allocator to an empty state.
     pub fn reset(&self) {
         *self.inner() = SlabAllocator::new();
+        self.remote_hint.clear();
     }
 
     /// Return this slab's logical CPU id.
@@ -170,7 +230,13 @@ impl<const PAGE_SIZE: usize> PerCpuSlab<PAGE_SIZE> {
 
     /// Allocate one object.
     pub fn alloc(&self, layout: Layout) -> AllocResult<SlabAllocResult> {
-        self.inner().alloc(layout)
+        self.inner().alloc_hinted(layout, Some(&self.remote_hint))
+    }
+
+    /// Full-list nodes this slab has walked looking for remote frees.
+    #[cfg(feature = "host-test")]
+    pub fn full_walk_steps(&self, size_class: SizeClass) -> usize {
+        self.inner().full_walk_steps(size_class)
     }
 
     /// Register a freshly allocated slab page.
@@ -185,7 +251,11 @@ impl<const PAGE_SIZE: usize> PerCpuSlab<PAGE_SIZE> {
 
     /// Queue an object onto this slab's remote-free list.
     pub fn dealloc_remote(&self, ptr: NonNull<u8>) {
-        unsafe { SlabPageHeader::remote_free_object(ptr, self.cpu_id, PAGE_SIZE) };
+        if let Some(size_class) =
+            unsafe { SlabPageHeader::queue_remote_free(ptr, self.cpu_id, PAGE_SIZE) }
+        {
+            self.remote_hint.mark(size_class);
+        }
     }
 }
 
@@ -230,10 +300,20 @@ impl<const PAGE_SIZE: usize> SlabAllocator<PAGE_SIZE> {
     /// If the matching cache is exhausted, [`SlabAllocResult::NeedsSlab`] is returned
     /// so the caller can supply pages and retry.
     pub fn alloc(&mut self, layout: Layout) -> AllocResult<SlabAllocResult> {
+        self.alloc_hinted(layout, None)
+    }
+
+    /// Allocate, consulting `hint` before walking the full list for remote
+    /// frees; `None` walks every time.
+    pub fn alloc_hinted(
+        &mut self,
+        layout: Layout,
+        hint: Option<&RemoteFreeHint>,
+    ) -> AllocResult<SlabAllocResult> {
         let sc = SizeClass::from_layout(layout).ok_or(AllocError::InvalidParam)?;
         let cache = &mut self.caches[sc.index()];
 
-        match cache.alloc_object::<PAGE_SIZE>() {
+        match cache.alloc_object_hinted::<PAGE_SIZE>(|| hint.is_none_or(|hint| hint.take(sc))) {
             Some(addr) => {
                 // SAFETY: `addr` is non-null, aligned, and within a live slab page.
                 let ptr = unsafe { NonNull::new_unchecked(addr as *mut u8) };
@@ -268,6 +348,13 @@ impl<const PAGE_SIZE: usize> SlabAllocator<PAGE_SIZE> {
     pub fn add_slab(&mut self, size_class: SizeClass, base: usize, bytes: usize, owner_cpu: u16) {
         self.caches[size_class.index()].add_slab(base, bytes, owner_cpu);
     }
+
+    /// Full-list nodes the cache for `size_class` has walked looking for
+    /// remote frees.
+    #[cfg(feature = "host-test")]
+    pub fn full_walk_steps(&self, size_class: SizeClass) -> usize {
+        self.caches[size_class.index()].full_walk_steps()
+    }
 }
 
 impl<const PAGE_SIZE: usize> SlabTrait for PerCpuSlab<PAGE_SIZE> {
@@ -289,6 +376,10 @@ impl<const PAGE_SIZE: usize> SlabTrait for PerCpuSlab<PAGE_SIZE> {
 
     fn dealloc_local(&self, ptr: NonNull<u8>, layout: Layout) -> SlabDeallocResult {
         PerCpuSlab::dealloc_local(self, ptr, layout)
+    }
+
+    fn remote_free_hint(&self) -> Option<&RemoteFreeHint> {
+        Some(&self.remote_hint)
     }
 }
 

--- a/memory/buddy-slab-allocator/src/slab/page.rs
+++ b/memory/buddy-slab-allocator/src/slab/page.rs
@@ -198,16 +198,30 @@ impl SlabPageHeader {
     /// - `owner_cpu` must match the slab header's owner CPU.
     /// - `page_size` must be the slab allocator's page size.
     pub unsafe fn remote_free_object(ptr: NonNull<u8>, owner_cpu: u16, page_size: usize) {
+        unsafe { Self::queue_remote_free(ptr, owner_cpu, page_size) };
+    }
+
+    /// Like [`Self::remote_free_object`], returning the size class the object
+    /// was queued into so the caller can announce it to the owner.
+    ///
+    /// # Safety
+    /// Same as [`Self::remote_free_object`].
+    pub(crate) unsafe fn queue_remote_free(
+        ptr: NonNull<u8>,
+        owner_cpu: u16,
+        page_size: usize,
+    ) -> Option<SizeClass> {
         let obj_addr = ptr.as_ptr() as usize;
         let Some(base) = Self::base_from_obj_addr_unknown_with_page_size(obj_addr, page_size)
         else {
             debug_assert!(false, "object address does not belong to a live slab");
-            return;
+            return None;
         };
         let hdr = unsafe { &*(base as *const SlabPageHeader) };
         debug_assert_eq!(hdr.magic, SLAB_MAGIC);
         debug_assert_eq!(hdr.owner_cpu, owner_cpu);
         unsafe { hdr.remote_free(obj_addr) };
+        Some(hdr.size_class)
     }
 
     // ------------------------------------------------------------------

--- a/memory/buddy-slab-allocator/tests/common/mod.rs
+++ b/memory/buddy-slab-allocator/tests/common/mod.rs
@@ -1,17 +1,71 @@
 #![allow(dead_code)]
 
-use core::ptr::NonNull;
+use core::{
+    panic::Location,
+    ptr::NonNull,
+    sync::atomic::{AtomicBool, Ordering},
+};
 use std::{
     alloc::{Layout, alloc, dealloc},
     cell::Cell,
     sync::{Mutex, MutexGuard, OnceLock},
 };
 
+use ax_sync::interface::{AcquireResult, ContextState, LockMetadata};
 use buddy_slab_allocator::{
     __reset_global_allocator_singleton_for_tests, GlobalAllocator, PerCpuSlab, SlabPoolTrait,
     interface::BuddySlabIf,
 };
 use rand::{SeedableRng, rngs::StdRng};
+
+/// Spin-lock backend for host test binaries; the kernel runtime links the real one.
+struct HostSpinOps;
+
+#[ax_crate_interface::impl_interface]
+impl ax_sync::interface::SpinOps for HostSpinOps {
+    fn acquire(
+        locked: &AtomicBool,
+        _metadata: &LockMetadata,
+        _lock_addr: usize,
+        _context: u8,
+        _subclass: u32,
+        _caller: &'static Location<'static>,
+    ) -> ContextState {
+        while locked
+            .compare_exchange_weak(false, true, Ordering::Acquire, Ordering::Relaxed)
+            .is_err()
+        {
+            core::hint::spin_loop();
+        }
+        ContextState::new(0, 0)
+    }
+
+    fn try_acquire(
+        locked: &AtomicBool,
+        _metadata: &LockMetadata,
+        _lock_addr: usize,
+        _context: u8,
+        _subclass: u32,
+        _caller: &'static Location<'static>,
+    ) -> AcquireResult {
+        let acquired = locked
+            .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
+            .is_ok();
+        AcquireResult::new(acquired, ContextState::new(0, 0))
+    }
+
+    fn release(locked: &AtomicBool, _lock_addr: usize, _context: u8, _state: ContextState) {
+        locked.store(false, Ordering::Release);
+    }
+
+    fn force_release(locked: &AtomicBool, _lock_addr: usize, _context: u8) {
+        locked.store(false, Ordering::Release);
+    }
+
+    fn is_locked(locked: &AtomicBool) -> bool {
+        locked.load(Ordering::Acquire)
+    }
+}
 
 thread_local! {
     static CURRENT_CPU: Cell<usize> = const { Cell::new(0) };

--- a/memory/buddy-slab-allocator/tests/integration_test.rs
+++ b/memory/buddy-slab-allocator/tests/integration_test.rs
@@ -683,8 +683,9 @@ fn init_global(
 
 #[test]
 fn global_reinit_same_instance_rejected() {
-    let allocator = GlobalAllocator::<PAGE_SIZE>::new();
+    // Held until the allocators drop: their Drop clears the singleton flag.
     let _ctx = global_test_context::<PAGE_SIZE>(1);
+    let allocator = GlobalAllocator::<PAGE_SIZE>::new();
     let mut first = HostRegion::new(TEST_HEAP_SIZE, PAGE_SIZE * 4);
     let mut second = HostRegion::new(TEST_HEAP_SIZE, PAGE_SIZE * 4);
 
@@ -695,9 +696,9 @@ fn global_reinit_same_instance_rejected() {
 
 #[test]
 fn global_second_live_instance_rejected() {
+    let _ctx = global_test_context::<PAGE_SIZE>(1);
     let first_allocator = GlobalAllocator::<PAGE_SIZE>::new();
     let second_allocator = GlobalAllocator::<PAGE_SIZE>::new();
-    let _ctx = global_test_context::<PAGE_SIZE>(1);
     let mut first = HostRegion::new(TEST_HEAP_SIZE, PAGE_SIZE * 4);
     let mut second = HostRegion::new(TEST_HEAP_SIZE, PAGE_SIZE * 4);
 
@@ -708,9 +709,9 @@ fn global_second_live_instance_rejected() {
 
 #[test]
 fn global_failed_init_rolls_back_singleton() {
+    let _ctx = global_test_context::<PAGE_SIZE>(1);
     let bad_allocator = GlobalAllocator::<PAGE_SIZE>::new();
     let good_allocator = GlobalAllocator::<PAGE_SIZE>::new();
-    let _ctx = global_test_context::<PAGE_SIZE>(1);
     let mut bad = HostRegion::new(PAGE_SIZE - 1, PAGE_SIZE);
     let mut good = HostRegion::new(TEST_HEAP_SIZE, PAGE_SIZE * 4);
 
@@ -1073,10 +1074,10 @@ fn global_unaligned_region_start() {
 
 #[test]
 fn global_rejects_region_without_one_managed_page() {
+    let _ctx = global_test_context::<PAGE_SIZE>(1);
     let region_size = PAGE_SIZE - 1;
     let mut region = HostRegion::new(region_size, PAGE_SIZE);
     let allocator = GlobalAllocator::<PAGE_SIZE>::new();
-    let _ctx = global_test_context::<PAGE_SIZE>(1);
 
     let err = unsafe { allocator.init(region.as_mut_slice()) }.unwrap_err();
     assert_eq!(err, AllocError::InvalidParam);

--- a/memory/buddy-slab-allocator/tests/remote_free_hint_test.rs
+++ b/memory/buddy-slab-allocator/tests/remote_free_hint_test.rs
@@ -1,0 +1,231 @@
+//! The owner CPU walks its full list only when a cross-CPU free says so.
+
+#![cfg(feature = "host-test")]
+
+extern crate buddy_slab_allocator;
+mod common;
+
+use core::{alloc::Layout, ptr::NonNull};
+
+use buddy_slab_allocator::{BuddyAllocator, PerCpuSlab, SizeClass, SlabAllocResult};
+use common::HostRegion;
+
+const PAGE_SIZE: usize = 0x1000;
+const TEST_HEAP_SIZE: usize = 16 * 1024 * 1024;
+const HEAP_ALIGN: usize = 0x10000;
+
+/// Object size chosen so slabs fill quickly and the full list grows fast.
+const OBJECT_SIZE: usize = 2048;
+
+fn aligned_buddy(region: &mut HostRegion) -> BuddyAllocator<PAGE_SIZE> {
+    let mut buddy = BuddyAllocator::<PAGE_SIZE>::new();
+    for offset in (0..HEAP_ALIGN).step_by(PAGE_SIZE) {
+        if region.len() <= offset {
+            break;
+        }
+        let slice = unsafe { region.subslice(offset, region.len() - offset) };
+        if unsafe { buddy.init(slice) }.is_ok()
+            && let Some(section) = buddy.section(0)
+            && section.start.is_multiple_of(HEAP_ALIGN)
+        {
+            return buddy;
+        }
+        buddy = BuddyAllocator::<PAGE_SIZE>::new();
+    }
+    panic!("no heap alignment produced an aligned section");
+}
+
+fn test_region() -> HostRegion {
+    let meta = BuddyAllocator::<PAGE_SIZE>::required_meta_size(TEST_HEAP_SIZE);
+    HostRegion::new(
+        TEST_HEAP_SIZE + meta + PAGE_SIZE * 4 + HEAP_ALIGN,
+        HEAP_ALIGN,
+    )
+}
+
+/// Allocate one object, feeding the slab pages until it can serve the request.
+fn alloc_one(
+    slab: &PerCpuSlab<PAGE_SIZE>,
+    buddy: &mut BuddyAllocator<PAGE_SIZE>,
+    layout: Layout,
+) -> NonNull<u8> {
+    loop {
+        match slab.alloc(layout).unwrap() {
+            SlabAllocResult::Allocated(ptr) => return ptr,
+            SlabAllocResult::NeedsSlab { size_class, pages } => {
+                let bytes = pages * PAGE_SIZE;
+                let base = buddy.alloc_pages(pages, bytes).unwrap();
+                slab.add_slab(size_class, base, bytes);
+            }
+        }
+    }
+}
+
+/// Allocate until the current slab is full and return its objects.
+fn fill_slab(
+    slab: &PerCpuSlab<PAGE_SIZE>,
+    buddy: &mut BuddyAllocator<PAGE_SIZE>,
+    layout: Layout,
+) -> Vec<NonNull<u8>> {
+    let mut objects = vec![alloc_one(slab, buddy, layout)];
+    while let SlabAllocResult::Allocated(ptr) = slab.alloc(layout).unwrap() {
+        objects.push(ptr);
+    }
+    objects
+}
+
+#[test]
+fn allocation_without_remote_frees_leaves_the_full_list_alone() {
+    let mut region = test_region();
+    let mut buddy = aligned_buddy(&mut region);
+    let slab = PerCpuSlab::<PAGE_SIZE>::new(0);
+    let layout = Layout::from_size_align(OBJECT_SIZE, 8).unwrap();
+    let class = SizeClass::from_layout(layout).unwrap();
+
+    // Every slab handed out here fills up and moves to the full list, so an
+    // unconditional reclaim walk would grow with each allocation.
+    let mut live = Vec::new();
+    for _ in 0..512 {
+        live.push(alloc_one(&slab, &mut buddy, layout));
+    }
+
+    assert_eq!(
+        slab.full_walk_steps(class),
+        0,
+        "no cross-CPU free happened, so the full list holds nothing to reclaim",
+    );
+}
+
+#[test]
+fn an_announced_remote_free_comes_back_to_the_owner() {
+    let mut region = test_region();
+    let mut buddy = aligned_buddy(&mut region);
+    let slab = PerCpuSlab::<PAGE_SIZE>::new(0);
+    let layout = Layout::from_size_align(OBJECT_SIZE, 8).unwrap();
+    let class = SizeClass::from_layout(layout).unwrap();
+
+    let mut live = Vec::new();
+    for _ in 0..64 {
+        live.push(alloc_one(&slab, &mut buddy, layout));
+    }
+    // Drain to the point where nothing is partial, so the reclaim walk is the
+    // only way back to a free object.
+    while let SlabAllocResult::Allocated(ptr) = slab.alloc(layout).unwrap() {
+        live.push(ptr);
+    }
+
+    let victim = live[0];
+    slab.dealloc_remote(victim);
+
+    match slab.alloc(layout).unwrap() {
+        SlabAllocResult::Allocated(ptr) => assert_eq!(
+            ptr.as_ptr(),
+            victim.as_ptr(),
+            "the reclaim walk must hand back the remotely freed object",
+        ),
+        SlabAllocResult::NeedsSlab { .. } => {
+            panic!("the announced remote free was never found")
+        }
+    }
+    assert!(
+        slab.full_walk_steps(class) > 0,
+        "finding the freed object requires walking the full list once",
+    );
+}
+
+#[test]
+fn a_partial_slab_hit_does_not_swallow_a_pending_remote_free() {
+    let mut region = test_region();
+    let mut buddy = aligned_buddy(&mut region);
+    let slab = PerCpuSlab::<PAGE_SIZE>::new(0);
+    // Small objects so one slab holds several: the point of this test is a
+    // cache that has a full slab and a partial slab with room at the same time.
+    let layout = Layout::from_size_align(64, 8).unwrap();
+
+    // Take one object so a first slab exists at all - a fresh cache holds none
+    // and would otherwise ask for a slab before allocating anything - then fill
+    // that slab exactly and queue a fresh one behind it.
+    let mut first = Vec::new();
+    first.push(alloc_one(&slab, &mut buddy, layout));
+    loop {
+        match slab.alloc(layout).unwrap() {
+            SlabAllocResult::Allocated(ptr) => first.push(ptr),
+            SlabAllocResult::NeedsSlab { size_class, pages } => {
+                let bytes = pages * PAGE_SIZE;
+                let base = buddy.alloc_pages(pages, bytes).unwrap();
+                slab.add_slab(size_class, base, bytes);
+                break;
+            }
+        }
+    }
+    // One object out of the fresh slab leaves it partial with room left.
+    let _held = alloc_one(&slab, &mut buddy, layout);
+
+    // A cross-CPU free lands on the slab that is already full.
+    let victim = first[0];
+    slab.dealloc_remote(victim);
+
+    // This allocation is satisfied by the partial slab, so it never reaches the
+    // reclaim walk. Consuming the announcement here would strand the freed
+    // object in the full list.
+    let from_partial = alloc_one(&slab, &mut buddy, layout);
+    assert_ne!(
+        from_partial.as_ptr(),
+        victim.as_ptr(),
+        "this allocation should have come from the partial slab",
+    );
+
+    // Drain what is left without handing over more slabs: the freed object has
+    // to come back out of the full list once the partial slab is spent.
+    let mut recovered = false;
+    for _ in 0..4096 {
+        match slab.alloc(layout).unwrap() {
+            SlabAllocResult::Allocated(ptr) => {
+                if ptr.as_ptr() == victim.as_ptr() {
+                    recovered = true;
+                    break;
+                }
+            }
+            SlabAllocResult::NeedsSlab { .. } => break,
+        }
+    }
+    assert!(
+        recovered,
+        "the remote free was announced before a partial-slab hit and then lost",
+    );
+}
+
+#[test]
+fn one_walk_reclaims_every_full_slab_with_remote_frees() {
+    let mut region = test_region();
+    let mut buddy = aligned_buddy(&mut region);
+    let slab = PerCpuSlab::<PAGE_SIZE>::new(0);
+    let layout = Layout::from_size_align(64, 8).unwrap();
+
+    // Two full slabs of one class, then a third left partial with room.
+    let first = fill_slab(&slab, &mut buddy, layout);
+    let second = fill_slab(&slab, &mut buddy, layout);
+    let _held = alloc_one(&slab, &mut buddy, layout);
+
+    // Both full slabs take a cross-CPU free before the owner allocates again.
+    let victims = [first[0], second[0]];
+    for victim in victims {
+        slab.dealloc_remote(victim);
+    }
+
+    // Spend the partial slab, then keep going without new slabs: both freed
+    // objects must come back although a single walk consumed the announcement.
+    let mut recovered = Vec::new();
+    for _ in 0..4096 {
+        match slab.alloc(layout).unwrap() {
+            SlabAllocResult::Allocated(ptr) if victims.contains(&ptr) => recovered.push(ptr),
+            SlabAllocResult::Allocated(_) => {}
+            SlabAllocResult::NeedsSlab { .. } => break,
+        }
+    }
+    assert_eq!(
+        recovered.len(),
+        victims.len(),
+        "a remote free on another full slab was stranded after the walk",
+    );
+}

--- a/scripts/test/std_crates.csv
+++ b/scripts/test/std_crates.csv
@@ -42,6 +42,7 @@ starry-kernel
 starry-vm
 ax-timer-list
 ax-alloc
+buddy-slab-allocator
 ax-display
 ax-hal
 ax-input


### PR DESCRIPTION
## 问题

`SlabCache::alloc_object` 在 partial 链表取不到对象时遍历整条 full 链表，查找跨 CPU 释放。跨 CPU 释放很少，这条遍历几乎总是空手返回，开销随 full slab 数量增长。浏览器负载下对内核采样，`reclaim_full_with_remote_frees` 是频次最高的栈顶符号。

## 改动

- 远程释放时把 size class 登记到 `RemoteFreeHint`；partial 取不到对象且该 class 已登记时才遍历 full 链表，先清标志再遍历。
- 一次遍历把所有带远程释放的 full slab 移回 partial。
- 公开接口不变：`SlabCache::alloc_object()` 与 `SlabPageHeader::remote_free_object` 保持原签名，带提示的版本是 crate 内部的 `alloc_object_hinted`、`queue_remote_free`。
- `buddy-slab-allocator` 加入 `std_crates.csv`，集成测试补上宿主机 `SpinOps` 后端，此前一直链接不上。
- 调整 4 个集成测试的声明顺序：测试上下文先于分配器析构时，分配器会在测试锁之外清掉全局单例标志，并行测试偶发失败。

## 回归测试

| 用例 | 覆盖 |
|:--:|:--:|
| `allocation_without_remote_frees_leaves_the_full_list_alone` | 无跨 CPU 释放时不遍历（修复前 512 次分配遍历 2701 个节点） |
| `an_announced_remote_free_comes_back_to_the_owner` | 登记过的释放经一次遍历取回 |
| `a_partial_slab_hit_does_not_swallow_a_pending_remote_free` | partial 命中不消费提示 |
| `one_walk_reclaims_every_full_slab_with_remote_frees` | 两个 full slab 上的远程释放都能取回 |

最后一条在只遍历到第一个 full slab 的实现上失败（`a remote free on another full slab was stranded after the walk`），修复后通过。

## 验证

`cargo xtask test --since 1d7f3c20`、`cargo xtask clippy --since 1d7f3c20` 全部通过。
