### PR TITLE
perf(starry-kernel): scope VMA and epoll scans to what each caller needs

### DIFF
--- a/os/StarryOS/kernel/src/file/epoll.rs
+++ b/os/StarryOS/kernel/src/file/epoll.rs
@@ -539,7 +539,7 @@ impl EpollInner {
     }
 
     fn publish_ready_for_file(&self, source: &Arc<EpollInterest>) {
-        let interests = match self.snapshot_interests() {
+        let interests = match self.snapshot_callback_batch(source) {
             Ok(interests) => interests,
             Err(_) => {
                 // Allocation failure must not lose the callback that reached
@@ -609,6 +609,57 @@ impl EpollInner {
                 txlist.push_back(entry);
             }
             return Ok(txlist);
+        }
+    }
+
+    /// Whether a readiness callback that reached `source` may publish
+    /// `interest`: the source itself, or a descriptor registered on the same
+    /// file.
+    fn in_callback_batch(interest: &Arc<EpollInterest>, source: &Arc<EpollInterest>) -> bool {
+        Arc::ptr_eq(interest, source) || Weak::ptr_eq(&interest.key.file, &source.key.file)
+    }
+
+    /// The interests one readiness callback can publish.
+    ///
+    /// A file becoming ready can only publish the interests registered on that
+    /// file, and that is almost always one. Taking the whole epoll set to find
+    /// them charged every callback a reference count per registered
+    /// descriptor and a sort of the entire set, so the candidates are picked
+    /// out by pointer identity first. Pointer identity is also all that may be
+    /// tested here: it takes no further lock, which is what lets it run while
+    /// the interests lock is held.
+    fn snapshot_callback_batch(
+        &self,
+        source: &Arc<EpollInterest>,
+    ) -> StarryResult<Vec<Arc<EpollInterest>>> {
+        loop {
+            let len = self
+                .interests
+                .lock()
+                .values()
+                .filter(|interest| Self::in_callback_batch(interest, source))
+                .count();
+            let mut batch = Vec::new();
+            batch.try_reserve(len).map_err(|_| StarryError::NoMemory)?;
+
+            let interests = self.interests.lock();
+            let mut matched = 0;
+            for interest in interests.values() {
+                if !Self::in_callback_batch(interest, source) {
+                    continue;
+                }
+                matched += 1;
+                if matched > batch.capacity() {
+                    break;
+                }
+                batch.push(Arc::clone(interest));
+            }
+            // An alias registered while the count was not held sends this
+            // round back rather than growing the vector under the lock.
+            if matched > batch.capacity() {
+                continue;
+            }
+            return Ok(batch);
         }
     }
 
@@ -847,6 +898,29 @@ impl Epoll {
             },
             flags,
         )
+    }
+
+    /// How many interests one readiness callback on `fd` would snapshot.
+    ///
+    /// What the callback publishes is the same either way, so the size of the
+    /// snapshot is the only thing that separates a per-file batch from a copy
+    /// of the whole epoll set.
+    #[cfg(all(test, not(axtest)))]
+    pub(super) fn callback_batch_len_for_test(
+        &self,
+        fd: i32,
+        file: &Arc<dyn FileLike>,
+    ) -> Option<usize> {
+        let source = self
+            .inner
+            .interests
+            .lock()
+            .get(&EntryKey::for_test(fd, file))
+            .cloned()?;
+        self.inner
+            .snapshot_callback_batch(&source)
+            .ok()
+            .map(|batch| batch.len())
     }
 
     pub fn modify(&self, fd: i32, event: EpollEvent, flags: EpollFlags) -> StarryResult<()> {

--- a/os/StarryOS/kernel/src/file/epoll_axtest.rs
+++ b/os/StarryOS/kernel/src/file/epoll_axtest.rs
@@ -388,6 +388,27 @@ fn epoll_requeues_readiness_observed_during_rearm_for_test() -> bool {
         })
 }
 
+#[cfg(all(test, not(axtest)))]
+fn callback_batch_covers_only_the_ready_file_for_test() -> bool {
+    const FILES: i32 = 64;
+    const SOURCE_FD: i32 = 7;
+
+    let epoll = Epoll::new();
+    let mut files: Vec<Arc<dyn FileLike>> = Vec::new();
+    for fd in 0..FILES {
+        let file_like: Arc<dyn FileLike> = ReadyFile::new();
+        if epoll
+            .add_file_for_test(fd, file_like.clone(), fd as u64, EpollFlags::empty())
+            .is_err()
+        {
+            return false;
+        }
+        files.push(file_like);
+    }
+
+    epoll.callback_batch_len_for_test(SOURCE_FD, &files[SOURCE_FD as usize]) == Some(1)
+}
+
 #[cfg(test)]
 mod tests {
     #[cfg(all(test, axtest))]
@@ -424,5 +445,11 @@ mod tests {
     #[test]
     fn requeues_readiness_observed_during_rearm() {
         assert!(super::epoll_requeues_readiness_observed_during_rearm_for_test());
+    }
+
+    #[cfg(all(test, not(axtest)))]
+    #[test]
+    fn callback_batch_covers_only_the_ready_file() {
+        assert!(super::callback_batch_covers_only_the_ready_file_for_test());
     }
 }

--- a/os/StarryOS/kernel/src/mm/aspace/mod.rs
+++ b/os/StarryOS/kernel/src/mm/aspace/mod.rs
@@ -1810,6 +1810,51 @@ impl AddrSpace {
     /// materialized mapping in `range` is detached.  This runs before the PTE
     /// mutation, so allocation or cache-identity failure leaves the published
     /// state untouched.
+    /// Records one VMA's backend, and the file-cache pins its shared lease
+    /// keeps alive, into the retired-mapping owners.
+    fn collect_retired_mapping_owner(
+        &self,
+        entry: &Arc<VmaEntry>,
+        range: VirtAddrRange,
+        owners: &mut RetiredMappingOwners,
+    ) -> StarryResult {
+        owners
+            .backends
+            .try_reserve(1)
+            .map_err(|_| StarryError::NoMemory)?;
+        let backend = entry.operation_clone();
+
+        if backend.shared_file_lease().is_some() {
+            let start = entry.start().max(range.start).align_down_4k();
+            let end = entry.end().min(range.end);
+            let file_range = VirtAddrRange::new(start, end);
+            let count = self.mapping_slots_overlapping(file_range).count();
+            owners
+                .cache_pins
+                .try_reserve(count)
+                .map_err(|_| StarryError::NoMemory)?;
+            for (_, slot) in self.mapping_slots_overlapping(file_range) {
+                if slot.state() != SlotState::Present
+                    || slot.mapping != backend.mapping_id()
+                    || slot.page_order != PageOrder::BASE
+                {
+                    return Err(StarryError::BadState);
+                }
+                let paddr = slot.mapped_paddr().ok_or(StarryError::BadState)?;
+                let (installed, _, page_size) = self.pt.query(slot.va)?;
+                if installed != paddr || page_size != PAGE_SIZE_4K {
+                    return Err(StarryError::BadState);
+                }
+                let pin = backend
+                    .pin_file_cache_owner_for_mapping(slot.va, paddr)?
+                    .ok_or(StarryError::BadState)?;
+                owners.cache_pins.push(pin);
+            }
+        }
+        owners.backends.push(backend);
+        Ok(())
+    }
+
     fn prepare_retired_mapping_owners(
         &self,
         range: VirtAddrRange,
@@ -1817,47 +1862,21 @@ impl AddrSpace {
         try_reserve_irq_vec(&self.retired_mapping_batches, 1).map_err(|_| StarryError::NoMemory)?;
 
         let mut owners = RetiredMappingOwners::default();
-        for entry in self.vma_root.iter_entries() {
-            if entry.start() >= range.end {
-                break;
-            }
-            if entry.end() <= range.start {
-                continue;
-            }
-            owners
-                .backends
-                .try_reserve(1)
-                .map_err(|_| StarryError::NoMemory)?;
-            let backend = entry.operation_clone();
-
-            if backend.shared_file_lease().is_some() {
-                let start = entry.start().max(range.start).align_down_4k();
-                let end = entry.end().min(range.end);
-                let file_range = VirtAddrRange::new(start, end);
-                let count = self.mapping_slots_overlapping(file_range).count();
-                owners
-                    .cache_pins
-                    .try_reserve(count)
-                    .map_err(|_| StarryError::NoMemory)?;
-                for (_, slot) in self.mapping_slots_overlapping(file_range) {
-                    if slot.state() != SlotState::Present
-                        || slot.mapping != backend.mapping_id()
-                        || slot.page_order != PageOrder::BASE
-                    {
-                        return Err(StarryError::BadState);
-                    }
-                    let paddr = slot.mapped_paddr().ok_or(StarryError::BadState)?;
-                    let (installed, _, page_size) = self.pt.query(slot.va)?;
-                    if installed != paddr || page_size != PAGE_SIZE_4K {
-                        return Err(StarryError::BadState);
-                    }
-                    let pin = backend
-                        .pin_file_cache_owner_for_mapping(slot.va, paddr)?
-                        .ok_or(StarryError::BadState)?;
-                    owners.cache_pins.push(pin);
+        // Only the VMAs the range covers matter here. Breaking out of a
+        // full-map iteration saved nothing: `iter_entries` builds the entire
+        // vector before the loop reads its first entry.
+        let mut failure = None;
+        self.vma_root.for_each_overlapping_entry(range, |entry| {
+            match self.collect_retired_mapping_owner(entry, range, &mut owners) {
+                Ok(()) => true,
+                Err(err) => {
+                    failure = Some(err);
+                    false
                 }
             }
-            owners.backends.push(backend);
+        });
+        if let Some(err) = failure {
+            return Err(err);
         }
 
         let matching_slots = self.mapping_slots_overlapping(range).count();
@@ -5326,17 +5345,20 @@ impl AddrSpace {
         // any PTE or VMA fragment.  This is intentionally done here (rather
         // than in one backend) because a range can span several fragments and
         // the envelope belongs to the VMA record itself.
-        let end = start.checked_add(size).ok_or(StarryError::InvalidInput)?;
-        for entry in self.vma_root.iter_entries() {
-            if entry.end() <= start {
-                continue;
+        start.checked_add(size).ok_or(StarryError::InvalidInput)?;
+        // The bounds check reads only the VMAs the range covers. Walking the
+        // whole map and breaking out of it saved nothing: `iter_entries` builds
+        // the entire vector before the loop gets to look at the first entry.
+        let mut denied = false;
+        self.vma_root.for_each_overlapping_entry(range, |entry| {
+            if entry.max_rights().contains(flags) {
+                return true;
             }
-            if entry.start() >= end {
-                break;
-            }
-            if !entry.max_rights().contains(flags) {
-                return Err(StarryError::PermissionDenied);
-            }
+            denied = true;
+            false
+        });
+        if denied {
+            return Err(StarryError::PermissionDenied);
         }
 
         let vma_preimage = self.vma_root.clone();

--- a/os/StarryOS/kernel/src/mm/aspace/mod.rs
+++ b/os/StarryOS/kernel/src/mm/aspace/mod.rs
@@ -5606,20 +5606,26 @@ impl AddrSpace {
         if range.is_empty() {
             return false;
         }
+        // This sits under every user-pointer check, so it must not allocate or
+        // touch a reference count per VMA: an ordinary `clock_gettime` writing
+        // one `timespec` was flattening the whole VMA tree.
         let mut cursor = range.start;
-        for vma in self.vma_root.lookup_range(range) {
+        let mut permitted = false;
+        self.vma_root.for_each_overlapping(range, |vma| {
             if vma.range.end <= cursor {
-                continue;
+                return true;
             }
             if vma.range.start > cursor || !vma.rights.contains(access_flags) {
                 return false;
             }
             cursor = vma.range.end.min(range.end);
             if cursor >= range.end {
-                return true;
+                permitted = true;
+                return false;
             }
-        }
-        false
+            true
+        });
+        permitted
     }
 
     /// Chooses the materialized leaf size for one fault without changing the

--- a/os/StarryOS/kernel/src/mm/aspace/vma.rs
+++ b/os/StarryOS/kernel/src/mm/aspace/vma.rs
@@ -1040,6 +1040,16 @@ impl VmaMap {
         range: VirtAddrRange,
         mut visit: impl FnMut(&Arc<VmaSnapshot>) -> bool,
     ) {
+        self.for_each_overlapping_entry(range, |entry| visit(&entry.snapshot));
+    }
+
+    /// [`Self::for_each_overlapping`] over the entries, for the callers that
+    /// need the mapping operation and not just the snapshot.
+    pub(super) fn for_each_overlapping_entry(
+        &self,
+        range: VirtAddrRange,
+        mut visit: impl FnMut(&Arc<VmaEntry>) -> bool,
+    ) {
         let mut visited = 0;
         Self::visit_overlapping(&self.root, range, &mut visited, &mut visit);
     }
@@ -1052,7 +1062,7 @@ impl VmaMap {
         node: &Option<Arc<VmaNode>>,
         range: VirtAddrRange,
         visited: &mut usize,
-        visit: &mut impl FnMut(&Arc<VmaSnapshot>) -> bool,
+        visit: &mut impl FnMut(&Arc<VmaEntry>) -> bool,
     ) -> bool {
         let Some(current) = node else {
             return true;
@@ -1064,7 +1074,7 @@ impl VmaMap {
         {
             return false;
         }
-        if vma.overlaps(range) && !visit(&current.entry.snapshot) {
+        if vma.overlaps(range) && !visit(&current.entry) {
             return false;
         }
         if range.end > vma.end
@@ -1787,9 +1797,9 @@ mod tests {
         let mut visited = 0;
         let mut found = 0;
         let mut first = None;
-        VmaMap::visit_overlapping(&map.root, range, &mut visited, &mut |vma| {
+        VmaMap::visit_overlapping(&map.root, range, &mut visited, &mut |entry| {
             found += 1;
-            first.get_or_insert(vma.range.start);
+            first.get_or_insert(entry.snapshot.range.start);
             true
         });
 

--- a/os/StarryOS/kernel/src/mm/aspace/vma.rs
+++ b/os/StarryOS/kernel/src/mm/aspace/vma.rs
@@ -1780,6 +1780,7 @@ mod tests {
     }
 
     /// One VMA per 0x2000, so VMA `i` covers `[0x1000 + i * 0x2000, +0x1000)`.
+    #[cfg(all(test, not(axtest)))]
     fn map_of(count: usize) -> VmaMap {
         let mut map = VmaMap::default();
         for i in 0..count {
@@ -1788,6 +1789,7 @@ mod tests {
         map
     }
 
+    #[cfg(all(test, not(axtest)))]
     #[test]
     fn a_range_lookup_walks_the_search_path_not_the_whole_tree() {
         let map = map_of(256);
@@ -1811,6 +1813,7 @@ mod tests {
         );
     }
 
+    #[cfg(all(test, not(axtest)))]
     #[test]
     fn a_spanning_lookup_returns_every_intersecting_vma_in_order() {
         let map = map_of(64);
@@ -1829,6 +1832,7 @@ mod tests {
         }
     }
 
+    #[cfg(all(test, not(axtest)))]
     #[test]
     fn a_lookup_starting_inside_a_vma_still_reaches_its_predecessor() {
         let map = map_of(32);

--- a/os/StarryOS/kernel/src/mm/aspace/vma.rs
+++ b/os/StarryOS/kernel/src/mm/aspace/vma.rs
@@ -1024,13 +1024,67 @@ impl VmaMap {
         candidate.filter(|entry| entry.snapshot.contains(address))
     }
 
+    /// Visits every VMA intersecting `range` in ascending order, stopping as
+    /// soon as `visit` returns `false`.
+    ///
+    /// VMAs never overlap, so each subtree covers one contiguous stretch of
+    /// address space and two facts prune the descent: a left subtree ends at
+    /// or before its parent's start, so it can only reach `range` when the
+    /// parent starts after `range.start`; a right subtree starts at or after
+    /// its parent's end, so it holds nothing once `range` ends there. What is
+    /// left is the search path plus the matches, without materialising the
+    /// tree or touching a single reference count for a VMA that does not
+    /// intersect.
+    pub fn for_each_overlapping(
+        &self,
+        range: VirtAddrRange,
+        mut visit: impl FnMut(&Arc<VmaSnapshot>) -> bool,
+    ) {
+        let mut visited = 0;
+        Self::visit_overlapping(&self.root, range, &mut visited, &mut visit);
+    }
+
+    /// `for_each_overlapping` with the node count the descent paid, which is
+    /// what the regression test asserts on: the result of a range lookup is
+    /// the same whether or not the tree was walked in full, so only the cost
+    /// distinguishes them.
+    fn visit_overlapping(
+        node: &Option<Arc<VmaNode>>,
+        range: VirtAddrRange,
+        visited: &mut usize,
+        visit: &mut impl FnMut(&Arc<VmaSnapshot>) -> bool,
+    ) -> bool {
+        let Some(current) = node else {
+            return true;
+        };
+        *visited += 1;
+        let vma = current.entry.snapshot.range;
+        if range.start < vma.start
+            && !Self::visit_overlapping(&current.left, range, visited, visit)
+        {
+            return false;
+        }
+        if vma.overlaps(range) && !visit(&current.entry.snapshot) {
+            return false;
+        }
+        if range.end > vma.end
+            && !Self::visit_overlapping(&current.right, range, visited, visit)
+        {
+            return false;
+        }
+        true
+    }
+
     /// Looks up every VMA intersecting a checked range.  Returned snapshots
     /// own their metadata and can safely be used after the publication lock is
     /// released or while a backend performs I/O.
     pub fn lookup_range(&self, range: VirtAddrRange) -> Vec<Arc<VmaSnapshot>> {
-        self.iter()
-            .filter(|vma| vma.range.overlaps(range))
-            .collect()
+        let mut found = Vec::new();
+        self.for_each_overlapping(range, |vma| {
+            found.push(vma.clone());
+            true
+        });
+        found
     }
 
     pub fn contains_range(&self, start: VirtAddr, size: usize) -> bool {
@@ -1041,9 +1095,10 @@ impl VmaMap {
             return false;
         }
         let mut cursor = request.start;
-        for vma in self.iter() {
+        let mut covered = false;
+        self.for_each_overlapping(request, |vma| {
             if vma.range.end <= cursor {
-                continue;
+                return true;
             }
             if vma.range.start > cursor {
                 return false;
@@ -1053,10 +1108,12 @@ impl VmaMap {
             // `AddrRange` whose start is greater than its end.
             cursor = vma.range.end.min(request.end);
             if cursor >= request.end {
-                return true;
+                covered = true;
+                return false;
             }
-        }
-        false
+            true
+        });
+        covered
     }
 
     fn fragment_with_huge_page_advice(
@@ -1710,6 +1767,73 @@ mod tests {
     fn insert(map: &VmaMap, start: usize, size: usize) -> Option<VmaMap> {
         let (snapshot, operation) = snapshot(start, size);
         map.insert_with_operation(snapshot, operation)
+    }
+
+    /// One VMA per 0x2000, so VMA `i` covers `[0x1000 + i * 0x2000, +0x1000)`.
+    fn map_of(count: usize) -> VmaMap {
+        let mut map = VmaMap::default();
+        for i in 0..count {
+            map = insert(&map, 0x1000 + i * 0x2000, 0x1000).unwrap();
+        }
+        map
+    }
+
+    #[test]
+    fn a_range_lookup_walks_the_search_path_not_the_whole_tree() {
+        let map = map_of(256);
+        let target = 0x1000 + 128 * 0x2000;
+        let range = VirtAddrRange::from_start_size(VirtAddr::from_usize(target), 0x1000);
+
+        let mut visited = 0;
+        let mut found = 0;
+        let mut first = None;
+        VmaMap::visit_overlapping(&map.root, range, &mut visited, &mut |vma| {
+            found += 1;
+            first.get_or_insert(vma.range.start);
+            true
+        });
+
+        assert_eq!(found, 1);
+        assert_eq!(first, Some(VirtAddr::from_usize(target)));
+        assert!(
+            visited <= 24,
+            "a one-VMA lookup walked {visited} nodes of a 256-VMA tree",
+        );
+    }
+
+    #[test]
+    fn a_spanning_lookup_returns_every_intersecting_vma_in_order() {
+        let map = map_of(64);
+        let start = 0x1000 + 10 * 0x2000;
+        let end = 0x1000 + 20 * 0x2000;
+        let range = VirtAddrRange::from_start_size(VirtAddr::from_usize(start), end - start);
+
+        let found = map.lookup_range(range);
+
+        assert_eq!(found.len(), 10);
+        for (offset, vma) in found.iter().enumerate() {
+            assert_eq!(
+                vma.range.start,
+                VirtAddr::from_usize(0x1000 + (10 + offset) * 0x2000),
+            );
+        }
+    }
+
+    #[test]
+    fn a_lookup_starting_inside_a_vma_still_reaches_its_predecessor() {
+        let map = map_of(32);
+        // Start halfway through VMA 7 so the match lies to the left of the
+        // node the descent lands on.
+        let start = 0x1000 + 7 * 0x2000 + 0x800;
+        let range = VirtAddrRange::from_start_size(VirtAddr::from_usize(start), 0x400);
+
+        let found = map.lookup_range(range);
+
+        assert_eq!(found.len(), 1);
+        assert_eq!(
+            found[0].range.start,
+            VirtAddr::from_usize(0x1000 + 7 * 0x2000),
+        );
     }
 
     #[test]


### PR DESCRIPTION
## 问题

同一轮 gdb stub 采样在内核里找到两处与请求规模无关的全量扫描。

`VmaMap` 是一棵有序 AVL 树，但 `lookup_range` 的实现是 `iter().filter(...)`：先把整棵树展开成 `Vec`，展开过程中每个节点两次引用计数、每个 VMA 再一次，然后丢掉所有不相交的项。真正要命的调用者是 `can_access_range`，它挂在 `UserAccess::prepare` 上，也就是每一个访问用户内存的系统调用都要过一遍。采样抓到的一例是 `sys_clock_gettime` 写一个 `timespec` 时在展开整棵 VMA 树。

`EpollInner::publish_ready_for_file` 是每一次 fd 就绪回调都会走的路径。它先把该 epoll 集合中所有 interest 复制进新向量（每个一次原子引用计数），再对整个集合排序，最后遍历全部，只保留与就绪 file 相同的 dup 别名，而别名通常只有一个。

## 改动

其一，`VmaMap` 增加按序下降的区间访问者，只访问与区间相交的节点。VMA 互不重叠是剪枝成立的前提：左子树的结束不超过父节点的起始，右子树的起始不早于父节点的结束，因此不需要区间树的 max-end 增广。`lookup_range` 改在其上实现，`can_access_range` 与 `contains_range` 改走不分配的访问者路径。

其二，`sys_munmap` 与 `sys_mprotect` 的 VMA 扫描收窄到各自作用的区间。这两处原本写了越过区间就 `break`，但省不下任何东西：`iter_entries` 是急求值的，循环拿到第一个元素之前整个向量已经建好。munmap 一侧把每个 VMA 的处理移入具名辅助函数，以保留原有的错误传播。

其三，epoll 就绪回调改为先用指针比较筛出候选再排序。指针比较是持 `interests` 锁期间唯一允许做的判断，因为它不会再取第二把锁；筛选条件是发布循环原判据的超集，因此发布的 interest 集合与顺序均不变。

## 验证

两处的回归测试都先在未修实现上确认必然失败：

| 场景 | 修复前 | 修复后 |
|:--:|:--:|:--:|
| 256 个 VMA 的树里查 1 个 VMA，访问的节点数 | 256 | 不超过搜索路径 |
| 64 个已注册 fd、其中 1 个就绪，一次回调快照的 interest 数 | 64 | 1 |

另有两条正确性测试守住剪枝条件：跨 10 个 VMA 的区间必须按序完整返回；从某个 VMA 内部起始的区间必须仍能命中它。这两条在修复前后都通过，防的是剪枝条件写错。epoll 一侧原有的行为测试（别名按 Linux 回调顺序轮转、边沿触发需要新通知、回调不重入目标）全部保持通过。

本地验证：`cargo xtask clippy --package starry-kernel` 93 项检查全部通过；`cargo xtask test` 报告 all std tests passed。

## 冲突处理验证（2026-09-08）

已变基到 `dev` 的 `cbed9ea5f04c19b0cf42c2e036c55dd8366aebd9`，保留四个原有提交。VMA 冲突保留区间扫描实现；epoll 测试保留 dev 的 PollRegistrar 接口和合并导入。

- `cargo fmt`、`git diff --check` 通过。
- `cargo xtask test --since origin/dev` 全部通过，包含 VMA 搜索路径及 epoll 单文件快照回归。
- x86_64 QEMU：`qemu/syscall-test-epoll`、`qemu/syscall-test-mprotect-wx` 均通过。
- `cargo xtask clippy --package starry-kernel` 首次因并行构建混入的 future-incompatibility 报告中断；串行重跑越过该位置，但按要求直接推送，未等待完整 92 项矩阵结束。此轮不声明完整静态检查或远端 CI 通过。
