### PR TITLE
fix(aic8800): honor firmware data packet credits

### DIFF
--- a/drivers/net/aic8800/src/device/data_plane.rs
+++ b/drivers/net/aic8800/src/device/data_plane.rs
@@ -6,13 +6,15 @@ use crate::{
     lmac::{
         SM_CONNECT_IND, SM_DISCONNECT_IND, parse_connect_indication, parse_disconnect_indication,
     },
-    profile::DataTxFlowPolicy,
     protocol::{BLOCK_SIZE, ethernet_tx_frame},
     registers::{ReceiveLength, flow_credits},
     rx::{ParsedFrame, RX_CAPACITY, parse_fifo},
 };
 
 const IO_RETRY: Duration = Duration::from_millis(1);
+// The firmware reports packet buffers, not SDIO blocks. Keep two buffers
+// available for commands, as in the vendor DATA_FLOW_CTRL_THRESH contract.
+const DATA_TX_RESERVED_CREDITS: u8 = 2;
 const INTERNAL_TX_CAPACITY: usize = 2;
 const ETHERTYPE_EAPOL: [u8; 2] = [0x88, 0x8e];
 
@@ -57,29 +59,12 @@ impl AicDevice {
         }
         self.prepare_next_transmit();
         if self.data.active_tx.is_some() {
-            return match self.data_tx_flow_policy() {
-                DataTxFlowPolicy::Direct => {
-                    let wire_frame = self
-                        .data
-                        .active_tx
-                        .as_ref()
-                        .expect("active TX is present after preparation")
-                        .wire_frame
-                        .clone();
-                    self.emit(
-                        IoPurpose::TransmitData,
-                        write_fifo(
-                            self.data_function(),
-                            self.registers().write_fifo,
-                            wire_frame,
-                        ),
-                    )
-                }
-                DataTxFlowPolicy::CreditGated => self.emit(
-                    IoPurpose::TransmitFlow,
-                    read_byte(self.data_function(), self.registers().flow_control),
-                ),
-            };
+            // DC bypasses flow control only for its separate command mailbox.
+            // Every data packet must obtain firmware capacity before CMD53.
+            return self.emit(
+                IoPurpose::TransmitFlow,
+                read_byte(self.data_function(), self.registers().flow_control),
+            );
         }
         AicAction::WaitForInterrupt
     }
@@ -325,7 +310,7 @@ impl AicDevice {
             .active_tx
             .as_ref()
             .ok_or(AicError::CompletionMismatch)?;
-        if credits == 0 || usize::from(credits) * BLOCK_SIZE <= active.wire_frame.len() {
+        if credits <= DATA_TX_RESERVED_CREDITS {
             self.lifecycle.retry_at = Some(now.after(IO_RETRY));
             return Ok(());
         }
@@ -825,9 +810,8 @@ mod tests {
         ));
     }
 
-    #[test]
-    fn dc_transmit_starts_without_reading_data_flow_credits() {
-        let mut device = AicDevice::new(ChipVariant::Aic8800DC).unwrap();
+    fn ready_transmitter(chip: ChipVariant, frame_len: usize) -> AicDevice {
+        let mut device = AicDevice::new(chip).unwrap();
         device.lifecycle.state = AicState::Ready;
         device.data.link.install_mac([2, 0, 0, 0, 0, 1]).unwrap();
         device.data.link.install_interface(0).unwrap();
@@ -839,14 +823,97 @@ mod tests {
         device
             .data
             .tx
-            .enqueue(TxToken::new(1), vec![0; 60])
+            .enqueue(TxToken::new(1), vec![0; frame_len])
             .unwrap();
+        device
+    }
 
-        let AicAction::SubmitSdio(request) = device.drive_ready(MonotonicTime::default()) else {
-            panic!("expected a direct DC data write")
+    #[test]
+    fn dc_data_tx_checks_firmware_credits_before_writing() {
+        let mut device = ready_transmitter(ChipVariant::Aic8800DC, 60);
+        let AicAction::SubmitSdio(request) = device.advance(AicInput {
+            now: MonotonicTime::default(),
+            event: None,
+        }) else {
+            panic!("expected a DC data credit read")
         };
-        assert!(
-            matches!(request.kind, SdioRequestKind::Write { function, .. } if function.get() == 1)
-        );
+        assert!(matches!(request.kind,
+            SdioRequestKind::ReadByte { function, address }
+            if function.get() == 1 && address.get() == 0x0a));
+    }
+
+    #[test]
+    fn data_tx_retains_packet_until_credit_reserve_is_available() {
+        // One full-sized packet consumes one firmware buffer, not three
+        // 512-byte SDIO blocks. Two buffers remain reserved for commands.
+        for chip in [ChipVariant::Aic8800D80, ChipVariant::Aic8800DC] {
+            let mut device = ready_transmitter(chip, 1414);
+            let mut now = MonotonicTime::default();
+            let mut action = device.advance(AicInput { now, event: None });
+            for credits in [0, 2, 3] {
+                let AicAction::SubmitSdio(request) = action else {
+                    panic!("expected a fresh credit read")
+                };
+                assert!(matches!(request.kind, SdioRequestKind::ReadByte { .. }));
+                action = device.advance(AicInput {
+                    now,
+                    event: Some(AicInputEvent::Sdio(SdioCompletion {
+                        request_id: request.id,
+                        result: Ok(SdioResponse::Byte(credits)),
+                    })),
+                });
+                if credits <= 2 {
+                    let AicAction::RetryAt(deadline) = action else {
+                        panic!("data TX must retain the packet while firmware buffers are reserved")
+                    };
+                    assert!(device.data.active_tx.is_some());
+                    assert!(device.data.events.is_empty());
+                    assert!(matches!(
+                        device.advance(AicInput { now, event: None }),
+                        AicAction::RetryAt(_)
+                    ));
+                    now = deadline;
+                    action = device.advance(AicInput { now, event: None });
+                }
+            }
+            let AicAction::SubmitSdio(write) = action else {
+                panic!("three packet credits must permit one full-sized data frame")
+            };
+            assert!(
+                matches!(&write.kind, SdioRequestKind::Write { bytes, .. } if bytes.len() == 1536)
+            );
+            let complete = device.advance(AicInput {
+                now,
+                event: Some(AicInputEvent::Sdio(SdioCompletion {
+                    request_id: write.id,
+                    result: Ok(SdioResponse::Unit),
+                })),
+            });
+            assert!(
+                matches!(complete, AicAction::Event(AicEvent::TransmitComplete(token)) if token == TxToken::new(1))
+            );
+            assert!(device.data.active_tx.is_none());
+            assert!(matches!(
+                device.advance(AicInput { now, event: None }),
+                AicAction::WaitForInterrupt
+            ));
+            let next = device.advance(AicInput {
+                now,
+                event: Some(AicInputEvent::Tx {
+                    token: TxToken::new(2),
+                    frame: vec![0; 60],
+                }),
+            });
+            assert!(
+                matches!(
+                    next,
+                    AicAction::SubmitSdio(SdioRequest {
+                        kind: SdioRequestKind::ReadByte { .. },
+                        ..
+                    })
+                ),
+                "each packet requires a fresh firmware credit check"
+            );
+        }
     }
 }

--- a/drivers/net/aic8800/src/device/progress.rs
+++ b/drivers/net/aic8800/src/device/progress.rs
@@ -270,10 +270,6 @@ impl AicDevice {
         self.profile.mailbox_flow()
     }
 
-    pub(super) const fn data_tx_flow_policy(&self) -> crate::profile::DataTxFlowPolicy {
-        self.profile.data_tx_flow()
-    }
-
     pub(super) const fn startup_function(&self, index: usize) -> Option<u8> {
         self.profile.function(index)
     }

--- a/drivers/net/aic8800/src/profile.rs
+++ b/drivers/net/aic8800/src/profile.rs
@@ -32,12 +32,6 @@ pub(crate) enum MailboxFlowPolicy {
     CreditGated,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) enum DataTxFlowPolicy {
-    Direct,
-    CreditGated,
-}
-
 pub(crate) struct ChipProfile {
     variant: ChipVariant,
     registers: RegisterMap,
@@ -46,7 +40,6 @@ pub(crate) struct ChipProfile {
     transport: TransportGeneration,
     transport_header: TransportHeader,
     mailbox_flow: MailboxFlowPolicy,
-    data_tx_flow: DataTxFlowPolicy,
     firmware: FirmwareProfile,
     functions: &'static [u8],
 }
@@ -95,10 +88,6 @@ impl ChipProfile {
         self.mailbox_flow
     }
 
-    pub(crate) const fn data_tx_flow(&self) -> DataTxFlowPolicy {
-        self.data_tx_flow
-    }
-
     pub(crate) const fn function(&self, index: usize) -> Option<u8> {
         if index < self.functions.len() {
             Some(self.functions[index])
@@ -119,7 +108,6 @@ static AIC8800DC_PROFILE: ChipProfile = ChipProfile {
     transport: TransportGeneration::V1,
     transport_header: TransportHeader::Zero,
     mailbox_flow: MailboxFlowPolicy::Direct,
-    data_tx_flow: DataTxFlowPolicy::Direct,
     firmware: FirmwareProfile::Aic8800Dc,
     functions: DC_FUNCTIONS,
 };
@@ -132,7 +120,6 @@ static AIC8800D80_PROFILE: ChipProfile = ChipProfile {
     transport: TransportGeneration::V3,
     transport_header: TransportHeader::Crc8,
     mailbox_flow: MailboxFlowPolicy::CreditGated,
-    data_tx_flow: DataTxFlowPolicy::CreditGated,
     firmware: FirmwareProfile::Aic8800D80,
     functions: D80_FUNCTIONS,
 };


### PR DESCRIPTION
## 问题与根因

PR #2300 已变基到包含 #2299 的 `dev`，但 [AKA-00 SG2002 板测](https://github.com/rcore-os/tgoskits/actions/runs/34183307570/job/101927576535)仍在正式传输开头连续 4 秒出现零传输，之后才恢复到数 Mbit/s。这不是变基遗漏：#2299 修复了卡中断重新启用和协议任务占用 CPU 的问题，数据发送还存在独立的固件流控缺口。

AIC8800DC 的 `DataTxFlowPolicy::Direct` 把命令邮箱的流控例外扩展到了普通数据 FIFO，数据写入前没有检查固件是否还有接收缓冲。SDIO 传输完成只表示总线写入结束，不代表固件有能力保留并发出该包；持续发送或初始突发可能超过固件容量，随后依赖 TCP 重传恢复。

对照固定版本荔枝派 BSP：

- [`aicwf_sdio_tx_msg`](https://github.com/sipeed/LicheeRV-Nano-Build/blob/d4003f15b35d43ad4842f427050ab2bba0114fa5/osdrv/extdrv/wireless/aic8800/aic8800_fdrv/aicwf_sdio.c#L1835-L1869)仅为 DC 的命令发送保留直接写入路径。
- [`aicwf_sdio_tx_process` 与 `aicwf_sdio_send`](https://github.com/sipeed/LicheeRV-Nano-Build/blob/d4003f15b35d43ad4842f427050ab2bba0114fa5/osdrv/extdrv/wireless/aic8800/aic8800_fdrv/aicwf_sdio.c#L1929-L1952)对普通数据检查可用 credit，并按聚合包数扣减，而不是按 SDIO 块数扣减。
- [`DATA_FLOW_CTRL_THRESH`](https://github.com/sipeed/LicheeRV-Nano-Build/blob/d4003f15b35d43ad4842f427050ab2bba0114fa5/osdrv/extdrv/wireless/aic8800/aic8800_fdrv/aicwf_sdio.h#L59)要求保留两个缓冲。

## 修改

- 所有已支持芯片的数据发送先读取本数据功能的 credit，再提交一包 CMD53 写入。删除没有合法使用者的数据直写策略，保留独立的命令邮箱策略。
- credit 按固件包缓冲计数，单包发送要求剩余数量大于 2；不再用 `credits * 512` 与 SDIO 传输长度比较。
- 缓冲不足时保留同一个在途包及完成 token，通过已有的 `RetryAt` 和 owner 运行时继续推进；未写入时不提前发布发送完成。
- 驱动继续与 OS 无关，不新增线程、休眠接口或调度依赖。保留 #2299 的修复和原有 20 秒持续传输判定，不放宽三秒停顿检查。

## 验证

确定性回归先红后绿：

- DC 的第一步必须读取 function 1 的 `0x0a` credit，旧实现直接写 FIFO，断言失败。
- 对 DC/D80 分别输入 0、2、3 个 credit：前两种保留包并返回重试期限；3 个 credit 允许一个 1536 字节的传输，旧实现把 credit 当成 512 字节块而继续等待，断言失败。
- 验证重复推进不提前完成、SDIO 写完成只归还一次 token、下一包必须重新取得 credit。
- `cargo xtask test --since origin/dev`，并在目标组合上执行 `cargo xtask test --since 94487ed861`：AIC8800 的 112 项核心测试、2 项集成测试通过。
- `cargo xtask clippy --package aic8800`：3 组检查通过；`cargo fmt`、差异检查通过。
- `cargo xtask sync-lint --since origin/dev`、`cargo publish -p aic8800 --dry-run --no-verify`：通过。

实机验证使用同一块 AKA-00 SG2002、同一 AP 和官方 iperf3 3.21，保持 `-t 20 -O 2 -P 1 -l 128K`。第一次带补丁的长测通过，每个正式区间都有进展，接收吞吐 5.54 Mbit/s，接收统计时长 20.25 秒。另在 PR #2300 的精确失败提交 `94487ed861` 上叠加同一补丁执行完整板测，boot、tennis-yolo、usb2-lsusb、wifi-iperf-smoke 共 4 项全部通过，Wi-Fi 接收吞吐为 5.02 Mbit/s、接收统计时长 20.28 秒。该验证组合提交为 `5e48cefbab`；驱动源码与本 PR 完全相同。

D80 的证据来自真实核心状态机测试和 BSP 对照；本次实机为 DC。

远端提交 `887c8df79f` 的 [AKA-00 SG2002 CI 作业](https://github.com/rcore-os/tgoskits/actions/runs/34187542092/job/101939786244)于 2026-09-08 04:51:25 UTC 完成并成功：4 项板测通过，20 个正式统计区间均有传输，接收吞吐 5.02 Mbit/s。整体 CI 的其余作业仍在运行或排队。
