### PR TITLE
fix(net): preserve ARP replies and stabilize board WiFi tests

### DIFF
--- a/.github/ci/iperf2.service
+++ b/.github/ci/iperf2.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=iperf2 shared board test server
+After=network.target
+
+[Service]
+Type=simple
+DynamicUser=yes
+ExecStart=/usr/bin/iperf --server --port 5001 --interval 1
+Restart=always
+RestartSec=2
+
+[Install]
+WantedBy=multi-user.target

--- a/drivers/net/aic8800/src/device/data_plane.rs
+++ b/drivers/net/aic8800/src/device/data_plane.rs
@@ -229,6 +229,17 @@ impl AicDevice {
                     message_id: SM_CONNECT_IND,
                     payload,
                 } => {
+                    // Firmware can leave an asynchronous association result in
+                    // the FIFO across host restart. Startup has no connection
+                    // transaction: its owner is handed to the network runtime
+                    // before a new Connect request can be submitted. Do not
+                    // interpret the old status or install its peer identity.
+                    if self.lifecycle.state == AicState::Starting {
+                        log::debug!(
+                            "[wifi] discarded pre-connection association indication during startup"
+                        );
+                        continue;
+                    }
                     let indication = parse_connect_indication(&payload)?;
                     log::info!(
                         "[wifi] association complete; learned firmware vif={} station={}",
@@ -612,6 +623,75 @@ mod tests {
         frame[header_len + 6..header_len + 8].copy_from_slice(&[0x08, 0x00]);
         frame[header_len + 8..].copy_from_slice(payload);
         frame
+    }
+
+    #[test]
+    fn startup_ignores_unowned_connect_results_and_keeps_mailbox_confirmation() {
+        for status in [1u16, 0] {
+            let mut device = AicDevice::new(ChipVariant::Aic8800DC).unwrap();
+            device.start(MonotonicTime::default()).unwrap();
+            device.lifecycle.mailbox =
+                Some(super::super::mailbox::MailboxState::confirmation_for_test(
+                    MonotonicTime::from_nanos(5_000_000_000),
+                ));
+            let mut payload = vec![0; 11];
+            payload[..2].copy_from_slice(&status.to_le_bytes());
+            let mut fifo = indication_fifo(SM_CONNECT_IND, &payload);
+            fifo.extend(indication_fifo(2, &[]));
+            device.io.pending = Some(PendingIo {
+                id: 7,
+                purpose: IoPurpose::ReceiveData(RxPath::Command),
+            });
+            let action = device.advance(AicInput {
+                now: MonotonicTime::default(),
+                event: Some(AicInputEvent::Sdio(SdioCompletion {
+                    request_id: 7,
+                    result: Ok(SdioResponse::Data(fifo)),
+                })),
+            });
+            assert!(
+                matches!(action, AicAction::SubmitSdio(_)),
+                "unowned connection result stopped startup: {action:?}"
+            );
+            assert_eq!(device.state(), AicState::Starting);
+            assert!(device.data.link.peer().is_none());
+            assert_eq!(
+                device.accept_mailbox_confirmation(2, Vec::new()),
+                Err(AicError::CompletionMismatch)
+            );
+        }
+    }
+
+    #[test]
+    fn active_connect_rejection_is_not_discarded_as_a_startup_indication() {
+        let mut device = ready_transmitter(ChipVariant::Aic8800DC, 60);
+        let mut control = super::super::control::build(
+            ControlRequest::Connect {
+                ssid: b"network".to_vec(),
+                pmk: None,
+                entropy: None,
+            },
+            [2, 0, 0, 0, 0, 1],
+            Some(0),
+        )
+        .unwrap();
+        if let super::super::control::ControlOperation::Connect(connect) = &mut control.operation {
+            connect.phase = super::super::control::ConnectPhase::AwaitIndication;
+        }
+        control.commands.clear();
+        device.lifecycle.control = Some(control);
+        let mut payload = vec![0; 11];
+        payload[0] = 1;
+        assert_eq!(
+            device.consume_receive_data(
+                RxPath::Command,
+                SdioResponse::Data(indication_fifo(SM_CONNECT_IND, &payload)),
+            ),
+            Err(AicError::FirmwareRejected {
+                message_id: SM_CONNECT_IND,
+                status: 1
+            })
+        );
     }
 
     #[test]

--- a/net/ax-net/src/device/ethernet.rs
+++ b/net/ax-net/src/device/ethernet.rs
@@ -20,7 +20,7 @@
 //! and does not inspect TCP/UDP socket state. Route selection is performed by
 //! the router before Ethernet sees the packet.
 
-use alloc::{boxed::Box, string::String, vec, vec::Vec};
+use alloc::{boxed::Box, collections::VecDeque, string::String, vec, vec::Vec};
 
 use hashbrown::HashMap;
 use smoltcp::{
@@ -59,6 +59,9 @@ pub struct EthernetDevice {
     ip: Option<Ipv4Cidr>,
 
     pending_packets: PacketBuffer<'static, IpAddress>,
+    /// Replies owned by the protocol executor until TX space is available.
+    /// A full data queue must not prevent a peer from resolving our address.
+    pending_arp_replies: VecDeque<(EthernetAddress, ArpRepr)>,
     /// Individual L2 frame lengths of packets transmitted on a side path
     /// during ARP resolution (inside `recv()`/`process_arp()`). Drained by
     /// the protocol executor via [`Device::drain_deferred_tx`].
@@ -115,6 +118,7 @@ impl EthernetDevice {
             ip,
 
             pending_packets,
+            pending_arp_replies: VecDeque::new(),
             deferred_tx_frame_lens: Vec::new(),
             deferred_rx_frame_lens: Vec::new(),
             deferred_tx_errors: 0,
@@ -134,6 +138,9 @@ impl EthernetDevice {
         destination: EthernetAddress,
         packet: &[u8],
     ) -> NetDeviceResult<usize> {
+        if !self.flush_arp_replies() {
+            return Err(NetDeviceError::Again);
+        }
         let protocol = match IpVersion::of_packet(packet) {
             Ok(IpVersion::Ipv4) => EthernetProtocol::Ipv4,
             Ok(IpVersion::Ipv6) => EthernetProtocol::Ipv6,
@@ -214,6 +221,27 @@ impl EthernetDevice {
             &mut fill,
         )?;
         Ok(wire_len)
+    }
+
+    fn flush_arp_replies(&mut self) -> bool {
+        while let Some((destination, reply)) = self.pending_arp_replies.front().copied() {
+            match Self::send_to(
+                &mut *self.inner,
+                destination,
+                reply.buffer_len(),
+                |buffer| reply.emit(&mut ArpPacket::new_unchecked(buffer)),
+                EthernetProtocol::Arp,
+            ) {
+                Ok(frame_len) => self.deferred_tx_frame_lens.push(frame_len),
+                Err(NetDeviceError::Again) => return false,
+                Err(error) => {
+                    warn!("{}: failed to send ARP reply: {error:?}", self.name);
+                    self.deferred_tx_errors += 1;
+                }
+            }
+            self.pending_arp_replies.pop_front();
+        }
+        true
     }
 
     /// Parses and handles a single Ethernet frame.
@@ -401,23 +429,17 @@ impl EthernetDevice {
                     target_protocol_addr: source_protocol_addr,
                 };
 
-                let arp_frame_len = Self::send_to(
-                    &mut *self.inner,
-                    source_hardware_addr,
-                    response.buffer_len(),
-                    |buf| response.emit(&mut ArpPacket::new_unchecked(buf)),
-                    EthernetProtocol::Arp,
-                );
-                // ARP replies are successfully transmitted L2 frames — record
-                // their length so the protocol executor can count them in TX stats.
-                match arp_frame_len {
-                    Ok(frame_len) => self.deferred_tx_frame_lens.push(frame_len),
-                    Err(NetDeviceError::Again) => self.deferred_tx_drops += 1,
-                    Err(err) => {
-                        warn!("{}: failed to send ARP reply: {err:?}", self.name);
-                        self.deferred_tx_errors += 1;
+                // Coalesce repeated probes while blocked, and bound storage
+                // independently of the number of peers sending requests.
+                let reply = (source_hardware_addr, response);
+                if !self.pending_arp_replies.contains(&reply) {
+                    if self.pending_arp_replies.len() < ETHERNET_MAX_PENDING_PACKETS {
+                        self.pending_arp_replies.push_back(reply);
+                    } else {
+                        self.deferred_tx_drops += 1;
                     }
                 }
+                self.flush_arp_replies();
             }
 
             // Drain every entry in the pending queue and either send it (if
@@ -514,6 +536,9 @@ impl Device for EthernetDevice {
         timestamp: Instant,
         snoop: &mut dyn FnMut(&[u8]),
     ) -> usize {
+        // TX completions already wake the protocol executor. Retry control
+        // traffic on that poll even if no new RX packet or IP send arrives.
+        self.flush_arp_replies();
         loop {
             let rx_buf = match self.inner.receive() {
                 Ok(buf) => buf,
@@ -540,6 +565,7 @@ impl Device for EthernetDevice {
     }
 
     fn poll_owned_rx(&mut self, timestamp: Instant) -> DeviceRxPoll {
+        self.flush_arp_replies();
         loop {
             let frame = match self.inner.receive_owned() {
                 Ok(Some(frame)) => frame,
@@ -605,6 +631,7 @@ impl Device for EthernetDevice {
         deliver: &mut dyn FnMut(&[u8]) -> bool,
         snoop: &mut dyn FnMut(&[u8]),
     ) -> Option<usize> {
+        self.flush_arp_replies();
         loop {
             let hardware_address = self.hardware_address();
             let mut side_frame = None;
@@ -775,6 +802,8 @@ impl Device for EthernetDevice {
         self.ip = addr;
         self.neighbors.clear();
         self.pending_neighbors.clear();
+        self.deferred_tx_drops += self.pending_arp_replies.len() as u64;
+        self.pending_arp_replies.clear();
         // The deferred TX/RX frame-length accumulators are deliberately left
         // intact. They hold L2 frames that were already successfully
         // transmitted to or received from the device before this call; those
@@ -882,6 +911,8 @@ mod ethernet_counter_tests {
     struct TxProbe {
         requests: SpinLock<Vec<(Vec<u8>, TxSubmitOptions)>>,
         failure: SpinLock<Option<NetDeviceError>>,
+        rx_frames: SpinLock<VecDeque<Vec<u8>>>,
+        blocked: SpinLock<bool>,
     }
 
     struct RecordingFramePort {
@@ -903,6 +934,9 @@ mod ethernet_counter_tests {
         }
 
         fn transmit(&mut self, frame: &ProtocolEthernetFrame) -> NetDeviceResult {
+            if *self.probe.blocked.lock_irqsave() {
+                return Err(NetDeviceError::Again);
+            }
             if let Some(error) = self.probe.failure.lock_irqsave().take() {
                 return Err(error);
             }
@@ -919,6 +953,9 @@ mod ethernet_counter_tests {
             options: TxSubmitOptions,
             fill: &mut dyn FnMut(&mut [u8]),
         ) -> NetDeviceResult {
+            if *self.probe.blocked.lock_irqsave() {
+                return Err(NetDeviceError::Again);
+            }
             if let Some(error) = self.probe.failure.lock_irqsave().take() {
                 return Err(error);
             }
@@ -929,7 +966,12 @@ mod ethernet_counter_tests {
         }
 
         fn receive(&mut self) -> NetDeviceResult<ProtocolEthernetFrame> {
-            Err(NetDeviceError::Again)
+            self.probe
+                .rx_frames
+                .lock_irqsave()
+                .pop_front()
+                .map(|packet| ProtocolEthernetFrame::copy_from_slice(&packet).unwrap())
+                .ok_or(NetDeviceError::Again)
         }
     }
 
@@ -1148,6 +1190,132 @@ mod ethernet_counter_tests {
         assert_eq!(tx_lens.len(), 1); // ARP reply TX
         // ARP reply over Ethernet: 14 (eth hdr) + 28 (ARP) = 42 → padded to 60.
         assert_eq!(tx_lens[0], 60);
+    }
+
+    #[test]
+    fn arp_reply_survives_tx_backpressure_and_precedes_bulk_ip() {
+        let (mut device, probe) = make_recording_device(TxChecksumCapabilities::NONE);
+        probe.rx_frames.lock_irqsave().push_back(build_arp_frame(
+            ArpOperation::Request,
+            REMOTE_MAC,
+            DEV_MAC,
+            REMOTE_IP,
+            DEV_IP,
+            EMPTY_MAC.0,
+        ));
+        *probe.failure.lock_irqsave() = Some(NetDeviceError::Again);
+        device.recv(
+            InterfaceId::new(1),
+            &mut test_packet_buffer(),
+            Instant::ZERO,
+            &mut |_| {},
+        );
+
+        let packet = raw_tcp_packet();
+        device
+            .try_send(IpAddress::Ipv4(REMOTE_IP), &packet, Instant::ZERO)
+            .unwrap();
+
+        let requests = probe.requests.lock_irqsave();
+        assert_eq!(requests.len(), 2, "queue pressure lost the ARP reply");
+        let reply = EthernetFrame::new_checked(&requests[0].0).unwrap();
+        assert_eq!(reply.ethertype(), EthernetProtocol::Arp);
+        assert_eq!(reply.dst_addr(), EthernetAddress(REMOTE_MAC));
+        assert_eq!(
+            ArpRepr::parse(&ArpPacket::new_checked(reply.payload()).unwrap()).unwrap(),
+            ArpRepr::EthernetIpv4 {
+                operation: ArpOperation::Reply,
+                source_hardware_addr: EthernetAddress(DEV_MAC),
+                source_protocol_addr: DEV_IP,
+                target_hardware_addr: EthernetAddress(REMOTE_MAC),
+                target_protocol_addr: REMOTE_IP,
+            }
+        );
+        assert_eq!(requests[0].1.notify, TxNotify::Immediate);
+        assert_eq!(&requests[1].0[14..], &packet);
+        drop(requests);
+        assert_eq!(device.drain_deferred_tx(), vec![ETH_ZLEN]);
+        assert_eq!(device.drain_deferred_tx_drops(), 0);
+    }
+
+    #[test]
+    fn arp_reply_retries_on_tx_completion_poll_without_new_rx() {
+        for receive_path in 0..3 {
+            let (mut device, probe) = make_recording_device(TxChecksumCapabilities::NONE);
+            *probe.blocked.lock_irqsave() = true;
+            for _ in 0..3 {
+                probe.rx_frames.lock_irqsave().push_back(build_arp_frame(
+                    ArpOperation::Request,
+                    REMOTE_MAC,
+                    DEV_MAC,
+                    REMOTE_IP,
+                    DEV_IP,
+                    EMPTY_MAC.0,
+                ));
+            }
+            let mut buffer = test_packet_buffer();
+            device.recv(InterfaceId::new(1), &mut buffer, Instant::ZERO, &mut |_| {});
+            *probe.blocked.lock_irqsave() = false;
+
+            match receive_path {
+                0 => {
+                    device.recv(InterfaceId::new(1), &mut buffer, Instant::ZERO, &mut |_| {});
+                }
+                1 => {
+                    let _ = device.poll_owned_rx(Instant::ZERO);
+                }
+                _ => {
+                    let _ = device.recv_direct(Instant::ZERO, &mut |_| false, &mut |_| {});
+                }
+            }
+
+            let requests = probe.requests.lock_irqsave();
+            assert_eq!(
+                requests.len(),
+                1,
+                "poll path {receive_path} lost or duplicated the reply"
+            );
+            let frame = EthernetFrame::new_checked(&requests[0].0).unwrap();
+            assert_eq!(frame.ethertype(), EthernetProtocol::Arp);
+            assert_eq!(frame.dst_addr(), EthernetAddress(REMOTE_MAC));
+            drop(requests);
+            assert_eq!(device.drain_deferred_tx(), vec![ETH_ZLEN]);
+            assert_eq!(device.drain_deferred_tx_drops(), 0);
+        }
+    }
+
+    #[test]
+    fn pending_arp_replies_are_bounded_and_cancelled_on_address_change() {
+        let (mut device, probe) = make_recording_device(TxChecksumCapabilities::NONE);
+        *probe.blocked.lock_irqsave() = true;
+        for index in 0..=ETHERNET_MAX_PENDING_PACKETS {
+            probe.rx_frames.lock_irqsave().push_back(build_arp_frame(
+                ArpOperation::Request,
+                REMOTE_MAC,
+                DEV_MAC,
+                Ipv4Address::from((0x0a00_0101 + index as u32).to_be_bytes()),
+                DEV_IP,
+                EMPTY_MAC.0,
+            ));
+        }
+        device.recv(
+            InterfaceId::new(1),
+            &mut test_packet_buffer(),
+            Instant::ZERO,
+            &mut |_| {},
+        );
+        assert_eq!(device.drain_deferred_tx_drops(), 1);
+        device.set_ipv4_addr(None);
+        *probe.blocked.lock_irqsave() = false;
+        let _ = device.poll_owned_rx(Instant::ZERO);
+        assert!(
+            probe.requests.lock_irqsave().is_empty(),
+            "sent replies for a removed address"
+        );
+        assert_eq!(
+            device.drain_deferred_tx_drops(),
+            ETHERNET_MAX_PENDING_PACKETS as u64
+        );
     }
 
     #[test]

--- a/scripts/axbuild/src/starry/test/tests.rs
+++ b/scripts/axbuild/src/starry/test/tests.rs
@@ -258,73 +258,111 @@ fn write_test_image_config(workspace_root: &Path) {
 
 #[cfg(unix)]
 #[test]
-fn aka_wifi_smoke_requires_sustained_progress_and_propagates_iperf_failure() {
+fn board_iperf2_smoke_requires_both_directions_and_propagates_failure() {
     let fake_bin = tempdir().unwrap();
-    let invocation_log = fake_bin.path().join("iperf3-invocations");
+    let invocation_log = fake_bin.path().join("iperf-invocations");
     let ip = fake_bin.path().join("ip");
-    let iperf3 = fake_bin.path().join("iperf3");
-
+    let iperf = fake_bin.path().join("iperf");
+    let legacy_iperf = fake_bin.path().join("iperf3");
+    fs::write(&legacy_iperf, "#!/bin/sh\nexit 99\n").unwrap();
     fs::write(&ip, "#!/bin/sh\necho '2: wlan0    inet 192.0.2.2/24'\n").unwrap();
     fs::write(
-        &iperf3,
+        &iperf,
         "#!/bin/sh\nprintf '%s\\n' \"$*\" >\"$IPERF_INVOCATION_LOG\"\nprintf '%s\\n' \
          \"$IPERF_OUTPUT\"\nexit \"$IPERF_STATUS\"\n",
     )
     .unwrap();
-    for executable in [&ip, &iperf3] {
+    for executable in [&ip, &iperf, &legacy_iperf] {
         fs::set_permissions(executable, fs::Permissions::from_mode(0o755)).unwrap();
     }
-
-    let script = Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join("../../test-suit/starryos/board-aka-00-sg2002/wifi-iperf-smoke/iperf-smoke.sh");
-    let report = |stalled: bool| {
-        let mut report = "[  5] 0.00-4.00 sec 0 Bytes 0 bits/sec (omitted)\n".to_owned();
-        for second in 0..20 {
-            let transferred = if second == 10 || (stalled && (8..12).contains(&second)) {
-                0
-            } else {
-                512
-            };
-            report.push_str(&format!(
-                "[  5] {second}.00-{}.00 sec {transferred} KBytes 0 bits/sec\n",
-                second + 1
-            ));
-        }
-        report.push_str("[  5] 0.00-20.00 sec 8 MBytes 3.36 Mbits/sec sender\n");
-        report.push_str("[  5] 0.00-20.10 sec 8 MBytes 3.34 Mbits/sec receiver\n");
-        report
-    };
-    for (name, report, status, expected) in [
-        ("progress with one empty interval", report(false), "0", true),
-        ("successful exit after a stall", report(true), "0", false),
-        ("no report", String::new(), "0", false),
-        ("iperf error after progress", report(false), "1", false),
+    let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../test-suit/starryos");
+    std::os::unix::fs::symlink(
+        root.join("board-common/iperf2/iperf2-smoke"),
+        fake_bin.path().join("iperf2-smoke"),
+    )
+    .unwrap();
+    for (case, duration, warmup, marker) in [
+        (
+            "board-aka-00-sg2002/wifi-iperf-smoke",
+            22,
+            2,
+            "STARRY_AKA_WIFI_IPERF_SMOKE",
+        ),
+        (
+            "board-orangepi-5-plus/native-network-smoke",
+            4,
+            1,
+            "STARRY_IPERF_SMOKE",
+        ),
     ] {
-        let output = Command::new("/bin/sh")
-            .arg(&script)
-            .arg("192.0.2.1")
-            .env(
-                "PATH",
-                format!("{}:/usr/bin:/bin", fake_bin.path().display()),
-            )
-            .env("IPERF_INVOCATION_LOG", &invocation_log)
-            .env("IPERF_OUTPUT", report)
-            .env("IPERF_STATUS", status)
-            .output()
-            .unwrap();
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        assert_eq!(output.status.success(), expected, "{name}: {stdout}");
-        assert_eq!(
-            stdout.contains("STARRY_AKA_WIFI_IPERF_SMOKE_PASSED"),
-            expected
-        );
-        assert_eq!(
-            stdout.contains("STARRY_AKA_WIFI_IPERF_SMOKE_FAILED"),
-            !expected
-        );
-        assert_eq!(
-            fs::read_to_string(&invocation_log).unwrap(),
-            "-c 192.0.2.1 -t 20 -O 2 -P 1 -l 128K\n"
-        );
+        let report = |stalled_direction: Option<&str>, omit_receive: bool, short: bool| {
+            let mut output = String::new();
+            for direction in [" 1", "*1"] {
+                if omit_receive && direction == "*1" {
+                    continue;
+                }
+                for second in 0..duration {
+                    let bytes = if second < warmup
+                        || (stalled_direction == Some(direction)
+                            && second >= warmup
+                            && second < warmup + 3)
+                    {
+                        0
+                    } else {
+                        524288
+                    };
+                    output.push_str(&format!(
+                        "[ {direction}] {second}.0000-{}.0000 sec {bytes} Bytes 4194304 bits/sec\n",
+                        second + 1
+                    ));
+                }
+                let end = if short { 1 } else { duration };
+                output.push_str(&format!(
+                    "[ {direction}] 0.0000-{end}.0200 sec 8388608 Bytes 3355443 bits/sec\n"
+                ));
+            }
+            output
+        };
+        for (name, report, status, expected) in [
+            (
+                "bidirectional progress",
+                report(None, false, false),
+                "0",
+                true,
+            ),
+            ("TX stall", report(Some(" 1"), false, false), "0", false),
+            ("RX stall", report(Some("*1"), false, false), "0", false),
+            ("missing RX", report(None, true, false), "0", false),
+            ("short transfer", report(None, false, true), "0", false),
+            ("empty report", String::new(), "0", false),
+            ("iperf error", report(None, false, false), "1", false),
+        ] {
+            let output = Command::new("/bin/sh")
+                .arg(root.join(case).join("iperf-smoke.sh"))
+                .arg("192.0.2.1")
+                .env(
+                    "PATH",
+                    format!("{}:/usr/bin:/bin", fake_bin.path().display()),
+                )
+                .env("IPERF_INVOCATION_LOG", &invocation_log)
+                .env("IPERF_OUTPUT", report)
+                .env("IPERF_STATUS", status)
+                .output()
+                .unwrap();
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            assert_eq!(
+                output.status.success(),
+                expected,
+                "{case}: {name}: {stdout}"
+            );
+            assert_eq!(stdout.contains(&format!("{marker}_PASSED")), expected);
+            assert_eq!(stdout.contains(&format!("{marker}_FAILED")), !expected);
+            assert_eq!(
+                fs::read_to_string(&invocation_log).unwrap(),
+                format!(
+                    "-c 192.0.2.1 -p 5001 -t {duration} -i 1 -P 1 -l 128K -f b --full-duplex\n"
+                )
+            );
+        }
     }
 }

--- a/scripts/axbuild/src/starry/test/tests.rs
+++ b/scripts/axbuild/src/starry/test/tests.rs
@@ -11,13 +11,10 @@ mod qemu_discovery_tests;
 
 mod qemu_run_tests;
 
-#[cfg(unix)]
-use std::os::unix::fs::PermissionsExt;
 use std::{
     collections::BTreeSet,
     fs,
     path::{Path, PathBuf},
-    process::Command,
 };
 
 use ostool::run::qemu::QemuConfig;
@@ -254,115 +251,4 @@ fn write_test_image_config(workspace_root: &Path) {
         extract_dir: workspace_root.join(".tgos-images"),
     };
     crate::image::config::ImageConfig::write_config(workspace_root, &config).unwrap();
-}
-
-#[cfg(unix)]
-#[test]
-fn board_iperf2_smoke_requires_both_directions_and_propagates_failure() {
-    let fake_bin = tempdir().unwrap();
-    let invocation_log = fake_bin.path().join("iperf-invocations");
-    let ip = fake_bin.path().join("ip");
-    let iperf = fake_bin.path().join("iperf");
-    let legacy_iperf = fake_bin.path().join("iperf3");
-    fs::write(&legacy_iperf, "#!/bin/sh\nexit 99\n").unwrap();
-    fs::write(&ip, "#!/bin/sh\necho '2: wlan0    inet 192.0.2.2/24'\n").unwrap();
-    fs::write(
-        &iperf,
-        "#!/bin/sh\nprintf '%s\\n' \"$*\" >\"$IPERF_INVOCATION_LOG\"\nprintf '%s\\n' \
-         \"$IPERF_OUTPUT\"\nexit \"$IPERF_STATUS\"\n",
-    )
-    .unwrap();
-    for executable in [&ip, &iperf, &legacy_iperf] {
-        fs::set_permissions(executable, fs::Permissions::from_mode(0o755)).unwrap();
-    }
-    let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../test-suit/starryos");
-    std::os::unix::fs::symlink(
-        root.join("board-common/iperf2/iperf2-smoke"),
-        fake_bin.path().join("iperf2-smoke"),
-    )
-    .unwrap();
-    for (case, duration, warmup, marker) in [
-        (
-            "board-aka-00-sg2002/wifi-iperf-smoke",
-            22,
-            2,
-            "STARRY_AKA_WIFI_IPERF_SMOKE",
-        ),
-        (
-            "board-orangepi-5-plus/native-network-smoke",
-            4,
-            1,
-            "STARRY_IPERF_SMOKE",
-        ),
-    ] {
-        let report = |stalled_direction: Option<&str>, omit_receive: bool, short: bool| {
-            let mut output = String::new();
-            for direction in [" 1", "*1"] {
-                if omit_receive && direction == "*1" {
-                    continue;
-                }
-                for second in 0..duration {
-                    let bytes = if second < warmup
-                        || (stalled_direction == Some(direction)
-                            && second >= warmup
-                            && second < warmup + 3)
-                    {
-                        0
-                    } else {
-                        524288
-                    };
-                    output.push_str(&format!(
-                        "[ {direction}] {second}.0000-{}.0000 sec {bytes} Bytes 4194304 bits/sec\n",
-                        second + 1
-                    ));
-                }
-                let end = if short { 1 } else { duration };
-                output.push_str(&format!(
-                    "[ {direction}] 0.0000-{end}.0200 sec 8388608 Bytes 3355443 bits/sec\n"
-                ));
-            }
-            output
-        };
-        for (name, report, status, expected) in [
-            (
-                "bidirectional progress",
-                report(None, false, false),
-                "0",
-                true,
-            ),
-            ("TX stall", report(Some(" 1"), false, false), "0", false),
-            ("RX stall", report(Some("*1"), false, false), "0", false),
-            ("missing RX", report(None, true, false), "0", false),
-            ("short transfer", report(None, false, true), "0", false),
-            ("empty report", String::new(), "0", false),
-            ("iperf error", report(None, false, false), "1", false),
-        ] {
-            let output = Command::new("/bin/sh")
-                .arg(root.join(case).join("iperf-smoke.sh"))
-                .arg("192.0.2.1")
-                .env(
-                    "PATH",
-                    format!("{}:/usr/bin:/bin", fake_bin.path().display()),
-                )
-                .env("IPERF_INVOCATION_LOG", &invocation_log)
-                .env("IPERF_OUTPUT", report)
-                .env("IPERF_STATUS", status)
-                .output()
-                .unwrap();
-            let stdout = String::from_utf8_lossy(&output.stdout);
-            assert_eq!(
-                output.status.success(),
-                expected,
-                "{case}: {name}: {stdout}"
-            );
-            assert_eq!(stdout.contains(&format!("{marker}_PASSED")), expected);
-            assert_eq!(stdout.contains(&format!("{marker}_FAILED")), !expected);
-            assert_eq!(
-                fs::read_to_string(&invocation_log).unwrap(),
-                format!(
-                    "-c 192.0.2.1 -p 5001 -t {duration} -i 1 -P 1 -l 128K -f b --full-duplex\n"
-                )
-            );
-        }
-    }
 }

--- a/test-suit/starryos/GUIDE.md
+++ b/test-suit/starryos/GUIDE.md
@@ -547,13 +547,37 @@ cargo xtask starry app board -t iperf3 -b OrangePi-5-Plus
 ```
 
 `native-hardware-smoke` 在一次启动中依次验证启动、PCIe、USB2、PWM 和 NPU。
-`native-network-smoke` 只执行一条短 TCP TX 命令，随后在 `eth1` 上验证 rtnetlink
+`native-network-smoke` 执行一条短 TCP 双向命令，随后在 `eth1` 上验证 rtnetlink
 地址增删，适合作为 CI 连通性检查。完整吞吐测试位于 `apps/starry/iperf3`，直接通过
 上面的 `cargo xtask starry app board` 命令启动板测；ostool server 持续提供 iperf3
 服务，board 配置的 `shell_init_cmd` 通过活动 session 的 `${boardServerIp}` 和
 `${sessionFile:iperf-bench.sh}` 获取实际地址；app 的 `init.sh` 会按现有 xtask 流程合并
 到该命令中，下载并启动测试脚本，不依赖固定网卡、固定 IP、固定网段或额外的板测
 启动脚本。
+
+真板卡 CI 的 AKA WiFi 与 OrangePi 网络冒烟统一使用 iperf2，共享 TCP 5001
+服务端口；iperf2 服务进程接受多个独立客户端。`board-common/iperf2` 提供公共脚本
+和打包规则，各 case 的 `c/prebuild.sh` 在 Alpine 暂存环境安装 `iperf`，CMake 将
+客户端、musl 加载器及匹配的 C++ 运行库打包为 `share/iperf2.tar.gz`。板卡通过
+`${sessionFile:share/iperf2.tar.gz}` 下载到 `/tmp`，不要求预装客户端或修改持久根文件系统。
+
+`iperf2-smoke` 使用 `--full-duplex` 同时收发，按 iperf2 的普通线程 ID 和带 `*`
+的接收线程 ID 分别检查进展。AKA 运行 22 秒，其中前 2 秒预热；OrangePi 运行
+4 秒，其中前 1 秒预热。任一方向在预热后连续 3 秒无进展、缺少接收报告、最终
+报告提前结束或命令非零退出均失败。最终汇总不能覆盖中间停滞。完整 iperf3
+benchmark 应用仍可手工运行，不属于这两个 CI 冒烟入口。
+
+在 runner 服务器安装并启用共享 iperf2 服务：
+
+```bash
+sudo apt-get install -y iperf
+sudo install -m 644 .github/ci/iperf2.service /etc/systemd/system/iperf2.service
+sudo systemctl daemon-reload
+sudo systemctl enable --now iperf2.service
+```
+
+模板使用 systemd 动态用户，服务器防火墙需要允许板卡访问 TCP 5001。服务端和
+板端必须都是 iperf2；iperf3 不兼容该协议。无需为每块板分配独立的 iperf3 实例。
 
 完整 benchmark 固定执行 T01--T07：单流 TX、单流 RX、单流双向、2/4/8 流 TX 和
 4 流 RX。每个场景使用 `-t 10 -O 2 -l 128K` 运行 3 次，每个连接结束后固定冷却

--- a/test-suit/starryos/board-aka-00-sg2002/wifi-iperf-smoke/board-aka-00-sg2002.toml
+++ b/test-suit/starryos/board-aka-00-sg2002/wifi-iperf-smoke/board-aka-00-sg2002.toml
@@ -3,25 +3,26 @@ dtb_file = "os/StarryOS/configs/board/aka-00-sg2002.dtb"
 kernel_load_addr = "0x80200000"
 fit_load_addr = "0x82200000"
 bootm_addr = "0x82200000"
-session_files = ["iperf-smoke.sh"]
 shell_prefix = "root@starry:"
 shell_init_cmd = '''
-script=/tmp/iperf-smoke.sh
-download=/tmp/iperf-smoke.sh.part
+marker=STARRY_AKA_WIFI_IPERF_SMOKE
 ready=0
-rm -f "$script" "$download"
 attempt=1
 while [ "$attempt" -le 30 ]; do
   if command -v curl >/dev/null 2>&1; then
-    curl --connect-timeout 2 --max-time 5 -fsSL '${sessionFile:iperf-smoke.sh}' -o "$download" || true
+    curl --connect-timeout 2 --max-time 5 -fsSL '${sessionFile:share/iperf2.tar.gz}' -o /tmp/iperf2.tar.gz && ready=1
   elif command -v wget >/dev/null 2>&1; then
-    wget -T 5 -O "$download" '${sessionFile:iperf-smoke.sh}' || true
+    wget -T 5 -O /tmp/iperf2.tar.gz '${sessionFile:share/iperf2.tar.gz}' && ready=1
   fi
-  if [ -s "$download" ] && mv "$download" "$script" && chmod +x "$script"; then ready=1; break; fi
+  if [ "$ready" = 1 ]; then break; fi
   sleep 1
   attempt=$((attempt + 1))
 done
-if [ "$ready" = 1 ]; then "$script" '${boardServerIp}'; else echo STARRY_AKA_WIFI_IPERF_SMOKE_FAILED; fi
+if [ "$ready" = 1 ] && mkdir -p /tmp/iperf2 && tar -xzf /tmp/iperf2.tar.gz -C /tmp/iperf2; then
+  PATH="/tmp/iperf2:$PATH" /tmp/iperf2/board-smoke.sh '${boardServerIp}'
+else
+  echo "${marker}_FAILED"
+fi
 '''
 success_regex = ['(?m)^STARRY_AKA_WIFI_IPERF_SMOKE_PASSED\s*$']
 fail_regex = [
@@ -29,7 +30,7 @@ fail_regex = [
   '(?i)segmentation fault|SIGSEGV',
   '(?m)^STARRY_AKA_WIFI_DHCP_FAILED\s*$',
   '(?m)^STARRY_AKA_WIFI_IPERF_SMOKE_FAILED\s*$',
-  '(?i)(iperf3|curl|wget|chmod|ip|grep|sh): .*not found',
+  '(?i)(iperf|curl|wget|chmod|ip|grep|sh): .*not found',
   '(?i)WPA2 .*failed|AIC .*failed|DHCP .*failed',
 ]
 timeout = 600

--- a/test-suit/starryos/board-aka-00-sg2002/wifi-iperf-smoke/c/CMakeLists.txt
+++ b/test-suit/starryos/board-aka-00-sg2002/wifi-iperf-smoke/c/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 3.21)
+project(aka_iperf2_assets NONE)
+set(BOARD_SMOKE_SCRIPT "${CMAKE_CURRENT_LIST_DIR}/../iperf-smoke.sh")
+include("${CMAKE_CURRENT_LIST_DIR}/../../../board-common/iperf2/CMakeLists.txt")

--- a/test-suit/starryos/board-aka-00-sg2002/wifi-iperf-smoke/c/prebuild.sh
+++ b/test-suit/starryos/board-aka-00-sg2002/wifi-iperf-smoke/c/prebuild.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -eu
+apk add iperf

--- a/test-suit/starryos/board-aka-00-sg2002/wifi-iperf-smoke/iperf-smoke.sh
+++ b/test-suit/starryos/board-aka-00-sg2002/wifi-iperf-smoke/iperf-smoke.sh
@@ -22,37 +22,4 @@ if ! ip -4 -o addr show dev wlan0 | grep -q ' inet '; then
     fail
 fi
 
-command -v iperf3 >/dev/null 2>&1 || fail
-
-report=$(mktemp) || fail
-trap 'rm -f "$report"' EXIT
-iperf3 -c "$server_ip" -t 20 -O 2 -P 1 -l 128K >"$report" 2>&1
-status=$?
-cat "$report"
-[ "$status" -eq 0 ] || fail
-
-# A completed 128 KiB write can straddle a reporting interval. Allow that
-# jitter, but reject three seconds without progress after the warm-up.
-awk '
-    /omitted/ { next }
-    !sub(/^\[[[:space:]]*[0-9]+\][[:space:]]*/, "") { next }
-    $NF == "receiver" { received = ($3 + 0 > 0); next }
-    $NF == "sender" { next }
-    $1 ~ /^[0-9]+\.[0-9]+-[0-9]+\.[0-9]+$/ && $2 == "sec" {
-        split($1, interval, "-")
-        if ($3 + 0 > 0) {
-            stalled = 0
-            progressed = 1
-        } else {
-            stalled += interval[2] - interval[1]
-        }
-        if (stalled >= 3) {
-            print "Wi-Fi transfer stalled for at least three seconds"
-            exit 1
-        }
-        end = interval[2]
-    }
-    END { if (!progressed || !received || end < 19) exit 1 }
-' "$report" || fail
-
-echo STARRY_AKA_WIFI_IPERF_SMOKE_PASSED
+iperf2-smoke "$server_ip" 22 2 STARRY_AKA_WIFI_IPERF_SMOKE || fail

--- a/test-suit/starryos/board-common/iperf2/CMakeLists.txt
+++ b/test-suit/starryos/board-common/iperf2/CMakeLists.txt
@@ -1,0 +1,29 @@
+# Package a matched Alpine executable, loader and C++ runtime as session files.
+# The board root filesystem does not need iperf2 or matching library versions.
+set(bundle "${CMAKE_CURRENT_BINARY_DIR}/iperf2")
+file(MAKE_DIRECTORY "${bundle}")
+file(COPY_FILE "${STARRY_STAGING_ROOT}/usr/bin/iperf" "${bundle}/iperf.bin")
+file(GLOB loaders "${STARRY_STAGING_ROOT}/lib/ld-musl-*.so.1")
+list(LENGTH loaders loader_count)
+if(NOT loader_count EQUAL 1)
+    message(FATAL_ERROR "Expected one musl loader for the board iperf2 bundle")
+endif()
+foreach(library IN ITEMS ${loaders}
+    "${STARRY_STAGING_ROOT}/usr/lib/libstdc++.so.6"
+    "${STARRY_STAGING_ROOT}/usr/lib/libgcc_s.so.1")
+    file(COPY "${library}" DESTINATION "${bundle}" FOLLOW_SYMLINK_CHAIN)
+endforeach()
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/iperf" "${CMAKE_CURRENT_LIST_DIR}/iperf2-smoke"
+    DESTINATION "${bundle}" FILE_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
+file(CHMOD "${bundle}/iperf.bin" PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
+file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/../iperf-smoke.sh" DESTINATION "${bundle}"
+    FILE_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
+file(COPY_FILE "${BOARD_SMOKE_SCRIPT}" "${bundle}/board-smoke.sh")
+file(CHMOD "${bundle}/board-smoke.sh" PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
+# Archive only files: the guest creates the destination directory itself,
+# so extraction does not need to restore host directory ownership or modes.
+file(GLOB bundle_files RELATIVE "${bundle}" "${bundle}/*")
+execute_process(COMMAND "${CMAKE_COMMAND}" -E tar czf "${CMAKE_CURRENT_BINARY_DIR}/iperf2.tar.gz"
+    "--mtime=1970-01-01 00:00:00 UTC" -- ${bundle_files}
+    WORKING_DIRECTORY "${bundle}" COMMAND_ERROR_IS_FATAL ANY)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/iperf2.tar.gz" DESTINATION share)

--- a/test-suit/starryos/board-common/iperf2/iperf
+++ b/test-suit/starryos/board-common/iperf2/iperf
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -eu
+root=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+for loader in "$root"/ld-musl-*.so.1; do
+    exec "$loader" --library-path "$root" "$root/iperf.bin" "$@"
+done

--- a/test-suit/starryos/board-common/iperf2/iperf2-smoke
+++ b/test-suit/starryos/board-common/iperf2/iperf2-smoke
@@ -1,0 +1,54 @@
+#!/bin/sh
+set -u
+
+server_ip=$1
+duration=$2
+warmup=$3
+marker=$4
+fail() {
+    echo "${marker}_FAILED"
+    exit 1
+}
+
+command -v iperf >/dev/null 2>&1 || fail
+report=$(mktemp) || fail
+trap 'rm -f "$report"' EXIT
+iperf -c "$server_ip" -p 5001 -t "$duration" -i 1 -P 1 -l 128K -f b --full-duplex >"$report" 2>&1
+status=$?
+cat "$report"
+[ "$status" -eq 0 ] || fail
+
+# iperf2 marks receive threads with '*'. Check each direction independently;
+# a final aggregate must never hide a stall in the interval reports.
+awk -v duration="$duration" -v warmup="$warmup" '
+    /^\[[[:space:]]*\*?[0-9]+\]/ {
+        direction = ($0 ~ /^\[[[:space:]]*\*/ ? "rx" : "tx")
+        sub(/^\[[[:space:]]*\*?[0-9]+\][[:space:]]*/, "")
+        if ($1 !~ /^[0-9]+\.[0-9]+-[0-9]+\.[0-9]+$/ || $2 != "sec" || $4 != "Bytes") next
+        split($1, interval, "-")
+        start = interval[1] + 0
+        end = interval[2] + 0
+        if (start == 0 && end > 1.5) {
+            complete[direction] = ($3 + 0 > 0 && end >= duration - 0.1)
+            next
+        }
+        if (start < warmup) next
+        if ($3 + 0 > 0) {
+            stalled[direction] = 0
+            progressed[direction] = 1
+        } else {
+            stalled[direction] += end - start
+        }
+        if (stalled[direction] >= 3) {
+            print direction " transfer stalled for at least three seconds"
+            failed = 1
+        }
+        last[direction] = end
+    }
+    END {
+        if (failed || !progressed["tx"] || !progressed["rx"] ||
+            !complete["tx"] || !complete["rx"] ||
+            last["tx"] < duration - 1 || last["rx"] < duration - 1) exit 1
+    }
+' "$report" || fail
+echo "${marker}_PASSED"

--- a/test-suit/starryos/board-orangepi-5-plus/native-network-smoke/board-orangepi-5-plus.toml
+++ b/test-suit/starryos/board-orangepi-5-plus/native-network-smoke/board-orangepi-5-plus.toml
@@ -1,89 +1,23 @@
 board_type = "OrangePi-5-Plus"
-session_files = [
-  "iperf-smoke.sh",
-]
 shell_prefix = "root@starry:/root #"
 shell_init_cmd = '''
-suite=STARRY_NATIVE_NETWORK
-iperf_marker=STARRY_IPERF_SMOKE
-rtnl_marker=STARRY_RTNL
-ok=1
-
-echo RTL8125_NET_TEST_PASSED
-
-server_ip='${boardServerIp}'
-url='${sessionFile:iperf-smoke.sh}'
-script=/tmp/iperf-smoke.sh
-
-download_script() {
-  if command -v curl >/dev/null 2>&1; then
-    curl --connect-timeout 2 --max-time 5 -fsSL "$url" -o "$script"
-  elif command -v wget >/dev/null 2>&1; then
-    wget -T 5 -O "$script" "$url"
-  else
-    return 1
-  fi
-}
-
-downloaded=0
+marker=STARRY_IPERF_SMOKE
+ready=0
 attempt=1
 while [ "$attempt" -le 30 ]; do
-  if download_script; then
-    downloaded=1
-    break
+  if command -v curl >/dev/null 2>&1; then
+    curl --connect-timeout 2 --max-time 5 -fsSL '${sessionFile:share/iperf2.tar.gz}' -o /tmp/iperf2.tar.gz && ready=1
+  elif command -v wget >/dev/null 2>&1; then
+    wget -T 5 -O /tmp/iperf2.tar.gz '${sessionFile:share/iperf2.tar.gz}' && ready=1
   fi
+  if [ "$ready" = 1 ]; then break; fi
   sleep 1
   attempt=$((attempt + 1))
 done
-if [ "$downloaded" != "1" ]; then
-  echo "${iperf_marker}_FAILED"
-  ok=0
-elif ! chmod +x "$script" || ! "$script" "$server_ip"; then
-  echo "${iperf_marker}_FAILED"
-  ok=0
-fi
-
-printf '\n%s_BEGIN\n' "$rtnl_marker"
-rtnl_ok=1
-ip addr del 192.168.10.2/24 dev eth1 >/tmp/starry-rtnl-cleanup 2>&1 || true
-ip link show dev eth1 || rtnl_ok=0
-if ip link show dev starry_missing0 >/tmp/starry-rtnl-missing 2>&1; then
-  echo "${rtnl_marker}_BAD_MISSING_LINK"
-  rtnl_ok=0
+if [ "$ready" = 1 ] && mkdir -p /tmp/iperf2 && tar -xzf /tmp/iperf2.tar.gz -C /tmp/iperf2; then
+  PATH="/tmp/iperf2:$PATH" /tmp/iperf2/board-smoke.sh '${boardServerIp}'
 else
-  cat /tmp/starry-rtnl-missing
-fi
-
-ip addr add 192.168.10.2/24 dev eth1 || rtnl_ok=0
-ip -o addr show dev eth1 || rtnl_ok=0
-ip addr del 192.168.10.2/24 dev eth1 || rtnl_ok=0
-if ip addr del 192.168.10.2/24 dev eth1 >/tmp/starry-rtnl-del-missing 2>&1; then
-  echo "${rtnl_marker}_BAD_DELADDR_MISSING"
-  rtnl_ok=0
-else
-  cat /tmp/starry-rtnl-del-missing
-fi
-
-if ip -o addr show dev eth1 | grep -q '192\.168\.10\.2/24'; then
-  echo "${rtnl_marker}_BAD_DELADDR"
-  rtnl_ok=0
-fi
-
-ip addr add 192.168.10.2/24 dev eth1 || rtnl_ok=0
-ip -o addr show dev eth1 || rtnl_ok=0
-
-if [ "$rtnl_ok" = "1" ]; then
-  echo "${rtnl_marker}_OK"
-else
-  echo "${rtnl_marker}_FAILED"
-  ok=0
-fi
-printf '\n%s_DONE\n' "$rtnl_marker"
-
-if [ "$ok" = "1" ]; then
-  echo ${suite}_OK
-else
-  echo ${suite}_FAILED
+  echo "${marker}_FAILED"
 fi
 '''
 success_regex = ['STARRY_NATIVE_NETWORK_OK']

--- a/test-suit/starryos/board-orangepi-5-plus/native-network-smoke/board-smoke.sh
+++ b/test-suit/starryos/board-orangepi-5-plus/native-network-smoke/board-smoke.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+set -u
+suite=STARRY_NATIVE_NETWORK
+rtnl_marker=STARRY_RTNL
+ok=1
+iperf-smoke.sh "$1" || ok=0
+printf '\n%s_BEGIN\n' "$rtnl_marker"
+rtnl_ok=1
+ip addr del 192.168.10.2/24 dev eth1 >/tmp/starry-rtnl-cleanup 2>&1 || true
+ip link show dev eth1 || rtnl_ok=0
+if ip link show dev starry_missing0 >/tmp/starry-rtnl-missing 2>&1; then
+  echo "${rtnl_marker}_BAD_MISSING_LINK"
+  rtnl_ok=0
+else
+  cat /tmp/starry-rtnl-missing
+fi
+
+ip addr add 192.168.10.2/24 dev eth1 || rtnl_ok=0
+ip -o addr show dev eth1 || rtnl_ok=0
+ip addr del 192.168.10.2/24 dev eth1 || rtnl_ok=0
+if ip addr del 192.168.10.2/24 dev eth1 >/tmp/starry-rtnl-del-missing 2>&1; then
+  echo "${rtnl_marker}_BAD_DELADDR_MISSING"
+  rtnl_ok=0
+else
+  cat /tmp/starry-rtnl-del-missing
+fi
+
+if ip -o addr show dev eth1 | grep -q '192\.168\.10\.2/24'; then
+  echo "${rtnl_marker}_BAD_DELADDR"
+  rtnl_ok=0
+fi
+
+ip addr add 192.168.10.2/24 dev eth1 || rtnl_ok=0
+ip -o addr show dev eth1 || rtnl_ok=0
+
+if [ "$rtnl_ok" = "1" ]; then
+  echo "${rtnl_marker}_OK"
+else
+  echo "${rtnl_marker}_FAILED"
+  ok=0
+fi
+printf '\n%s_DONE\n' "$rtnl_marker"
+
+if [ "$ok" = "1" ]; then
+  echo ${suite}_OK
+else
+  echo ${suite}_FAILED
+fi
+
+[ "$ok" = 1 ]

--- a/test-suit/starryos/board-orangepi-5-plus/native-network-smoke/c/CMakeLists.txt
+++ b/test-suit/starryos/board-orangepi-5-plus/native-network-smoke/c/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 3.21)
+project(orangepi_iperf2_assets NONE)
+set(BOARD_SMOKE_SCRIPT "${CMAKE_CURRENT_LIST_DIR}/../board-smoke.sh")
+include("${CMAKE_CURRENT_LIST_DIR}/../../../board-common/iperf2/CMakeLists.txt")

--- a/test-suit/starryos/board-orangepi-5-plus/native-network-smoke/c/prebuild.sh
+++ b/test-suit/starryos/board-orangepi-5-plus/native-network-smoke/c/prebuild.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -eu
+apk add iperf

--- a/test-suit/starryos/board-orangepi-5-plus/native-network-smoke/iperf-smoke.sh
+++ b/test-suit/starryos/board-orangepi-5-plus/native-network-smoke/iperf-smoke.sh
@@ -7,20 +7,7 @@ if [ "$#" -ne 1 ] || [ -z "$1" ]; then
     exit 1
 fi
 
-command -v iperf3 >/dev/null 2>&1 || {
-    echo "iperf-smoke: iperf3 is not installed"
+if ! iperf2-smoke "$1" 4 1 STARRY_IPERF_SMOKE; then
     echo STARRY_IPERF_SMOKE_FAILED
-    exit 1
-}
-
-server_ip=$1
-
-printf '\n=== iperf3 network smoke ===\n\n'
-printf 'iperf3 -c %s -t 3 -O 1 -P 1 -l 128K\n\n' "$server_ip"
-
-if iperf3 -c "$server_ip" -t 3 -O 1 -P 1 -l 128K; then
-    printf '\nSTARRY_IPERF_SMOKE_PASSED\n'
-else
-    printf '\nSTARRY_IPERF_SMOKE_FAILED\n'
     exit 1
 fi


### PR DESCRIPTION
## 问题与根因

[PR #2300 的 AKA 启动作业](https://github.com/rcore-os/tgoskits/actions/runs/34190233087/job/101947721440) 在 `ControlRequest::Connect` 提交前收到 `SM_CONNECT_IND`，把无当前连接事务的异步结果当成初始化错误，触发 `firmware rejected message 0x1802 with status 1`。旧成功通知也可能错误安装 peer，并截断同一 FIFO 中真正的初始化邮箱确认。

[随后 OrangePi CI](https://github.com/rcore-os/tgoskits/actions/runs/34193528464/job/101957826063) 的控制连接断开是另一项根因：它与 AKA 共用单个 iperf3 服务。服务器日志显示该时段 WiFi 测试正在运行；iperf3 3.21 的 `iperf_accept()` 在已有活动测试时发送 `ACCESS_DENIED` 并关闭新连接。板卡租约只隔离单块板，无法隔离不同板共用的服务端。

[最新一轮 AKA 吞吐失败](https://github.com/rcore-os/tgoskits/actions/runs/34204965867/job/101994213656) 暴露了 `ax-net` 的另一个丢包路径：TCP 双向流在第 2–15 秒同时停止，服务器也记录了同样的零吞吐；停顿前网关连续三次发出 ARP 探测。`EthernetFramePort` 返回 `Again` 时要求调用方保留报文，而 `process_arp()` 却直接丢弃 ARP 回复。网关无法确认板卡邻居后会停止向板卡转发，直到再次完成邻居解析。临时实板诊断已记录到该 ARP 回复因 TX 拥塞而丢弃的真实事件；确定性回归进一步证明队列恢复后回复确实丢失。

## 修改

- `ax-net::EthernetDevice` 保留有界、去重的待发 ARP 回复，TX 空间恢复后通过现有协议轮询补发，优先于后续 IP 数据；不依赖新 RX 或新 ARP 请求触发。IPv4 地址变更时取消旧回复，成功发送、错误和丢弃计数各自保持正确。复用 TX 完成唤醒，不增加线程或轮询定时器。
- AIC8800 仅在 `AicState::Starting` 丢弃没有所属连接的 `SM_CONNECT_IND`，继续处理当前接收批次的邮箱确认。Ready 后真正连接的非零状态仍报错。驱动没有增加 OS 线程、调度依赖、重试或更宽超时。
- 所有实际使用 iperf 的真板卡 CI 入口——AKA WiFi 与 OrangePi 网络冒烟——改用支持多独立客户端的 iperf2，共享 TCP 5001。服务模板为 `.github/ci/iperf2.service`，runner 已直接安装 Ubuntu `iperf` 2.1.9 并启用该服务。取消临时的 iperf3 5202 独立实例及模板。
- 板端通过现有 C 资产流水线从 Alpine 安装 iperf2，打包客户端、匹配的 musl 加载器和 C++ 运行库为会话文件，解压到 `/tmp` 执行，不依赖板上预装软件。串口只发送下载与启动命令，测试正文随会话传输；OrangePi 的 rtnetlink 断言原样迁入脚本，保留失败传播。
- 公共 `iperf2-smoke` 使用 `--full-duplex`，分别检查发送和接收报告：AKA 22 秒含 2 秒预热，OrangePi 4 秒含 1 秒预热。任一方向连续 3 秒无进展、缺少接收、最终报告提前结束或命令失败均判失败，最终汇总不能掩盖中间停滞。原有手工 iperf3 benchmark 应用不属于这些 CI 入口。

异步连接通知语义参考[荔枝派 BSP](https://github.com/sipeed/LicheeRV-Nano-Build/blob/d4003f15b35d43ad4842f427050ab2bba0114fa5/osdrv/extdrv/wireless/aic8800/aic8800_fdrv/rwnx_msg_rx.c#L803)。iperf2 多客户端及双向选项参考[官方手册](https://iperf2.sourceforge.io/iperf-manpage.html)。

## 验证

本地验证基于 dev `cbed9ea5f04c19b0cf42c2e036c55dd8366aebd9`，包含 #1775 的调度器重构、#2312 的 clippy 配置修复和 #2290 的 AIC8800 队列预算修复。

- AIC8800 确定性红绿：真实 `AicDevice::advance` 注入同批旧连接通知与当前邮箱确认，旧实现失败，修复后旧成功/失败通知不改变启动和 peer，邮箱确认被消费；真正连接拒绝仍返回 `FirmwareRejected`。
- iperf2 迁移期间已完成脚本契约红绿验证；最终按框架边界移除 axbuild 中的板卡专用测试。持续进展、双向报告和失败判定由板卡脚本执行，以真实板测和 CI 验证，不在通用框架中逐个登记业务用例。
- `cargo xtask test --since origin/dev`：AIC8800 120 项、axbuild 810 项通用测试通过；定向 clippy：AIC8800 3 组、axbuild 1 组通过。格式、同步检查和差异检查通过。
- 当前 dev `cbed9ea5f0` 上 `cargo xtask starry test board --board aka-00-sg2002` 完整板测 4/4 通过，包含新队列预算下的启动、tennis-yolo、USB 和 iperf2 WiFi。2.2.1 客户端与 2.1.9 服务端进行 22 秒双向传输，持续进展检查通过。
- OrangePi iperf2 网络项通过，约 TX 248 Mbit/s / RX 242 Mbit/s；服务器同步记录双向传输，原有 rtnetlink 检查全部通过。最终会话包格式在 AKA WiFi 和 OrangePi 网络项均通过，ARP 修复后的正式 AKA WiFi 22 秒双向测试也已通过，TX 6.62 Mbit/s / RX 2.37 Mbit/s。
- ARP 确定性红绿：旧实现仅发送后续 IP 包、丢失 ARP 回复（实际 1 帧，预期 2 帧）；修复后回复在前，IP 在后。另覆盖三种 RX 轮询入口在没有新 RX 时补发、重复探测合并、队列上限和地址变更取消。回归位于负责此行为的 `ax-net`，没有添加 axbuild 板卡专用测试。
- `cargo xtask test --since 553c5fe9b7`：10 个受影响软件包全部通过；`cargo xtask clippy --package ax-net`：9 组检查通过；格式、同步检查和 ax-net 发布预检查通过。
- ARP 修复后 AKA 180 秒双向压力检查通过，OrangePi 完整板测 2/2 通过；正式 CI 的时长和失败判定保持不变。
- runner 上两个独立 iperf2 客户端同时连接 5001，双向测试均成功；服务 enabled/active，systemd 模板校验通过，5202 已停止监听。
