### PR TITLE
feat(axvm): service virtio block images with on-demand file I/O

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1559,6 +1559,7 @@ name = "axvirtio-blk"
 version = "0.2.0"
 dependencies = [
  "ax-memory-addr",
+ "ax-runtime",
  "ax-sync",
  "axaddrspace",
  "axdevice_base",
@@ -1667,6 +1668,7 @@ dependencies = [
  "rdrive",
  "riscv_vcpu",
  "riscv_vplic",
+ "rsext4",
  "serde",
  "thiserror 2.0.20",
  "toml 1.1.4+spec-1.1.0",

--- a/docs/design/axvisor-resolved-device-graph.md
+++ b/docs/design/axvisor-resolved-device-graph.md
@@ -50,7 +50,12 @@ model = "virtio-blk"
 capacity = "20GiB"
 backend = "file"
 path = "/images/data.raw"
+filesystem = "ext4"
 ```
+
+此文件后端示例要求 Axvisor 宿主文件系统内已经存在一个长度为 20 GiB 的 ext4 镜像；`path` 不是开发机路径或客户机挂载路径。`virtio_blk::options::parse_backend()` 在省略 `backend` 时仍选择 `file`，`parse_file_backend()` 要求显式填写 `filesystem = "ext4"`，缺失或填写其他值会使设备实例化失败。迁移旧配置时，无论原来写了 `backend = "file"` 还是省略了 `backend`，都需要补上该字段，并在启动前准备好已有文件系统的镜像。
+
+`virtio_blk::image::inspect_file_image()` 要求镜像非空、文件长度为 512 字节的整数倍，并校验 ext4 超级块和文件系统大小；该校验不替代完整文件系统检查。`capacity` 可省略，省略时采用实际文件长度；显式容量必须等于文件长度，不再触发创建文件、格式化或扩缩容。原来依赖自动创建或调整容量的流程，需要在宿主侧先准备镜像，再更新容量配置。使用 `backend = "ramdisk"` 时不要填写 `path` 或 `filesystem`。
 
 `VirtualDeviceRequest` 只保留稳定 ID、规范 model 名和剩余 TOML table。它禁止用户填写 MMIO、PIO、IRQ、MSI 或 LPI 数字。catalog 中的 `ConfiguredModelRegistration` 保存规范 model 名和普通构造函数指针；构造函数使用带 `deny_unknown_fields` 的类型化结构解析 options，并直接返回 `DeviceNodeSpec`。未知 model、重复注册、重复设备 ID 和未知选项都明确失败，不存在额外 factory trait 或 instance 包装层。
 

--- a/docs/docs/architecture/axvisor/emulated-devices.md
+++ b/docs/docs/architecture/axvisor/emulated-devices.md
@@ -556,13 +556,15 @@ reset 和 resume 按注册顺序执行，suspend 按逆序执行。pollable 去�
 
 ### 8.1 用户可配置设备
 
+设备选项由所属 model 解析。virtio-blk 的后端选项由 `virtualization/axvm/src/configured/devices/virtio_blk/options.rs` 中的 `parse_backend()` 校验，文件后端还通过 `image.rs` 中的 `inspect_file_image()` 检查已有镜像。
+
 | model | 构建结果 | 关键 options |
 | --- | --- | --- |
 | `pl011-mmio` | PL011 MMIO 设备，wired IRQ，FDT/ACPI 串口元数据 | `clock_hz`、`register_shift`、`register_width`、`backend` |
 | `uart16550-mmio` | 16550 MMIO 设备，wired IRQ，串口 service/固件元数据 | 同上 |
 | `uart16550-pio` | 16550 PIO 设备，wired IRQ，x86 端口访问 | `clock_hz`、`backend` |
 | `ivc-channel` | IVC aperture allocator service + wired notify endpoint service | options 为空且拒绝未知字段 |
-| `virtio-blk` | VirtIO MMIO block runtime + DMA grant/poller；ramdisk 或 file backend | `capacity`/`capacity_sectors`、`backend`、`path` |
+| `virtio-blk` | VirtIO MMIO block runtime + DMA grant/poller；ramdisk 或 file backend | `capacity`/`capacity_sectors`、`backend`、`path`；file 后端必填 `filesystem = "ext4"` |
 | `virtio-net` | VirtIO MMIO net runtime + DMA grant/poller；连接 AxVM 内部 L2 switch | `guest_mac` |
 
 串口 backend 目前支持 `{ type = "host-console" }` 和 `{ type = "null" }`。`host-console` 每台 VM 只能有一个 owner。
@@ -570,6 +572,10 @@ reset 和 resume 按注册顺序执行，suspend 按逆序执行。pollable 去�
 `ivc-channel` 不注册可直接读写的 `Device`；它通过 service 提供共享 MMIO aperture 分配器和 notify endpoint。判断 IVC 是否生效不能只看 `device_count()`。
 
 virtio-blk/net 的 model、MMIO transport、DMA 接线、IRQ 和 backend glue 都由 AxVM 拥有；Axvisor 不再维护单独的 `virtual_devices` 模块或 model registration。两者的 MMIO/IRQ 均来自 auto pool，因此多实例按 graph ID 确定性分配，固件节点与实例一一对应。
+
+virtio-blk 省略 `backend` 时默认使用 `file`。文件后端必须显式配置 `filesystem = "ext4"`，目前不接受其他值，也不提供文件系统类型默认值。`path` 是 Axvisor 宿主文件系统中的镜像路径，省略时使用 `/tmp/<设备 id>.img`。文件必须已存在、非空且长度按 512 字节对齐；超级块校验失败会终止设备实例化，不会自动创建文件或格式化。仅使用 `backend = "ramdisk"` 时无需镜像文件，且禁止配置 `path` 和 `filesystem`。
+
+迁移旧 file 配置（包括省略 `backend` 的配置）时，补上 `filesystem = "ext4"`，并在启动前将已有 ext4 镜像放入宿主文件系统。文件后端省略容量时采用文件实际长度；显式 `capacity` 或 `capacity_sectors` 必须与实际长度一致，两者不能同时填写。原来依赖自动创建或调整文件长度的配置需要先在宿主侧准备镜像、核对容量；本实现不执行扩缩容。`ramdisk` 的默认容量仍为 2 MiB。文件后端基础校验与客户机挂载时的文件系统检查是两个阶段，不保证整个 ext4 镜像没有损坏。
 
 ### 8.2 `fw_cfg`
 

--- a/scripts/axbuild/src/axvisor/rootfs.rs
+++ b/scripts/axbuild/src/axvisor/rootfs.rs
@@ -252,11 +252,19 @@ pub(crate) fn patch_qemu_rootfs(
     explicit_rootfs: Option<&Path>,
 ) -> anyhow::Result<()> {
     let rootfs_path = qemu_rootfs_path(request, workspace_root, explicit_rootfs)?;
-    patch_qemu_rootfs_path(
-        config,
-        &rootfs_path,
-        rootfs::qemu::RootfsWritePolicy::Persist,
-    )
+    let global_snapshot = config.args.iter().any(|argument| argument == "-snapshot");
+    let write_policy = if global_snapshot {
+        rootfs::qemu::RootfsWritePolicy::Discard
+    } else {
+        rootfs::qemu::RootfsWritePolicy::Persist
+    };
+    patch_qemu_rootfs_path(config, &rootfs_path, write_policy)?;
+    // The shared rootfs patcher narrows Discard to the selected drive. Axvisor
+    // must also retain the user's global protection for all other drives.
+    if global_snapshot {
+        config.args.push("-snapshot".into());
+    }
+    Ok(())
 }
 
 /// Resolves the rootfs path selected for an Axvisor QEMU request.
@@ -585,6 +593,39 @@ kernel_path = "{}"
                 .iter()
                 .any(|arg| { arg.contains(&format!("file={}", rootfs.display())) })
         );
+    }
+
+    #[test]
+    fn patch_qemu_rootfs_preserves_global_snapshot_for_other_disks() {
+        let root = tempdir().unwrap();
+        write_test_image_config(root.path());
+        let rootfs = managed_rootfs_path_for_test(root.path(), "rootfs-aarch64-alpine.img");
+        let mut qemu = QemuConfig {
+            args: vec![
+                "-snapshot".to_string(),
+                "-drive".to_string(),
+                "id=disk0,if=none,format=raw,file=/old/tmp/rootfs.img".to_string(),
+                "-drive".to_string(),
+                "id=data,if=none,format=raw,file=/tmp/data.img".to_string(),
+            ],
+            ..Default::default()
+        };
+
+        patch_qemu_rootfs(&mut qemu, &request(root.path(), vec![]), root.path(), None).unwrap();
+
+        assert!(qemu.args.iter().any(|argument| argument == "-snapshot"));
+        assert!(
+            qemu.args
+                .iter()
+                .any(|argument| argument == "id=data,if=none,format=raw,file=/tmp/data.img")
+        );
+        assert!(qemu.args.iter().any(|argument| {
+            argument
+                == &format!(
+                    "id=disk0,if=none,format=raw,file={},snapshot=on",
+                    rootfs.display()
+                )
+        }));
     }
 
     #[test]

--- a/scripts/axbuild/src/test/std.rs
+++ b/scripts/axbuild/src/test/std.rs
@@ -93,6 +93,28 @@ const HOST_TEST_FEATURE_PROFILES: &[PackageFeatureProfile] = &[PackageFeaturePro
     expected_tests: &[],
 }];
 
+const AXVM_FEATURE_PROFILES: &[PackageFeatureProfile] = &[
+    HOST_TEST_FEATURE_PROFILES[0],
+    PackageFeatureProfile {
+        name: "fs+host-test",
+        no_default_features: false,
+        features: &["fs", "host-test"],
+        name_filter: None,
+        expected_tests: &[
+            "configured::devices::virtio_blk::image::tests::existing_ext4_image_is_loaded_without_modification",
+            "configured::devices::virtio_blk::image::tests::empty_ext4_file_is_rejected",
+            "configured::devices::virtio_blk::image::tests::non_ext4_backing_file_is_rejected",
+            "configured::devices::virtio_blk::image::tests::configured_capacity_must_match_existing_image",
+            "configured::devices::virtio_blk::image::tests::backing_file_length_must_be_sector_aligned",
+            "configured::devices::virtio_blk::image::tests::read_failure_is_reported_without_modifying_the_image",
+            "configured::devices::virtio_blk::image::tests::short_read_is_rejected",
+            "configured::devices::virtio_blk::image::tests::large_image_initialization_reads_only_superblock",
+            "configured::devices::virtio_blk::file::tests::sparse_large_file_roundtrip_uses_real_worker_and_flush",
+            "configured::devices::virtio_blk::file::tests::reset_drains_old_io_without_reusing_its_completion",
+        ],
+    },
+];
+
 const ALLOC_FEATURE_PROFILES: &[PackageFeatureProfile] = &[PackageFeatureProfile {
     name: "alloc",
     no_default_features: false,
@@ -496,7 +518,6 @@ fn package_feature_profiles(package: &str) -> Option<&'static [PackageFeaturePro
         | "rsext4"
         | "scope-local"
         | "ax-sync"
-        | "axvm"
         | "ax-display"
         | "ax-input"
         | "ax-ipi"
@@ -507,6 +528,7 @@ fn package_feature_profiles(package: &str) -> Option<&'static [PackageFeaturePro
         | "ax-net"
         | "dma-api"
         | "buddy-slab-allocator" => Some(HOST_TEST_FEATURE_PROFILES),
+        "axvm" => Some(AXVM_FEATURE_PROFILES),
         "ax-fs-ng" => Some(AX_FS_NG_FEATURE_PROFILES),
         "ax-io" | "axbacktrace" => Some(ALLOC_FEATURE_PROFILES),
         "ax-hal" => Some(AX_HAL_FEATURE_PROFILES),

--- a/scripts/test/std_crates.csv
+++ b/scripts/test/std_crates.csv
@@ -25,6 +25,7 @@ realtek-rtl8125
 aic8800
 ax-sched
 axvm
+axvirtio-blk
 virtualization-tests
 axvmconfig
 ax-cpumask

--- a/virtualization/axvirtio-blk/Cargo.toml
+++ b/virtualization/axvirtio-blk/Cargo.toml
@@ -21,5 +21,6 @@ log.workspace = true
 ax-sync.workspace = true
 
 [dev-dependencies]
+ax-runtime = { workspace = true, features = ["host-test"] }
 ax-memory-addr = { path = "../../memory/memory_addr" }
 ax-sync = { path = "../../os/arceos/modules/axsync", features = ["host-test"] }

--- a/virtualization/axvirtio-blk/src/backend.rs
+++ b/virtualization/axvirtio-blk/src/backend.rs
@@ -2,6 +2,27 @@ use axvirtio_common::VirtioResult;
 
 /// Trait for block device backends
 pub trait BlockBackend: Send + Sync {
+    /// Whether retrying the current deferred request can make progress.
+    /// Returning false lets the transport skip descriptor reads, allocation,
+    /// and data copies. This query must not consume the completion. Backends
+    /// returning false must notify their runtime when progress becomes possible,
+    /// including after cancellation drains. The default retains eager retries.
+    fn pending_request_ready(&self) -> bool {
+        true
+    }
+
+    /// Abandons the current deferred request when the transport stops retrying it.
+    /// Must be nonblocking and idempotent. Running I/O may drain, but its result
+    /// must never be consumed by the next request, even for an identical range.
+    /// Called on every terminal request path, including successful completion.
+    fn cancel_pending_request(&self) {}
+
+    /// Invalidates asynchronous results after a transport reset. Must not block.
+    /// Already executing storage I/O may drain, but must not complete a new request.
+    fn reset(&self) {
+        self.cancel_pending_request();
+    }
+
     /// Returns whether queue processing must be deferred to a pollable runtime
     /// context because backend operations can block.
     fn requires_deferred_processing(&self) -> bool {

--- a/virtualization/axvirtio-blk/src/lib.rs
+++ b/virtualization/axvirtio-blk/src/lib.rs
@@ -57,6 +57,8 @@
 #![no_std]
 
 extern crate alloc;
+#[cfg(test)]
+extern crate ax_runtime as _;
 
 extern crate log;
 

--- a/virtualization/axvirtio-blk/src/mmio/device.rs
+++ b/virtualization/axvirtio-blk/src/mmio/device.rs
@@ -149,6 +149,7 @@ impl<B: BlockBackend, T: GuestMemoryAccessor + Clone> VirtioMmioBlockDevice<B, T
                 // A transport reset invalidates every in-flight descriptor,
                 // including a deferred request that was removed from avail.
                 self.pending_head.lock().take();
+                self.backend.reset();
                 Ok(BlockDeviceEvent::Reset)
             }
             MmioWriteAction::InterruptPending => Ok(BlockDeviceEvent::InterruptPending),
@@ -190,6 +191,9 @@ impl<B: BlockBackend, T: GuestMemoryAccessor + Clone> VirtioMmioBlockDevice<B, T
         }
         let mut notify = false;
         let mut pending_head = self.pending_head.lock();
+        if pending_head.is_some() && !self.backend.pending_request_ready() {
+            return Ok(BlockDeviceEvent::QueuePending(queue_index));
+        }
         loop {
             let head = if let Some(head) = pending_head.take() {
                 head
@@ -206,6 +210,11 @@ impl<B: BlockBackend, T: GuestMemoryAccessor + Clone> VirtioMmioBlockDevice<B, T
                 }
                 Ok(None) => {
                     *pending_head = Some(head);
+                    // Earlier completions may already have crossed used_event.
+                    // A later retry cannot reconstruct that notification edge.
+                    if notify {
+                        self.trigger_interrupt();
+                    }
                     return Ok(BlockDeviceEvent::QueuePending(queue_index));
                 }
                 Err(error) => {
@@ -223,6 +232,21 @@ impl<B: BlockBackend, T: GuestMemoryAccessor + Clone> VirtioMmioBlockDevice<B, T
     }
 
     fn process_request(
+        &self,
+        queue: &VirtioQueue<T>,
+        head: u16,
+        memory: &mut dyn axvirtio_common::GuestMemory,
+    ) -> VirtioResult<Option<u32>> {
+        let result = self.process_request_inner(queue, head, memory);
+        // A retry may fail before calling the backend (allocation, descriptor,
+        // or guest-memory failure). Retire any old I/O before returning the head.
+        if !matches!(result, Ok(None)) {
+            self.backend.cancel_pending_request();
+        }
+        result
+    }
+
+    fn process_request_inner(
         &self,
         queue: &VirtioQueue<T>,
         head: u16,
@@ -472,9 +496,12 @@ mod tests {
         }
     }
 
-    struct TestBackend;
+    struct TestBackend(core::sync::atomic::AtomicBool);
 
     impl BlockBackend for TestBackend {
+        fn reset(&self) {
+            self.0.store(true, core::sync::atomic::Ordering::Relaxed);
+        }
         fn read(&self, sector: u64, buffer: &mut [u8]) -> VirtioResult<usize> {
             if sector >= 8 {
                 return Err(VirtioError::InvalidSector);
@@ -484,6 +511,9 @@ mod tests {
         }
 
         fn write(&self, sector: u64, buffer: &[u8]) -> VirtioResult<usize> {
+            if sector == 1 {
+                return Err(VirtioError::WouldBlock);
+            }
             if sector >= 8 {
                 return Err(VirtioError::InvalidSector);
             }
@@ -512,7 +542,7 @@ mod tests {
         let device = VirtioMmioBlockDevice::new(
             GuestPhysAddr::from(0x0a00_0000),
             0x200,
-            TestBackend,
+            TestBackend(core::sync::atomic::AtomicBool::new(false)),
             config,
             NoGuestMemoryAccessor,
         )
@@ -561,6 +591,57 @@ mod tests {
 
         assert_eq!(event, Ok(BlockDeviceEvent::Reset));
         assert_eq!(*device.pending_head.lock(), None);
+        assert!(device.backend.0.load(core::sync::atomic::Ordering::Relaxed));
+    }
+
+    #[test]
+    fn completed_request_interrupt_survives_a_later_blocked_request() {
+        let (mut device, _queue, mut memory) = fixture(512, 0);
+        device.block_config.size_max = 512;
+        device.set_status(crate::constants::VIRTIO_STATUS_DRIVER_OK);
+        {
+            let mut queues = device.state.queues_lock();
+            let queue = &mut queues[0];
+            queue.set_size(8).unwrap();
+            queue
+                .set_desc_table_addr(GuestPhysAddr::from(DESC_TABLE))
+                .unwrap();
+            queue
+                .set_avail_ring_addr(GuestPhysAddr::from(AVAIL_RING))
+                .unwrap();
+            queue
+                .set_used_ring_addr(GuestPhysAddr::from(USED_RING))
+                .unwrap();
+            queue.set_ready(true);
+            queue.event_idx_enabled = true;
+        }
+        memory.set_descriptor(
+            3,
+            HEADER + 32,
+            VirtioBlockHeader::SIZE,
+            VIRTQ_DESC_F_NEXT,
+            4,
+        );
+        memory.set_descriptor(4, DATA + 512, 512, VIRTQ_DESC_F_NEXT, 5);
+        memory.set_descriptor(5, STATUS + 1, 1, VIRTQ_DESC_F_WRITE, 0);
+        memory.0[HEADER + 32..HEADER + 36].copy_from_slice(&VIRTIO_BLK_T_OUT.to_le_bytes());
+        memory.0[HEADER + 40..HEADER + 48].copy_from_slice(&1_u64.to_le_bytes());
+        memory.0[AVAIL_RING + 2..AVAIL_RING + 4].copy_from_slice(&2_u16.to_le_bytes());
+        memory.0[AVAIL_RING + 6..AVAIL_RING + 8].copy_from_slice(&3_u16.to_le_bytes());
+        assert_eq!(
+            device.handle_queue_notify(0, &mut memory),
+            Ok(BlockDeviceEvent::QueuePending(0))
+        );
+        assert_eq!(*device.pending_head.lock(), Some(3));
+        assert_eq!(
+            u16::from_le_bytes(memory.0[USED_RING + 2..USED_RING + 4].try_into().unwrap()),
+            1
+        );
+        assert_ne!(
+            device.interrupt_status(),
+            0,
+            "the completed head still requires its EVENT_IDX interrupt"
+        );
     }
 
     #[test]

--- a/virtualization/axvirtio-blk/tests/block_tests.rs
+++ b/virtualization/axvirtio-blk/tests/block_tests.rs
@@ -5,6 +5,8 @@
 
 use std::sync::{Arc, RwLock};
 
+extern crate ax_runtime as _;
+
 use ax_memory_addr::PhysAddr;
 use axaddrspace::{AddrSpaceError, AddrSpaceResult, GuestMemoryAccessor};
 use axdevice_base::{
@@ -289,8 +291,9 @@ mod mmio_device_tests {
     fn test_queue_ready_requires_scoped_memory_with_placeholder_accessor() {
         // axvisor constructs the block device with `NoGuestMemoryAccessor` and
         // holds real guest memory only as a scoped capability at MMIO access
-        // time (`os/axvisor/src/virtio_blk.rs`). The `QUEUE_READY` layout
-        // validation must be screened against that scoped memory: the
+        // time (`virtualization/axvm/src/configured/devices/virtio_blk/device.rs`). The
+        // `QUEUE_READY`
+        // layout validation must be screened against that scoped memory: the
         // accessor-based fallback cannot translate any guest address, while
         // the scoped path validates the same layout against the real backing
         // and must make the queue ready.

--- a/virtualization/axvm/Cargo.toml
+++ b/virtualization/axvm/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["vm", "hypervisor", "arceos"]
 license = "Apache-2.0"
 
 [features]
-fs = ["ax-std/fs", "dep:ax-api", "ax-api/fs"]
+fs = ["ax-std/fs", "dep:ax-api", "ax-api/fs", "dep:rsext4"]
 host-fs = ["fs", "dep:ax-driver"]
 host-test = [
     "ax-std/host-test",
@@ -48,6 +48,7 @@ ax-std = { workspace = true, default-features = false, features = [
 ] }
 irq-framework = { workspace = true }
 ax-api = { workspace = true, optional = true }
+rsext4 = { workspace = true, optional = true }
 # System dependent modules provided by ArceOS-Hypervisor.
 axaddrspace = { workspace = true }
 axvm-types = { workspace = true }

--- a/virtualization/axvm/src/configured/devices/virtio_blk/device.rs
+++ b/virtualization/axvm/src/configured/devices/virtio_blk/device.rs
@@ -1,14 +1,11 @@
 //! Configured VirtIO MMIO block device backed by memory or a file.
 
-#[cfg(feature = "fs")]
-use core::sync::atomic::AtomicUsize;
 use core::sync::atomic::{AtomicBool, Ordering};
 #[cfg(feature = "fs")]
-use std::collections::VecDeque;
+use std::string::String;
 use std::{
     boxed::Box,
     format,
-    string::String,
     sync::{Arc, Mutex},
     vec,
     vec::Vec,
@@ -17,13 +14,19 @@ use std::{
 use axdevice::*;
 use axdevice_base::{
     BusKind, Device, DeviceAccess, DeviceContext, DeviceError, DmaGrant, InterruptSharing,
-    InterruptTrigger, IrqLine, Resource,
+    InterruptTrigger, IrqLine, IrqResult, Resource,
 };
 use axvirtio_blk::{BlockBackend, BlockDeviceEvent, VirtioBlockConfig, VirtioMmioBlockDevice};
 use axvirtio_common::{GuestMemory, NoGuestMemoryAccessor, VirtioError, VirtioResult};
 use axvm_types::GuestPhysAddr;
 use axvmconfig::VirtualDeviceRequest;
 
+use super::options::{BackendConfig, FilesystemFormat, parse_backend};
+#[cfg(feature = "fs")]
+use super::{
+    file::FileBackend,
+    image::{ImageReader, inspect_file_image},
+};
 use crate::{ConfiguredDeviceError, ConfiguredModelRegistration, DeviceInstantiationContext};
 
 const MMIO_SLOT: &str = "mmio";
@@ -31,33 +34,57 @@ const IRQ_SLOT: &str = "irq";
 const MMIO_SIZE: u64 = 0x200;
 const SECTOR_SIZE: usize = 512;
 const DEFAULT_CAPACITY_BYTES: u64 = 2 * 1024 * 1024;
+pub(crate) const VIRTIO_BLK_IRQ_TRIGGER: InterruptTrigger = InterruptTrigger::LevelTriggered;
+
+const fn interrupt_line_should_be_asserted(interrupt_status: u32) -> bool {
+    interrupt_status != 0
+}
+
+fn synchronize_interrupt_line(irq: &IrqLine, interrupt_status: u32) -> IrqResult {
+    if interrupt_line_should_be_asserted(interrupt_status) {
+        irq.assert()
+    } else {
+        irq.deassert()
+    }
+}
 
 /// Catalog entry for `[[devices.virtual]] model = "virtio-blk"`.
-pub const REGISTRATION: ConfiguredModelRegistration = ConfiguredModelRegistration {
+pub(super) const REGISTRATION: ConfiguredModelRegistration = ConfiguredModelRegistration {
     model: "virtio-blk",
     create: create_device_node,
 };
-
-pub(super) fn register(
-    catalog: &mut crate::ConfiguredDeviceCatalog,
-) -> Result<(), ConfiguredDeviceError> {
-    catalog.register(module_path!(), REGISTRATION)
-}
 
 fn create_device_node(
     id: DeviceNodeId,
     request: &VirtualDeviceRequest,
     context: &DeviceInstantiationContext,
 ) -> Result<DeviceNodeSpec, ConfiguredDeviceError> {
-    let capacity_bytes = parse_capacity(request)?;
-    let backend_config = parse_backend(request)?;
-    let backend = VirtioBlkBackend::open(&backend_config, capacity_bytes).map_err(|error| {
-        ConfiguredDeviceError::Instantiation {
-            device: request.id.clone(),
-            model: request.model.clone(),
-            detail: format!("failed to initialize backing storage: {error}"),
+    let backend_config =
+        parse_backend(request).map_err(|detail| invalid_options(request, detail))?;
+    let capacity_bytes =
+        parse_capacity(request).map_err(|detail| invalid_options(request, detail))?;
+    let vm_id = match &backend_config {
+        BackendConfig::RamDisk => None,
+        BackendConfig::File { .. } => {
+            Some(
+                context
+                    .vm_id()
+                    .ok_or_else(|| ConfiguredDeviceError::Instantiation {
+                        device: request.id.clone(),
+                        model: request.model.clone(),
+                        detail: "virtio-blk file backend requires a VM identity".into(),
+                    })?,
+            )
         }
-    })?;
+    };
+    let backend =
+        VirtioBlkBackend::open(&backend_config, capacity_bytes, vm_id).map_err(|error| {
+            ConfiguredDeviceError::Instantiation {
+                device: request.id.clone(),
+                model: request.model.clone(),
+                detail: format!("failed to initialize backing storage: {error}"),
+            }
+        })?;
     let controller =
         context
             .default_wired_controller()
@@ -85,30 +112,25 @@ fn invalid_options(request: &VirtualDeviceRequest, detail: &str) -> ConfiguredDe
     }
 }
 
-fn parse_capacity(request: &VirtualDeviceRequest) -> Result<Option<u64>, ConfiguredDeviceError> {
+fn parse_capacity(request: &VirtualDeviceRequest) -> Result<Option<u64>, &'static str> {
     let capacity = request.options.get("capacity");
     let legacy_sectors = request.options.get("capacity_sectors");
     if capacity.is_some() && legacy_sectors.is_some() {
-        return Err(invalid_options(
-            request,
-            "specify only one of `capacity` and `capacity_sectors`",
-        ));
+        return Err("specify only one of `capacity` and `capacity_sectors`");
     }
     let bytes = if let Some(value) = capacity {
-        let value = value
-            .as_str()
-            .ok_or_else(|| invalid_options(request, "`capacity` must be a size string"))?;
-        Some(parse_capacity_bytes(value).map_err(|detail| invalid_options(request, detail))?)
+        let value = value.as_str().ok_or("`capacity` must be a size string")?;
+        Some(parse_capacity_bytes(value)?)
     } else if let Some(value) = legacy_sectors {
         let sectors = value
             .as_integer()
             .and_then(|value| u64::try_from(value).ok())
             .filter(|value| *value > 0)
-            .ok_or_else(|| invalid_options(request, "`capacity_sectors` must be positive"))?;
+            .ok_or("`capacity_sectors` must be positive")?;
         Some(
             sectors
                 .checked_mul(SECTOR_SIZE as u64)
-                .ok_or_else(|| invalid_options(request, "`capacity_sectors` is too large"))?,
+                .ok_or("`capacity_sectors` is too large")?,
         )
     } else {
         None
@@ -145,42 +167,6 @@ fn parse_capacity_bytes(value: &str) -> Result<u64, &'static str> {
     Ok(bytes)
 }
 
-fn parse_backend(request: &VirtualDeviceRequest) -> Result<BackendConfig, ConfiguredDeviceError> {
-    let backend = request
-        .options
-        .get("backend")
-        .map(|value| {
-            value
-                .as_str()
-                .ok_or_else(|| invalid_options(request, "`backend` must be `file` or `ramdisk`"))
-        })
-        .transpose()?
-        .unwrap_or("file");
-    let path = request.options.get("path").map(|value| {
-        value
-            .as_str()
-            .filter(|path| !path.is_empty())
-            .ok_or_else(|| invalid_options(request, "`path` must be a non-empty string"))
-    });
-    match backend {
-        "ramdisk" if path.is_none() => Ok(BackendConfig::RamDisk),
-        "ramdisk" => Err(invalid_options(
-            request,
-            "`path` is only valid for the file backend",
-        )),
-        "file" => Ok(BackendConfig::File {
-            path: path
-                .transpose()?
-                .map(str::to_owned)
-                .unwrap_or_else(|| format!("/tmp/{}.img", request.id)),
-        }),
-        _ => Err(invalid_options(
-            request,
-            "`backend` must be `file` or `ramdisk`",
-        )),
-    }
-}
-
 fn invalid_device_config(operation: &'static str, detail: &str) -> DeviceManagerError {
     DeviceManagerError::InvalidConfig {
         operation,
@@ -211,11 +197,6 @@ struct VirtioBlkModel {
     controller: axdevice_base::InterruptControllerId,
 }
 
-enum BackendConfig {
-    RamDisk,
-    File { path: String },
-}
-
 impl DeviceModel for VirtioBlkModel {
     fn requirements(&self) -> DeviceManagerResult<DeviceRequirements> {
         DeviceRequirements::new()
@@ -228,7 +209,7 @@ impl DeviceModel for VirtioBlkModel {
             .with_wired_irq(
                 ResourceSlot::new(IRQ_SLOT)?,
                 self.controller,
-                InterruptTrigger::EdgeTriggered,
+                VIRTIO_BLK_IRQ_TRIGGER,
                 InterruptSharing::Exclusive,
                 ResourceRequest::Auto,
             )
@@ -256,7 +237,7 @@ impl DeviceModel for VirtioBlkModel {
     fn build(&self, context: &mut DeviceBuildContext<'_>) -> DeviceManagerResult<DeviceBundle> {
         let (base, size) = context.mmio(MMIO_SLOT)?;
         let irq = context.irq(IRQ_SLOT)?;
-        let irq_id = irq.input().value() as u32;
+        let resolved_irq = irq.input().value();
         let backend = self
             .backend
             .lock()
@@ -296,19 +277,23 @@ impl DeviceModel for VirtioBlkModel {
             irq,
             grant: grant.clone(),
             queue_pending: AtomicBool::new(false),
-            resources: vec![
-                Resource::MmioRange { base, size },
-                Resource::IrqLine {
-                    line: irq_id,
-                    trigger: axdevice_base::InterruptTriggerMode::EdgeTriggered,
-                },
-            ]
-            .into_boxed_slice(),
+            resources: runtime_resources(base, size, resolved_irq),
         });
         let mut bundle = DeviceBundle::new();
         bundle.add_dma_pollable_device(device.clone(), device, grant);
         Ok(bundle)
     }
+}
+
+fn runtime_resources(base: u64, size: u64, resolved_irq: usize) -> Box<[Resource]> {
+    vec![
+        Resource::MmioRange { base, size },
+        Resource::IrqLine {
+            line: resolved_irq as u32,
+            trigger: axdevice_base::InterruptTriggerMode::LevelTriggered,
+        },
+    ]
+    .into_boxed_slice()
 }
 
 enum VirtioBlkBackend {
@@ -318,13 +303,25 @@ enum VirtioBlkBackend {
 }
 
 impl VirtioBlkBackend {
-    fn open(config: &BackendConfig, capacity_bytes: Option<u64>) -> DeviceManagerResult<Self> {
+    fn open(
+        config: &BackendConfig,
+        capacity_bytes: Option<u64>,
+        vm_id: Option<usize>,
+    ) -> DeviceManagerResult<Self> {
         match config {
             BackendConfig::RamDisk => {
                 let capacity = capacity_bytes.unwrap_or(DEFAULT_CAPACITY_BYTES);
                 Ok(Self::RamDisk(RamDiskBackend::new(capacity)?))
             }
-            BackendConfig::File { path } => open_file_backend(path, capacity_bytes),
+            BackendConfig::File { path, filesystem } => {
+                let vm_id = vm_id.ok_or_else(|| {
+                    invalid_device_config(
+                        "open virtio-blk backing file",
+                        "file backend requires a VM identity",
+                    )
+                })?;
+                open_file_backend(path, capacity_bytes, *filesystem, vm_id)
+            }
         }
     }
 
@@ -341,71 +338,53 @@ impl VirtioBlkBackend {
 fn open_file_backend(
     path: &str,
     configured_capacity: Option<u64>,
+    filesystem: FilesystemFormat,
+    vm_id: usize,
 ) -> DeviceManagerResult<VirtioBlkBackend> {
     let mut options = ax_api::fs::AxOpenOptions::new();
     options.read(true);
     options.write(true);
-    options.create(true);
     let file = ax_api::fs::ax_open_file(path, &options).map_err(|error| {
         invalid_device_config(
             "open virtio-blk backing file",
             &format!("failed to open `{path}`: {error}"),
         )
     })?;
-    let existing_len = ax_api::fs::ax_file_attr(&file)
-        .map_err(|error| {
+    let mut reader = AxFileReader { file: &file };
+    let capacity =
+        inspect_file_image(&mut reader, configured_capacity, filesystem).map_err(|error| {
             invalid_device_config(
-                "inspect virtio-blk backing file",
-                &format!("failed to inspect `{path}`: {error}"),
-            )
-        })?
-        .size;
-    let capacity = configured_capacity.unwrap_or({
-        if existing_len == 0 {
-            DEFAULT_CAPACITY_BYTES
-        } else {
-            existing_len
-        }
-    });
-    if capacity == 0 || !capacity.is_multiple_of(SECTOR_SIZE as u64) {
-        return Err(invalid_device_config(
-            "validate virtio-blk backing file",
-            "backing file capacity must be a positive multiple of 512 bytes",
-        ));
-    }
-    if existing_len != capacity {
-        ax_api::fs::ax_truncate_file(&file, capacity).map_err(|error| {
-            invalid_device_config(
-                "resize virtio-blk backing file",
-                &format!("failed to resize `{path}` to {capacity} bytes: {error}"),
+                "prepare virtio-blk backing file",
+                &format!("failed to prepare `{path}`: {error}"),
             )
         })?;
-    }
-    let mut bytes = allocate_file_mirror(capacity)?;
-    let read = ax_api::fs::ax_read_file_at(&file, 0, &mut bytes).map_err(|error| {
-        invalid_device_config(
-            "load virtio-blk backing file",
-            &format!("failed to read `{path}`: {error}"),
-        )
-    })?;
-    if read != bytes.len() {
-        return Err(invalid_device_config(
-            "load virtio-blk backing file",
-            "backing file returned a short read",
-        ));
-    }
-    FileBackend::spawn(file, bytes, capacity / SECTOR_SIZE as u64).map(VirtioBlkBackend::File)
+    FileBackend::new(file, capacity / SECTOR_SIZE as u64, vm_id).map(VirtioBlkBackend::File)
 }
 
 #[cfg(feature = "fs")]
-fn allocate_file_mirror(capacity: u64) -> DeviceManagerResult<Vec<u8>> {
-    allocate_zeroed_backend_buffer(capacity, "allocate virtio-blk file mirror")
+struct AxFileReader<'a> {
+    file: &'a ax_api::fs::AxFileHandle,
+}
+
+#[cfg(feature = "fs")]
+impl ImageReader for AxFileReader<'_> {
+    fn len(&self) -> Result<u64, String> {
+        ax_api::fs::ax_file_attr(self.file)
+            .map(|attribute| attribute.size)
+            .map_err(|error| format!("{error}"))
+    }
+
+    fn read_at(&mut self, offset: u64, bytes: &mut [u8]) -> Result<usize, String> {
+        ax_api::fs::ax_read_file_at(self.file, offset, bytes).map_err(|error| format!("{error}"))
+    }
 }
 
 #[cfg(not(feature = "fs"))]
 fn open_file_backend(
     path: &str,
     _configured_capacity: Option<u64>,
+    _filesystem: FilesystemFormat,
+    _vm_id: usize,
 ) -> DeviceManagerResult<VirtioBlkBackend> {
     Err(invalid_device_config(
         "open virtio-blk backing file",
@@ -414,6 +393,30 @@ fn open_file_backend(
 }
 
 impl BlockBackend for VirtioBlkBackend {
+    fn pending_request_ready(&self) -> bool {
+        match self {
+            Self::RamDisk(backend) => backend.pending_request_ready(),
+            #[cfg(feature = "fs")]
+            Self::File(backend) => backend.pending_request_ready(),
+        }
+    }
+
+    fn cancel_pending_request(&self) {
+        match self {
+            Self::RamDisk(backend) => backend.cancel_pending_request(),
+            #[cfg(feature = "fs")]
+            Self::File(backend) => backend.cancel_pending_request(),
+        }
+    }
+
+    fn reset(&self) {
+        match self {
+            Self::RamDisk(backend) => backend.reset(),
+            #[cfg(feature = "fs")]
+            Self::File(backend) => backend.reset(),
+        }
+    }
+
     fn requires_deferred_processing(&self) -> bool {
         match self {
             Self::RamDisk(_) => false,
@@ -479,166 +482,6 @@ impl RamDiskBackend {
             return Err(VirtioError::InvalidAddress);
         }
         Ok(start..end)
-    }
-}
-
-#[cfg(feature = "fs")]
-struct FileBackend {
-    bytes: Mutex<Vec<u8>>,
-    writes: Arc<Mutex<VecDeque<FileWrite>>>,
-    pending_writes: Arc<AtomicUsize>,
-    writeback_failed: Arc<AtomicBool>,
-    stop_worker: Arc<AtomicBool>,
-    worker: Option<std::thread::JoinHandle<()>>,
-    capacity_sectors: u64,
-}
-
-#[cfg(feature = "fs")]
-struct FileWrite {
-    offset: u64,
-    bytes: Vec<u8>,
-}
-
-#[cfg(feature = "fs")]
-impl FileBackend {
-    fn spawn(
-        file: ax_api::fs::AxFileHandle,
-        bytes: Vec<u8>,
-        capacity_sectors: u64,
-    ) -> DeviceManagerResult<Self> {
-        let writes = Arc::new(Mutex::new(VecDeque::<FileWrite>::new()));
-        let worker_writes = writes.clone();
-        let pending_writes = Arc::new(AtomicUsize::new(0));
-        let worker_pending = pending_writes.clone();
-        let writeback_failed = Arc::new(AtomicBool::new(false));
-        let worker_failed = writeback_failed.clone();
-        let stop_worker = Arc::new(AtomicBool::new(false));
-        let worker_stop = stop_worker.clone();
-        let worker = std::thread::Builder::new()
-            .name("virtio-blk-file".into())
-            .spawn(move || {
-                loop {
-                    if let Some(write) = worker_writes
-                        .lock()
-                        .expect("virtio-blk file queue mutex poisoned")
-                        .pop_front()
-                    {
-                        match ax_api::fs::ax_write_file_at(&file, write.offset, &write.bytes) {
-                            Ok(written) if written == write.bytes.len() => {
-                                if let Err(error) = ax_api::fs::ax_flush_file(&file) {
-                                    error!("virtio-blk file write-back flush failed: {error}");
-                                    worker_failed.store(true, Ordering::Release);
-                                }
-                            }
-                            Ok(written) => {
-                                error!(
-                                    "virtio-blk file write-back was short: wrote {written} of {} \
-                                     bytes",
-                                    write.bytes.len()
-                                );
-                                worker_failed.store(true, Ordering::Release);
-                            }
-                            Err(error) => {
-                                error!("virtio-blk file write-back failed: {error}");
-                                worker_failed.store(true, Ordering::Release);
-                            }
-                        }
-                        worker_pending.fetch_sub(1, Ordering::AcqRel);
-                    } else if worker_stop.load(Ordering::Acquire) {
-                        break;
-                    } else {
-                        std::thread::sleep(core::time::Duration::from_millis(1));
-                    }
-                }
-            })
-            .map_err(|error| {
-                invalid_device_config(
-                    "spawn virtio-blk file worker",
-                    &format!("failed to spawn worker: {error}"),
-                )
-            })?;
-        Ok(Self {
-            bytes: Mutex::new(bytes),
-            writes,
-            pending_writes,
-            writeback_failed,
-            stop_worker,
-            worker: Some(worker),
-            capacity_sectors,
-        })
-    }
-
-    fn range(&self, sector: u64, len: usize) -> VirtioResult<core::ops::Range<usize>> {
-        let start = usize::try_from(sector)
-            .ok()
-            .and_then(|sector| sector.checked_mul(SECTOR_SIZE))
-            .ok_or(VirtioError::InvalidAddress)?;
-        let end = start.checked_add(len).ok_or(VirtioError::InvalidAddress)?;
-        if end
-            > self
-                .bytes
-                .lock()
-                .expect("virtio-blk file mirror mutex poisoned")
-                .len()
-        {
-            return Err(VirtioError::InvalidAddress);
-        }
-        Ok(start..end)
-    }
-}
-
-#[cfg(feature = "fs")]
-impl Drop for FileBackend {
-    fn drop(&mut self) {
-        // The worker drains every queued write before observing this flag, so
-        // teardown never silently discards writes already accepted from the guest.
-        self.stop_worker.store(true, Ordering::Release);
-        if let Some(worker) = self.worker.take()
-            && worker.join().is_err()
-        {
-            error!("virtio-blk file worker failed during teardown");
-        }
-    }
-}
-
-#[cfg(feature = "fs")]
-impl BlockBackend for FileBackend {
-    fn read(&self, sector: u64, buffer: &mut [u8]) -> VirtioResult<usize> {
-        let range = self.range(sector, buffer.len())?;
-        buffer.copy_from_slice(
-            &self
-                .bytes
-                .lock()
-                .expect("virtio-blk file mirror mutex poisoned")[range],
-        );
-        Ok(buffer.len())
-    }
-
-    fn write(&self, sector: u64, buffer: &[u8]) -> VirtioResult<usize> {
-        let range = self.range(sector, buffer.len())?;
-        self.bytes
-            .lock()
-            .expect("virtio-blk file mirror mutex poisoned")[range.clone()]
-        .copy_from_slice(buffer);
-        self.pending_writes.fetch_add(1, Ordering::AcqRel);
-        self.writes
-            .lock()
-            .expect("virtio-blk file queue mutex poisoned")
-            .push_back(FileWrite {
-                offset: range.start as u64,
-                bytes: buffer.to_vec(),
-            });
-        Ok(buffer.len())
-    }
-
-    fn flush(&self) -> VirtioResult<()> {
-        if self.pending_writes.load(Ordering::Acquire) != 0 {
-            return Err(VirtioError::WouldBlock);
-        }
-        if self.writeback_failed.load(Ordering::Acquire) {
-            return Err(VirtioError::BackendError);
-        }
-        Ok(())
     }
 }
 
@@ -748,13 +591,10 @@ impl Device for VirtioBlkRuntimeDevice {
             )
             .map_err(map_virtio_error)?;
         match event {
-            BlockDeviceEvent::InterruptPending => {
-                self.irq.pulse().map_err(|error| DeviceError::Backend {
-                    operation: "pulse virtio-blk interrupt",
-                    detail: format!("{error}"),
-                })?
+            BlockDeviceEvent::InterruptPending => {}
+            BlockDeviceEvent::QueuePending(0) => {
+                self.queue_pending.store(true, Ordering::Release);
             }
-            BlockDeviceEvent::QueuePending(0) => self.queue_pending.store(true, Ordering::Release),
             BlockDeviceEvent::QueuePending(_) => {
                 return Err(DeviceError::InvalidInput {
                     operation: "notify virtio-blk queue",
@@ -766,6 +606,12 @@ impl Device for VirtioBlkRuntimeDevice {
             }
             BlockDeviceEvent::None => {}
         }
+        synchronize_interrupt_line(&self.irq, self.model.interrupt_status()).map_err(|error| {
+            DeviceError::Backend {
+                operation: "synchronize virtio-blk interrupt",
+                detail: format!("{error}"),
+            }
+        })?;
         Ok(())
     }
 }
@@ -789,14 +635,7 @@ impl DmaPollableDeviceOps for VirtioBlkRuntimeDevice {
                 detail: format!("{error:?}"),
             })?;
         match event {
-            BlockDeviceEvent::InterruptPending => {
-                self.irq
-                    .pulse()
-                    .map_err(|error| DeviceManagerError::InvalidState {
-                        operation: "pulse deferred virtio-blk interrupt",
-                        detail: format!("{error}"),
-                    })?;
-            }
+            BlockDeviceEvent::InterruptPending => {}
             BlockDeviceEvent::QueuePending(0) => {
                 self.queue_pending.store(true, Ordering::Release);
             }
@@ -808,6 +647,12 @@ impl DmaPollableDeviceOps for VirtioBlkRuntimeDevice {
             }
             BlockDeviceEvent::None | BlockDeviceEvent::Reset => {}
         }
+        synchronize_interrupt_line(&self.irq, self.model.interrupt_status()).map_err(|error| {
+            DeviceManagerError::InvalidState {
+                operation: "synchronize deferred virtio-blk interrupt",
+                detail: format!("{error}"),
+            }
+        })?;
         Ok(())
     }
 }
@@ -821,7 +666,70 @@ fn map_virtio_error(error: VirtioError) -> DeviceError {
 
 #[cfg(test)]
 mod tests {
-    use super::{allocate_zeroed_backend_buffer, parse_capacity_bytes};
+    use axdevice::DeviceNodeId;
+    use axdevice_base::{InterruptControllerId, InterruptTrigger, Resource};
+    use axvmconfig::VirtualDeviceRequest;
+
+    use super::{
+        super::register, VIRTIO_BLK_IRQ_TRIGGER, allocate_zeroed_backend_buffer,
+        interrupt_line_should_be_asserted, parse_capacity_bytes, runtime_resources,
+    };
+    use crate::{ConfiguredDeviceCatalog, DeviceInstantiationContext};
+
+    #[test]
+    fn ramdisk_catalog_instantiation_does_not_require_vm_id() {
+        let mut request = virtual_device_request();
+        request
+            .options
+            .insert("backend".into(), toml::Value::String("ramdisk".into()));
+
+        assert!(
+            registered_catalog()
+                .instantiate_node(&request, &context_without_vm_id())
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn file_catalog_instantiation_requires_vm_id() {
+        let mut request = virtual_device_request();
+        request
+            .options
+            .insert("filesystem".into(), toml::Value::String("ext4".into()));
+        let error = match registered_catalog().instantiate_node(&request, &context_without_vm_id())
+        {
+            Err(error) => error,
+            Ok(_) => panic!("file backend must require a VM identity"),
+        };
+
+        assert!(matches!(
+            error,
+            crate::ConfiguredDeviceError::Instantiation { detail, .. }
+                if detail.contains("requires a VM identity")
+        ));
+    }
+
+    #[test]
+    fn virtio_blk_interrupt_is_level_triggered() {
+        assert_eq!(
+            VIRTIO_BLK_IRQ_TRIGGER,
+            InterruptTrigger::LevelTriggered,
+            "VirtIO MMIO interrupt status remains pending until the driver acknowledges it"
+        );
+    }
+
+    #[test]
+    fn virtio_blk_interrupt_line_tracks_pending_status() {
+        assert!(!interrupt_line_should_be_asserted(0));
+        assert!(interrupt_line_should_be_asserted(1));
+        assert!(interrupt_line_should_be_asserted(u32::MAX));
+    }
+
+    #[test]
+    fn runtime_inventory_uses_resolved_irq() {
+        let resources = runtime_resources(0x8000_0000, 0x200, 7);
+        assert!(matches!(resources[1], Resource::IrqLine { line: 7, .. }));
+    }
 
     #[test]
     fn parses_decimal_and_binary_capacity_suffixes() {
@@ -840,5 +748,26 @@ mod tests {
     #[test]
     fn oversized_backend_capacity_returns_configuration_error() {
         assert!(allocate_zeroed_backend_buffer(u64::MAX, "test virtio-blk allocation").is_err());
+    }
+
+    fn registered_catalog() -> ConfiguredDeviceCatalog {
+        let mut catalog = ConfiguredDeviceCatalog::new();
+        register(&mut catalog).expect("register virtio-blk model");
+        catalog
+    }
+
+    fn context_without_vm_id() -> DeviceInstantiationContext {
+        DeviceInstantiationContext::new().with_default_wired_controller(
+            DeviceNodeId::new("controller").expect("valid controller node ID"),
+            InterruptControllerId::new(0),
+        )
+    }
+
+    fn virtual_device_request() -> VirtualDeviceRequest {
+        VirtualDeviceRequest {
+            id: "disk0".into(),
+            model: "virtio-blk".into(),
+            options: Default::default(),
+        }
     }
 }

--- a/virtualization/axvm/src/configured/devices/virtio_blk/file.rs
+++ b/virtualization/axvm/src/configured/devices/virtio_blk/file.rs
@@ -1,0 +1,726 @@
+//! On-demand file I/O with one bounded, owned request in flight.
+//!
+//! The virtqueue retries its pending head after `WouldBlock`. Only the worker
+//! touches storage; guest memory never escapes the scoped polling call.
+//! Reset discards queued/completed work and drains running I/O before reuse.
+
+use std::{
+    format,
+    sync::{Arc, Mutex},
+    thread::JoinHandle,
+    vec::Vec,
+};
+
+use axvirtio_blk::{BlockBackend, VirtioBlockConfig};
+use axvirtio_common::{VirtioError, VirtioResult};
+
+fn max_request_bytes() -> usize {
+    let config = VirtioBlockConfig::default();
+    config.seg_max as usize * config.size_max as usize
+}
+const IO_CHUNK_BYTES: usize = 4096;
+const WORKER_STACK_BYTES: usize = 1024 * 1024;
+
+pub(super) struct FileBackend {
+    shared: Arc<Mutex<Shared>>,
+    worker: Option<JoinHandle<()>>,
+    pub(super) capacity_sectors: u64,
+}
+
+trait Storage: Send + 'static {
+    fn read_at(&mut self, offset: u64, bytes: &mut [u8]) -> VirtioResult<usize>;
+    fn write_at(&mut self, offset: u64, bytes: &[u8]) -> VirtioResult<usize>;
+    fn sync(&mut self) -> VirtioResult<()>;
+}
+
+struct AxStorage(ax_api::fs::AxFileHandle);
+
+impl Storage for AxStorage {
+    fn read_at(&mut self, offset: u64, bytes: &mut [u8]) -> VirtioResult<usize> {
+        ax_api::fs::ax_read_file_at(&self.0, offset, bytes).map_err(|error| {
+            log::error!("virtio-blk read at {offset:#x} failed: {error}");
+            VirtioError::BackendError
+        })
+    }
+
+    fn write_at(&mut self, offset: u64, bytes: &[u8]) -> VirtioResult<usize> {
+        ax_api::fs::ax_write_file_at(&self.0, offset, bytes).map_err(|error| {
+            log::error!("virtio-blk write at {offset:#x} failed: {error}");
+            VirtioError::BackendError
+        })
+    }
+
+    fn sync(&mut self) -> VirtioResult<()> {
+        ax_api::fs::ax_flush_file(&self.0).map_err(|error| {
+            log::error!("virtio-blk flush failed: {error}");
+            VirtioError::BackendError
+        })
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum Kind {
+    Read,
+    Write,
+    Flush,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct RequestKey {
+    kind: Kind,
+    offset: u64,
+    len: usize,
+}
+
+struct Operation {
+    key: RequestKey,
+    bytes: Vec<u8>,
+}
+
+#[derive(Default)]
+enum State {
+    #[default]
+    Idle,
+    Queued(Operation),
+    Running {
+        key: RequestKey,
+        cancelled: bool,
+    },
+    Complete {
+        operation: Operation,
+        result: VirtioResult<()>,
+    },
+}
+
+#[derive(Default)]
+struct Shared {
+    state: State,
+    stopping: bool,
+}
+
+impl Shared {
+    fn cancel(&mut self) {
+        match &mut self.state {
+            State::Running { cancelled, .. } => *cancelled = true,
+            _ => self.state = State::Idle,
+        }
+    }
+
+    fn take_work(&mut self) -> Option<Operation> {
+        if let State::Queued(operation) = &self.state {
+            let running = State::Running {
+                key: operation.key,
+                cancelled: false,
+            };
+            if let State::Queued(operation) = core::mem::replace(&mut self.state, running) {
+                return Some(operation);
+            }
+        }
+        None
+    }
+
+    fn finish(&mut self, operation: Operation, result: VirtioResult<()>) {
+        self.state = match self.state {
+            State::Running {
+                cancelled: false, ..
+            } => State::Complete { operation, result },
+            _ => State::Idle,
+        };
+    }
+}
+
+impl FileBackend {
+    pub(super) fn new(
+        file: ax_api::fs::AxFileHandle,
+        capacity_sectors: u64,
+        vm_id: usize,
+    ) -> axdevice::DeviceManagerResult<Self> {
+        Self::spawn(AxStorage(file), capacity_sectors, pin_worker, move || {
+            // notify_vm publishes device work and requests execution on vCPU0.
+            if let Err(error) = crate::AxvmRuntime::notify_vm(vm_id) {
+                log::warn!("failed to notify VM[{vm_id}] of file I/O completion: {error}");
+            }
+        })
+        .map_err(|error| axdevice::DeviceManagerError::InvalidConfig {
+            operation: "spawn virtio-blk file worker",
+            detail: format!("{error}"),
+        })
+    }
+
+    fn spawn<S: Storage>(
+        mut storage: S,
+        capacity_sectors: u64,
+        start: fn(),
+        notify: impl Fn() + Send + 'static,
+    ) -> std::io::Result<Self> {
+        let shared = Arc::new(Mutex::new(Shared::default()));
+        let worker_shared = shared.clone();
+        let worker = std::thread::Builder::new()
+            .name("virtio-blk-file".into())
+            .stack_size(WORKER_STACK_BYTES)
+            .spawn(move || {
+                start();
+                loop {
+                    // Never hold the state lock across storage I/O or notification.
+                    let operation = {
+                        let mut shared = worker_shared.lock().expect("file state mutex poisoned");
+                        let work = shared.take_work();
+                        if work.is_none() && shared.stopping {
+                            break;
+                        }
+                        work
+                    };
+                    if let Some(mut operation) = operation {
+                        let result = execute(&mut storage, &mut operation);
+                        worker_shared
+                            .lock()
+                            .expect("file state mutex poisoned")
+                            .finish(operation, result);
+                        notify();
+                    } else {
+                        // unpark retains a token when it races this call.
+                        std::thread::park();
+                    }
+                }
+                if let Err(error) = storage.sync() {
+                    log::error!("virtio-blk shutdown sync failed: {error:?}");
+                }
+            })?;
+        Ok(Self {
+            shared,
+            worker: Some(worker),
+            capacity_sectors,
+        })
+    }
+
+    fn key(&self, kind: Kind, sector: u64, len: usize) -> VirtioResult<RequestKey> {
+        if len > max_request_bytes() {
+            return Err(VirtioError::InvalidBufferSize);
+        }
+        let offset = sector.checked_mul(512).ok_or(VirtioError::InvalidAddress)?;
+        let end = offset
+            .checked_add(len as u64)
+            .ok_or(VirtioError::InvalidAddress)?;
+        let capacity = self
+            .capacity_sectors
+            .checked_mul(512)
+            .ok_or(VirtioError::InvalidAddress)?;
+        if end > capacity {
+            return Err(VirtioError::InvalidAddress);
+        }
+        Ok(RequestKey { kind, offset, len })
+    }
+
+    fn poll(&self, key: RequestKey, write_bytes: Option<&[u8]>) -> VirtioResult<Operation> {
+        let mut shared = self.shared.lock().expect("file state mutex poisoned");
+        if shared.stopping {
+            return Err(VirtioError::DeviceNotReady);
+        }
+        match &shared.state {
+            State::Idle => {
+                let mut bytes = Vec::new();
+                bytes
+                    .try_reserve_exact(key.len)
+                    .map_err(|_| VirtioError::MemoryError)?;
+                bytes.resize(key.len, 0);
+                if let Some(source) = write_bytes {
+                    bytes.copy_from_slice(source);
+                }
+                shared.state = State::Queued(Operation { key, bytes });
+                drop(shared);
+                self.wake_worker();
+                Err(VirtioError::WouldBlock)
+            }
+            State::Running {
+                cancelled: true, ..
+            } => Err(VirtioError::WouldBlock),
+            State::Queued(operation) | State::Complete { operation, .. }
+                if operation.key != key =>
+            {
+                shared.cancel();
+                Err(VirtioError::InvalidRequest)
+            }
+            State::Running { key: running, .. } if *running != key => {
+                shared.cancel();
+                Err(VirtioError::InvalidRequest)
+            }
+            State::Queued(_) | State::Running { .. } => Err(VirtioError::WouldBlock),
+            State::Complete { .. } => {
+                let State::Complete { operation, result } = core::mem::take(&mut shared.state)
+                else {
+                    unreachable!()
+                };
+                result?;
+                Ok(operation)
+            }
+        }
+    }
+
+    fn wake_worker(&self) {
+        if let Some(worker) = &self.worker {
+            worker.thread().unpark();
+        }
+    }
+}
+
+fn pin_worker() {
+    let cpu = crate::host::cpu::current_id();
+    if ax_api::task::ax_set_current_affinity(ax_api::task::AxCpuMask::one_shot(cpu)).is_err() {
+        log::warn!("failed to pin virtio-blk file worker to CPU{cpu}");
+    }
+}
+
+fn execute(storage: &mut impl Storage, operation: &mut Operation) -> VirtioResult<()> {
+    if operation.key.kind == Kind::Flush {
+        return storage.sync();
+    }
+    let mut done = 0;
+    while done < operation.bytes.len() {
+        let end = (done + IO_CHUNK_BYTES).min(operation.bytes.len());
+        let offset = operation.key.offset + done as u64;
+        let count = match operation.key.kind {
+            Kind::Read => storage.read_at(offset, &mut operation.bytes[done..end])?,
+            Kind::Write => storage.write_at(offset, &operation.bytes[done..end])?,
+            Kind::Flush => unreachable!(),
+        };
+        if count == 0 || count > end - done {
+            return Err(VirtioError::BackendError);
+        }
+        done += count;
+    }
+    Ok(())
+}
+
+impl BlockBackend for FileBackend {
+    fn pending_request_ready(&self) -> bool {
+        let shared = self.shared.lock().expect("file state mutex poisoned");
+        shared.stopping || matches!(shared.state, State::Idle | State::Complete { .. })
+    }
+
+    fn requires_deferred_processing(&self) -> bool {
+        true
+    }
+
+    fn read(&self, sector: u64, buffer: &mut [u8]) -> VirtioResult<usize> {
+        let key = self.key(Kind::Read, sector, buffer.len())?;
+        let completed = self.poll(key, None)?;
+        buffer.copy_from_slice(&completed.bytes);
+        Ok(buffer.len())
+    }
+
+    fn write(&self, sector: u64, buffer: &[u8]) -> VirtioResult<usize> {
+        let key = self.key(Kind::Write, sector, buffer.len())?;
+        self.poll(key, Some(buffer))?;
+        Ok(buffer.len())
+    }
+
+    fn flush(&self) -> VirtioResult<()> {
+        self.poll(
+            RequestKey {
+                kind: Kind::Flush,
+                offset: 0,
+                len: 0,
+            },
+            None,
+        )?;
+        Ok(())
+    }
+
+    fn cancel_pending_request(&self) {
+        self.shared
+            .lock()
+            .expect("file state mutex poisoned")
+            .cancel();
+    }
+}
+
+impl Drop for FileBackend {
+    fn drop(&mut self) {
+        self.shared
+            .lock()
+            .expect("file state mutex poisoned")
+            .stopping = true;
+        self.wake_worker();
+        if let Some(worker) = self.worker.take()
+            && worker.join().is_err()
+        {
+            log::error!("virtio-blk file worker failed during teardown");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{sync::mpsc, time::Duration};
+
+    use super::*;
+
+    fn manual_backend() -> FileBackend {
+        FileBackend {
+            shared: Arc::new(Mutex::new(Shared::default())),
+            worker: None,
+            capacity_sectors: (1 << 40) / 512,
+        }
+    }
+
+    #[test]
+    fn failed_retry_cannot_complete_a_later_write_with_old_data() {
+        use axvirtio_blk::{BlockDeviceEvent, VirtioMmioBlockDevice};
+        use axvirtio_common::{GuestMemory, NoGuestMemoryAccessor};
+        use axvm_types::{AccessWidth, GuestPhysAddr};
+
+        struct Memory {
+            bytes: Vec<u8>,
+            fail_data: bool,
+            read_calls: usize,
+        }
+        impl GuestMemory for Memory {
+            fn read(&mut self, addr: GuestPhysAddr, bytes: &mut [u8]) -> VirtioResult<()> {
+                self.read_calls += 1;
+                if self.fail_data && addr.as_usize() == 0x400 {
+                    return Err(VirtioError::MemoryError);
+                }
+                let start = addr.as_usize();
+                bytes.copy_from_slice(&self.bytes[start..start + bytes.len()]);
+                Ok(())
+            }
+            fn write(&mut self, addr: GuestPhysAddr, bytes: &[u8]) -> VirtioResult<()> {
+                let start = addr.as_usize();
+                self.bytes[start..start + bytes.len()].copy_from_slice(bytes);
+                Ok(())
+            }
+        }
+        for complete_before_failure in [false, true] {
+            let backend = manual_backend();
+            let shared = backend.shared.clone();
+            let model = VirtioMmioBlockDevice::new(
+                GuestPhysAddr::from(0x1000),
+                0x200,
+                backend,
+                VirtioBlockConfig {
+                    capacity: 8,
+                    ..Default::default()
+                },
+                NoGuestMemoryAccessor,
+            )
+            .unwrap();
+            let mut memory = Memory {
+                bytes: vec![0; 0x1000],
+                fail_data: false,
+                read_calls: 0,
+            };
+            for (index, (address, len, flags, next)) in [
+                (0x300_u64, 16_u32, 1_u16, 1_u16),
+                (0x400, 512, 1, 2),
+                (0x800, 1, 2, 0),
+            ]
+            .into_iter()
+            .enumerate()
+            {
+                let start = 0x100 + index * 16;
+                memory.bytes[start..start + 8].copy_from_slice(&address.to_le_bytes());
+                memory.bytes[start + 8..start + 12].copy_from_slice(&len.to_le_bytes());
+                memory.bytes[start + 12..start + 14].copy_from_slice(&flags.to_le_bytes());
+                memory.bytes[start + 14..start + 16].copy_from_slice(&next.to_le_bytes());
+            }
+            memory.bytes[0x300..0x304].copy_from_slice(&1_u32.to_le_bytes());
+            memory.bytes[0x400..0x600].fill(0x11);
+            memory.bytes[0x202..0x204].copy_from_slice(&1_u16.to_le_bytes());
+            for (register, value) in [
+                (0x30, 0),
+                (0x38, 4),
+                (0x80, 0x100),
+                (0x90, 0x200),
+                (0xa0, 0x240),
+                (0x44, 1),
+            ] {
+                model
+                    .mmio_write_with_memory(
+                        GuestPhysAddr::from(0x1000 + register),
+                        AccessWidth::Dword,
+                        value,
+                        &mut memory,
+                    )
+                    .unwrap();
+            }
+            model.set_status(4);
+            assert_eq!(
+                model.process_pending_queue(0, &mut memory),
+                Ok(BlockDeviceEvent::QueuePending(0))
+            );
+            let mut old = Some(shared.lock().unwrap().take_work().unwrap());
+            let reads_before_wait = memory.read_calls;
+            for _ in 0..32 {
+                assert_eq!(
+                    model.process_pending_queue(0, &mut memory),
+                    Ok(BlockDeviceEvent::QueuePending(0))
+                );
+            }
+            assert_eq!(
+                memory.read_calls, reads_before_wait,
+                "waiting for storage must not reread descriptors or copy guest data"
+            );
+            if complete_before_failure {
+                shared.lock().unwrap().finish(old.take().unwrap(), Ok(()));
+            }
+            memory.fail_data = true;
+            if !complete_before_failure {
+                assert_eq!(
+                    model.process_pending_queue(0, &mut memory),
+                    Ok(BlockDeviceEvent::QueuePending(0))
+                );
+                shared.lock().unwrap().finish(old.take().unwrap(), Ok(()));
+            }
+            model.process_pending_queue(0, &mut memory).unwrap();
+            assert_eq!(memory.bytes[0x800], 1, "the failed retry must report IOERR");
+            if let Some(old) = old {
+                shared.lock().unwrap().finish(old, Ok(()));
+            }
+            // Reuse the returned descriptor with the same range but new contents.
+            memory.fail_data = false;
+            memory.bytes[0x400..0x600].fill(0x22);
+            memory.bytes[0x800] = 0xff;
+            memory.bytes[0x202..0x204].copy_from_slice(&2_u16.to_le_bytes());
+            assert_eq!(
+                model.process_pending_queue(0, &mut memory),
+                Ok(BlockDeviceEvent::QueuePending(0)),
+                "a later write must issue fresh I/O, not consume the abandoned result"
+            );
+            assert_eq!(memory.bytes[0x800], 0xff);
+            let fresh = shared
+                .lock()
+                .unwrap()
+                .take_work()
+                .expect("new storage write");
+            assert_eq!(fresh.bytes, vec![0x22; 512]);
+            shared.lock().unwrap().finish(fresh, Ok(()));
+            model.process_pending_queue(0, &mut memory).unwrap();
+            assert_eq!(memory.bytes[0x800], 0);
+        }
+    }
+
+    #[test]
+    fn read_waits_for_storage_and_returns_only_completed_bytes() {
+        let backend = manual_backend();
+        let mut bytes = [0xcc; 512];
+        assert_eq!(backend.read(100, &mut bytes), Err(VirtioError::WouldBlock));
+        assert_eq!(bytes, [0xcc; 512]);
+        let mut work = backend.shared.lock().unwrap().take_work().unwrap();
+        assert_eq!(work.key.offset, 100 * 512);
+        assert_eq!(work.bytes.len(), 512);
+        assert_eq!(backend.read(100, &mut bytes), Err(VirtioError::WouldBlock));
+        work.bytes.fill(0x42);
+        backend.shared.lock().unwrap().finish(work, Ok(()));
+        assert_eq!(backend.read(100, &mut bytes), Ok(512));
+        assert_eq!(bytes, [0x42; 512]);
+        assert!(matches!(backend.shared.lock().unwrap().state, State::Idle));
+    }
+
+    #[test]
+    fn writes_snapshot_once_and_report_storage_errors() {
+        let backend = manual_backend();
+        let mut bytes = [0x31; 512];
+        assert_eq!(backend.write(7, &bytes), Err(VirtioError::WouldBlock));
+        bytes.fill(0x99);
+        assert_eq!(backend.write(7, &bytes), Err(VirtioError::WouldBlock));
+        let work = backend.shared.lock().unwrap().take_work().unwrap();
+        assert_eq!(work.bytes, [0x31; 512]);
+        backend
+            .shared
+            .lock()
+            .unwrap()
+            .finish(work, Err(VirtioError::BackendError));
+        assert_eq!(backend.write(7, &bytes), Err(VirtioError::BackendError));
+        assert!(matches!(backend.shared.lock().unwrap().state, State::Idle));
+    }
+
+    #[test]
+    fn flush_waits_for_sync_and_propagates_failure() {
+        let backend = manual_backend();
+        assert_eq!(backend.flush(), Err(VirtioError::WouldBlock));
+        let work = backend.shared.lock().unwrap().take_work().unwrap();
+        assert_eq!(work.key.kind, Kind::Flush);
+        assert!(work.bytes.is_empty());
+        assert_eq!(backend.flush(), Err(VirtioError::WouldBlock));
+        backend
+            .shared
+            .lock()
+            .unwrap()
+            .finish(work, Err(VirtioError::BackendError));
+        assert_eq!(backend.flush(), Err(VirtioError::BackendError));
+    }
+
+    #[test]
+    fn reset_drains_old_io_without_reusing_its_completion() {
+        let backend = manual_backend();
+        let mut bytes = [0; 512];
+        assert_eq!(backend.read(0, &mut bytes), Err(VirtioError::WouldBlock));
+        backend.reset();
+        assert!(backend.shared.lock().unwrap().take_work().is_none());
+        assert_eq!(backend.read(0, &mut bytes), Err(VirtioError::WouldBlock));
+        let old = backend.shared.lock().unwrap().take_work().unwrap();
+        backend.reset();
+        assert_eq!(backend.read(0, &mut bytes), Err(VirtioError::WouldBlock));
+        backend.shared.lock().unwrap().finish(old, Ok(()));
+        // Even an identical request after reset must issue fresh storage I/O.
+        assert_eq!(backend.read(0, &mut bytes), Err(VirtioError::WouldBlock));
+        let fresh = backend.shared.lock().unwrap().take_work().unwrap();
+        backend.shared.lock().unwrap().finish(fresh, Ok(()));
+        backend.reset();
+        assert_eq!(backend.read(0, &mut bytes), Err(VirtioError::WouldBlock));
+    }
+
+    #[test]
+    fn oversized_and_out_of_range_io_are_rejected_before_queueing() {
+        let backend = manual_backend();
+        assert_eq!(
+            backend.key(Kind::Read, 0, max_request_bytes() + 1),
+            Err(VirtioError::InvalidBufferSize)
+        );
+        assert_eq!(
+            backend.key(Kind::Read, u64::MAX, 512),
+            Err(VirtioError::InvalidAddress)
+        );
+        assert_eq!(
+            backend.read(backend.capacity_sectors, &mut [0; 512]),
+            Err(VirtioError::InvalidAddress)
+        );
+        assert!(matches!(backend.shared.lock().unwrap().state, State::Idle));
+    }
+
+    struct PartialStorage {
+        bytes: Vec<u8>,
+        fail: bool,
+        zero: bool,
+    }
+    impl Storage for PartialStorage {
+        fn read_at(&mut self, offset: u64, bytes: &mut [u8]) -> VirtioResult<usize> {
+            if self.fail {
+                return Err(VirtioError::BackendError);
+            }
+            if self.zero {
+                return Ok(0);
+            }
+            let count = bytes.len().min(17);
+            bytes[..count].copy_from_slice(&self.bytes[offset as usize..offset as usize + count]);
+            Ok(count)
+        }
+        fn write_at(&mut self, offset: u64, bytes: &[u8]) -> VirtioResult<usize> {
+            if self.fail {
+                return Err(VirtioError::BackendError);
+            }
+            if self.zero {
+                return Ok(0);
+            }
+            let count = bytes.len().min(17);
+            self.bytes[offset as usize..offset as usize + count].copy_from_slice(&bytes[..count]);
+            Ok(count)
+        }
+        fn sync(&mut self) -> VirtioResult<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn partial_io_advances_offsets_and_zero_progress_is_an_error() {
+        let mut storage = PartialStorage {
+            bytes: vec![0; 8192],
+            fail: false,
+            zero: false,
+        };
+        let mut operation = Operation {
+            key: RequestKey {
+                kind: Kind::Write,
+                offset: 512,
+                len: 4608,
+            },
+            bytes: vec![0x5a; 4608],
+        };
+        execute(&mut storage, &mut operation).unwrap();
+        assert_eq!(&storage.bytes[512..512 + 4608], &[0x5a; 4608]);
+        operation.key.kind = Kind::Read;
+        operation.bytes.fill(0);
+        execute(&mut storage, &mut operation).unwrap();
+        assert_eq!(operation.bytes, vec![0x5a; 4608]);
+        storage.zero = true;
+        assert_eq!(
+            execute(&mut storage, &mut operation),
+            Err(VirtioError::BackendError)
+        );
+        operation.key.kind = Kind::Write;
+        assert_eq!(
+            execute(&mut storage, &mut operation),
+            Err(VirtioError::BackendError)
+        );
+        storage.fail = true;
+        assert_eq!(
+            execute(&mut storage, &mut operation),
+            Err(VirtioError::BackendError)
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn sparse_large_file_roundtrip_uses_real_worker_and_flush() {
+        use std::os::unix::fs::FileExt;
+        struct HostFile(std::fs::File);
+        impl Storage for HostFile {
+            fn read_at(&mut self, offset: u64, bytes: &mut [u8]) -> VirtioResult<usize> {
+                self.0
+                    .read_at(bytes, offset)
+                    .map_err(|_| VirtioError::BackendError)
+            }
+            fn write_at(&mut self, offset: u64, bytes: &[u8]) -> VirtioResult<usize> {
+                self.0
+                    .write_at(bytes, offset)
+                    .map_err(|_| VirtioError::BackendError)
+            }
+            fn sync(&mut self) -> VirtioResult<()> {
+                self.0.sync_all().map_err(|_| VirtioError::BackendError)
+            }
+        }
+        let path = std::env::temp_dir().join(format!("axvm-sparse-{}.img", std::process::id()));
+        let file = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create_new(true)
+            .open(&path)
+            .unwrap();
+        // Unlink immediately: the open descriptors own this disposable fixture.
+        std::fs::remove_file(&path).unwrap();
+        let capacity = 64_u64 << 30;
+        file.set_len(capacity).unwrap();
+        let observer = file.try_clone().unwrap();
+        let (send, receive) = mpsc::channel();
+        let backend = FileBackend::spawn(
+            HostFile(file),
+            capacity / 512,
+            || {},
+            move || {
+                let _ = send.send(());
+            },
+        )
+        .unwrap();
+        let sector = capacity / 512 - 1;
+        assert_eq!(
+            backend.write(sector, &[0x4b; 512]),
+            Err(VirtioError::WouldBlock)
+        );
+        receive.recv_timeout(Duration::from_secs(10)).unwrap();
+        assert_eq!(backend.write(sector, &[0x4b; 512]), Ok(512));
+        assert_eq!(backend.flush(), Err(VirtioError::WouldBlock));
+        receive.recv_timeout(Duration::from_secs(10)).unwrap();
+        assert_eq!(backend.flush(), Ok(()));
+        let mut bytes = [0; 512];
+        assert_eq!(observer.read_at(&mut bytes, capacity - 512).unwrap(), 512);
+        assert_eq!(bytes, [0x4b; 512]);
+        assert_eq!(
+            backend.read(sector, &mut bytes),
+            Err(VirtioError::WouldBlock)
+        );
+        receive.recv_timeout(Duration::from_secs(10)).unwrap();
+        assert_eq!(backend.read(sector, &mut bytes), Ok(512));
+        assert_eq!(bytes, [0x4b; 512]);
+        drop(backend);
+    }
+}

--- a/virtualization/axvm/src/configured/devices/virtio_blk/image.rs
+++ b/virtualization/axvm/src/configured/devices/virtio_blk/image.rs
@@ -1,0 +1,375 @@
+//! Bounded metadata validation of existing filesystem images.
+
+use core::fmt;
+#[cfg(test)]
+use std::vec::Vec;
+use std::{format, string::String};
+
+#[cfg(test)]
+use rsext4::{
+    BLOCK_SIZE, BlockIo, DeviceCapabilities, DeviceGeometry, Ext4Timestamp, Jbd2Dev, SectorId,
+    error::{Ext4Error, Ext4Result},
+};
+use rsext4::{SUPERBLOCK_OFFSET, SUPERBLOCK_SIZE, endian::DiskFormat, superblock::Ext4Superblock};
+
+use super::options::FilesystemFormat;
+
+#[cfg(test)]
+struct Ext4Image<'a> {
+    bytes: &'a mut [u8],
+}
+
+#[cfg(test)]
+impl<'a> Ext4Image<'a> {
+    fn new(bytes: &'a mut [u8]) -> Ext4Result<Self> {
+        if !bytes.len().is_multiple_of(BLOCK_SIZE) {
+            return Err(Ext4Error::invalid_block_size(bytes.len(), BLOCK_SIZE));
+        }
+        Ok(Self { bytes })
+    }
+
+    fn range(
+        &self,
+        sector: SectorId,
+        count: u32,
+        buffer_len: usize,
+    ) -> Ext4Result<core::ops::Range<usize>> {
+        let expected_len = usize::try_from(count)
+            .ok()
+            .and_then(|count| count.checked_mul(BLOCK_SIZE))
+            .ok_or_else(Ext4Error::invalid_input)?;
+        if buffer_len != expected_len {
+            return Err(Ext4Error::invalid_block_size(buffer_len, expected_len));
+        }
+        let start = sector
+            .as_usize()?
+            .checked_mul(BLOCK_SIZE)
+            .ok_or_else(Ext4Error::invalid_input)?;
+        let end = start
+            .checked_add(buffer_len)
+            .ok_or_else(Ext4Error::invalid_input)?;
+        if end > self.bytes.len() {
+            return Err(Ext4Error::block_out_of_range(
+                sector.to_u32()?,
+                self.block_count(),
+            ));
+        }
+        Ok(start..end)
+    }
+
+    fn block_count(&self) -> u64 {
+        (self.bytes.len() / BLOCK_SIZE) as u64
+    }
+}
+
+#[cfg(test)]
+impl BlockIo for Ext4Image<'_> {
+    fn write(&mut self, buffer: &[u8], sector: SectorId, count: u32) -> Ext4Result<()> {
+        let range = self.range(sector, count, buffer.len())?;
+        self.bytes[range].copy_from_slice(buffer);
+        Ok(())
+    }
+
+    fn read(&mut self, buffer: &mut [u8], sector: SectorId, count: u32) -> Ext4Result<()> {
+        let range = self.range(sector, count, buffer.len())?;
+        buffer.copy_from_slice(&self.bytes[range]);
+        Ok(())
+    }
+
+    fn geometry(&self) -> DeviceGeometry {
+        DeviceGeometry::new(BLOCK_SIZE as u32, self.block_count())
+    }
+
+    fn capabilities(&self) -> DeviceCapabilities {
+        DeviceCapabilities {
+            flush: true,
+            ..DeviceCapabilities::default()
+        }
+    }
+
+    fn flush(&mut self) -> Ext4Result<()> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+impl rsext4::Clock for Ext4Image<'_> {
+    fn now(&self) -> Ext4Result<Ext4Timestamp> {
+        Ok(Ext4Timestamp::UNIX_EPOCH)
+    }
+}
+
+fn validate_ext4_image(raw: &[u8], image_len: u64) -> Result<(), &'static str> {
+    let superblock = Ext4Superblock::from_disk_bytes(raw);
+    if !superblock.is_valid() {
+        return Err("ext4 superblock magic is invalid");
+    }
+    superblock
+        .validate_geometry()
+        .map_err(|_| "ext4 superblock geometry is invalid")?;
+    let superblock = superblock
+        .verify_superblock()
+        .map_err(|_| "ext4 superblock checksum is invalid")?;
+    let filesystem_bytes = superblock
+        .blocks_count()
+        .checked_mul(superblock.block_size())
+        .ok_or("ext4 filesystem size overflowed")?;
+    if filesystem_bytes > image_len {
+        return Err("ext4 filesystem exceeds the backing file length");
+    }
+    Ok(())
+}
+
+pub(crate) trait ImageReader {
+    fn len(&self) -> Result<u64, String>;
+    fn read_at(&mut self, offset: u64, bytes: &mut [u8]) -> Result<usize, String>;
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) struct ImagePreparationError {
+    operation: &'static str,
+    detail: String,
+}
+
+impl ImagePreparationError {
+    pub(crate) fn new(operation: &'static str, detail: impl Into<String>) -> Self {
+        Self {
+            operation,
+            detail: detail.into(),
+        }
+    }
+}
+
+impl fmt::Display for ImagePreparationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{}: {}", self.operation, self.detail)
+    }
+}
+
+pub(crate) fn inspect_file_image<R: ImageReader>(
+    reader: &mut R,
+    configured_capacity: Option<u64>,
+    filesystem: FilesystemFormat,
+) -> Result<u64, ImagePreparationError> {
+    let existing_len = reader
+        .len()
+        .map_err(|detail| ImagePreparationError::new("inspect backing file", detail))?;
+    if existing_len == 0 {
+        return Err(ImagePreparationError::new(
+            "validate backing file",
+            "backing file must contain an existing filesystem image",
+        ));
+    }
+    if !existing_len.is_multiple_of(512) {
+        return Err(ImagePreparationError::new(
+            "validate backing file",
+            "backing file length must be a multiple of 512 bytes",
+        ));
+    }
+    if let Some(configured_capacity) = configured_capacity
+        && configured_capacity != existing_len
+    {
+        return Err(ImagePreparationError::new(
+            "validate backing file",
+            format!(
+                "configured capacity {configured_capacity} does not match backing file length \
+                 {existing_len}"
+            ),
+        ));
+    }
+
+    if existing_len < SUPERBLOCK_OFFSET + SUPERBLOCK_SIZE as u64 {
+        return Err(ImagePreparationError::new(
+            "validate ext4 image",
+            "backing file is too small to contain an ext4 superblock",
+        ));
+    }
+    let mut bytes = [0; SUPERBLOCK_SIZE];
+    let read = reader
+        .read_at(SUPERBLOCK_OFFSET, &mut bytes)
+        .map_err(|detail| ImagePreparationError::new("load backing file", detail))?;
+    if read != bytes.len() {
+        return Err(ImagePreparationError::new(
+            "load backing file",
+            "backing file returned a short read",
+        ));
+    }
+
+    match filesystem {
+        FilesystemFormat::Ext4 => validate_ext4_image(&bytes, existing_len)
+            .map_err(|error| ImagePreparationError::new("validate ext4 image", error))?,
+    }
+    Ok(existing_len)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TEST_IMAGE_CAPACITY: u64 = 64 * 1024 * 1024;
+
+    #[derive(Default)]
+    struct MemoryReader {
+        bytes: Vec<u8>,
+        fail_read: bool,
+        short_read: bool,
+    }
+
+    impl ImageReader for MemoryReader {
+        fn len(&self) -> Result<u64, String> {
+            Ok(self.bytes.len() as u64)
+        }
+
+        fn read_at(&mut self, offset: u64, bytes: &mut [u8]) -> Result<usize, String> {
+            if self.fail_read {
+                return Err("read failed".into());
+            }
+            let start = offset as usize;
+            let available = self.bytes.len().saturating_sub(start).min(bytes.len());
+            let read = if self.short_read {
+                available.saturating_sub(1)
+            } else {
+                available
+            };
+            bytes[..read].copy_from_slice(&self.bytes[start..start + read]);
+            Ok(read)
+        }
+    }
+
+    fn ext4_image() -> Vec<u8> {
+        let mut bytes = vec![0_u8; TEST_IMAGE_CAPACITY as usize];
+        {
+            let image = Ext4Image::new(&mut bytes).expect("valid test image geometry");
+            let mut device = Jbd2Dev::initial_jbd2dev(0, image, true);
+            rsext4::mkfs(&mut device).expect("format test fixture");
+        }
+        bytes
+    }
+
+    #[test]
+    fn large_image_initialization_reads_only_superblock() {
+        struct LargeImage(Vec<u8>);
+        impl ImageReader for LargeImage {
+            fn len(&self) -> Result<u64, String> {
+                Ok(1 << 40)
+            }
+            fn read_at(&mut self, offset: u64, bytes: &mut [u8]) -> Result<usize, String> {
+                assert_eq!(offset, SUPERBLOCK_OFFSET);
+                assert_eq!(bytes.len(), SUPERBLOCK_SIZE);
+                bytes.copy_from_slice(&self.0[offset as usize..offset as usize + bytes.len()]);
+                Ok(bytes.len())
+            }
+        }
+        let mut reader = LargeImage(ext4_image());
+        assert_eq!(
+            inspect_file_image(&mut reader, None, FilesystemFormat::Ext4)
+                .expect("inspect a large image with bounded memory"),
+            1 << 40
+        );
+    }
+
+    #[test]
+    fn existing_ext4_image_is_loaded_without_modification() {
+        let original = ext4_image();
+        let mut reader = MemoryReader {
+            bytes: original.clone(),
+            ..Default::default()
+        };
+
+        let capacity = inspect_file_image(
+            &mut reader,
+            Some(TEST_IMAGE_CAPACITY),
+            FilesystemFormat::Ext4,
+        )
+        .expect("load existing ext4 image");
+
+        assert_eq!(capacity, TEST_IMAGE_CAPACITY);
+        assert_eq!(reader.bytes, original);
+    }
+
+    #[test]
+    fn empty_ext4_file_is_rejected() {
+        let mut reader = MemoryReader::default();
+
+        let error = inspect_file_image(&mut reader, None, FilesystemFormat::Ext4)
+            .expect_err("an empty backing file must be rejected");
+
+        assert_eq!(error.operation, "validate backing file");
+    }
+
+    #[test]
+    fn non_ext4_backing_file_is_rejected() {
+        let original = vec![0x5a; BLOCK_SIZE];
+        let mut reader = MemoryReader {
+            bytes: original.clone(),
+            ..Default::default()
+        };
+
+        let error = inspect_file_image(&mut reader, None, FilesystemFormat::Ext4)
+            .expect_err("a non-ext4 backing file must be rejected");
+
+        assert_eq!(error.operation, "validate ext4 image");
+        assert_eq!(reader.bytes, original);
+    }
+
+    #[test]
+    fn configured_capacity_must_match_existing_image() {
+        let mut reader = MemoryReader {
+            bytes: ext4_image(),
+            ..Default::default()
+        };
+
+        let error = inspect_file_image(
+            &mut reader,
+            Some(TEST_IMAGE_CAPACITY + 512),
+            FilesystemFormat::Ext4,
+        )
+        .expect_err("capacity mismatch must be rejected");
+
+        assert_eq!(error.operation, "validate backing file");
+        assert_eq!(reader.bytes.len(), TEST_IMAGE_CAPACITY as usize);
+    }
+
+    #[test]
+    fn backing_file_length_must_be_sector_aligned() {
+        let mut reader = MemoryReader {
+            bytes: vec![0; 513],
+            ..Default::default()
+        };
+
+        let error = inspect_file_image(&mut reader, None, FilesystemFormat::Ext4)
+            .expect_err("unaligned backing file must be rejected");
+
+        assert_eq!(error.operation, "validate backing file");
+    }
+
+    #[test]
+    fn read_failure_is_reported_without_modifying_the_image() {
+        let original = ext4_image();
+        let mut reader = MemoryReader {
+            bytes: original.clone(),
+            fail_read: true,
+            ..Default::default()
+        };
+
+        let error = inspect_file_image(&mut reader, None, FilesystemFormat::Ext4)
+            .expect_err("read failure must abort loading");
+
+        assert_eq!(error.operation, "load backing file");
+        assert_eq!(reader.bytes, original);
+    }
+
+    #[test]
+    fn short_read_is_rejected() {
+        let mut reader = MemoryReader {
+            bytes: ext4_image(),
+            short_read: true,
+            ..Default::default()
+        };
+
+        let error = inspect_file_image(&mut reader, None, FilesystemFormat::Ext4)
+            .expect_err("short read must be rejected");
+
+        assert_eq!(error.operation, "load backing file");
+    }
+}

--- a/virtualization/axvm/src/configured/devices/virtio_blk/mod.rs
+++ b/virtualization/axvm/src/configured/devices/virtio_blk/mod.rs
@@ -1,0 +1,14 @@
+//! AxVM-owned configured VirtIO block devices.
+
+mod device;
+#[cfg(feature = "fs")]
+mod file;
+#[cfg(feature = "fs")]
+mod image;
+mod options;
+
+pub(super) fn register(
+    catalog: &mut crate::ConfiguredDeviceCatalog,
+) -> Result<(), crate::ConfiguredDeviceError> {
+    catalog.register(module_path!(), device::REGISTRATION)
+}

--- a/virtualization/axvm/src/configured/devices/virtio_blk/options.rs
+++ b/virtualization/axvm/src/configured/devices/virtio_blk/options.rs
@@ -1,0 +1,163 @@
+//! Typed backend options for AxVM-configured VirtIO block devices.
+
+use std::string::String;
+
+use axvmconfig::VirtualDeviceRequest;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum FilesystemFormat {
+    Ext4,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum BackendConfig {
+    RamDisk,
+    File {
+        path: String,
+        filesystem: FilesystemFormat,
+    },
+}
+
+pub(crate) fn parse_backend(request: &VirtualDeviceRequest) -> Result<BackendConfig, &'static str> {
+    let backend = request
+        .options
+        .get("backend")
+        .map(|value| {
+            value
+                .as_str()
+                .ok_or("`backend` must be `file` or `ramdisk`")
+        })
+        .transpose()?
+        .unwrap_or("file");
+
+    match backend {
+        "ramdisk" => parse_ramdisk_backend(request),
+        "file" => parse_file_backend(request),
+        _ => Err("`backend` must be `file` or `ramdisk`"),
+    }
+}
+
+fn parse_ramdisk_backend(request: &VirtualDeviceRequest) -> Result<BackendConfig, &'static str> {
+    if request.options.contains_key("path") {
+        return Err("`path` is only valid for the file backend");
+    }
+    if request.options.contains_key("filesystem") {
+        return Err("`filesystem` is only valid for the file backend");
+    }
+    Ok(BackendConfig::RamDisk)
+}
+
+fn parse_file_backend(request: &VirtualDeviceRequest) -> Result<BackendConfig, &'static str> {
+    let path = request
+        .options
+        .get("path")
+        .map(|value| {
+            value
+                .as_str()
+                .filter(|path| !path.is_empty())
+                .ok_or("`path` must be a non-empty string")
+        })
+        .transpose()?
+        .map(str::to_owned)
+        .unwrap_or_else(|| std::format!("/tmp/{}.img", request.id));
+    let filesystem = match request
+        .options
+        .get("filesystem")
+        .ok_or("`filesystem` is required for the file backend")?
+        .as_str()
+        .ok_or("`filesystem` must be a string")?
+    {
+        "ext4" => FilesystemFormat::Ext4,
+        _ => return Err("`filesystem` must be `ext4`"),
+    };
+
+    Ok(BackendConfig::File { path, filesystem })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::format;
+
+    use axvmconfig::{GuestConfig, VirtualDeviceRequest};
+
+    use super::*;
+
+    #[test]
+    fn omitted_filesystem_is_rejected_for_file_backend() {
+        let request = request_with_options(r#"path = "/tmp/data.img""#);
+
+        assert_eq!(
+            parse_backend(&request),
+            Err("`filesystem` is required for the file backend")
+        );
+    }
+
+    #[test]
+    fn explicit_ext4_selects_ext4_file() {
+        let request = request_with_options(
+            r#"
+path = "/tmp/data.img"
+filesystem = "ext4"
+"#,
+        );
+
+        assert_eq!(
+            parse_backend(&request),
+            Ok(BackendConfig::File {
+                path: "/tmp/data.img".into(),
+                filesystem: FilesystemFormat::Ext4,
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_empty_uppercase_and_non_string_filesystems() {
+        for filesystem in [r#""fat32""#, r#""""#, r#""EXT4""#, "42"] {
+            let request = request_with_options(&format!("filesystem = {filesystem}"));
+
+            assert!(
+                parse_backend(&request).is_err(),
+                "filesystem value {filesystem} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn ramdisk_rejects_any_filesystem_field() {
+        for filesystem in [r#""ext4""#, r#""fat32""#, "42"] {
+            let request =
+                request_with_options(&format!("backend = \"ramdisk\"\nfilesystem = {filesystem}"));
+
+            assert!(
+                parse_backend(&request).is_err(),
+                "ramdisk filesystem value {filesystem} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn ramdisk_without_filesystem_remains_valid() {
+        let request = request_with_options(r#"backend = "ramdisk""#);
+
+        assert_eq!(parse_backend(&request), Ok(BackendConfig::RamDisk));
+    }
+
+    fn request_with_options(options: &str) -> VirtualDeviceRequest {
+        let config = GuestConfig::from_toml(&format!(
+            r#"
+[devices]
+[[devices.virtual]]
+id = "data"
+model = "virtio-blk"
+{options}
+"#
+        ))
+        .expect("parse test guest configuration");
+        config
+            .devices
+            .virtual_devices
+            .into_iter()
+            .next()
+            .expect("test guest has one virtual device")
+    }
+}


### PR DESCRIPTION
原有 virtio-blk 文件后端会在初始化时将整个镜像读入内存，内存占用随镜像容量增长。本次改为按客户机请求的扇区范围访问宿主文件，避免大镜像需要等量内存副本。
## 主要改动：

- 文件后端要求显式配置 filesystem = "ext4"。初始化只读取文件长度和 1 KiB 超级块，校验文件系统及容量；不自动创建镜像、格式化或扩缩容。
- 后台线程按文件偏移执行读写，并处理 flush。每次处理一个 I/O 请求，完成后再处理下一个，单个请求的后端缓冲区上限为 8 MiB。实际 I/O 完成后再报告结果，缓存由宿主文件系统管理。
- 在请求终结和设备 reset 时清理旧后台状态，防止失败请求的结果被后续同位置写入误用。
- 修复 EVENT_IDX 模式下，后续请求返回 WouldBlock 导致此前完成请求的中断通知丢失。
- 保留 QEMU 全局 -snapshot，避免替换 rootfs 路径时使其他磁盘失去快照保护。
- 将文件后端和协议回归测试接入标准测试入口。

## 验证：

- cargo xtask test：70 个包全部通过。
- 定向 cargo xtask clippy：3 个包、9 项检查全部通过。
- AArch64 Linux：1 GiB ext4 镜像完成挂载、写入、同步、卸载及重挂载回读。
- 回归测试覆盖大镜像初始化、64 GiB 稀疏文件读写、请求取消、EVENT_IDX 通知及双磁盘快照配置；相关缺陷均验证修复前失败、修复后通过。