### PR TITLE
ci(axvisor): add Orange Pi dual-guest robot tests

### DIFF
--- a/.github/ci/checks/axvisor.toml
+++ b/.github/ci/checks/axvisor.toml
@@ -288,3 +288,17 @@ cargo xtask axvisor test board --board orangepi-5-plus-robot-linux
 [[check.suite]]
 kind = "axvisor-board"
 board = "orangepi-5-plus-robot-linux"
+
+[[check]]
+id = "test-orangepi-5-plus-dualguest-robot"
+impact_targets = ["axvisor:aarch64", "starry:aarch64"]
+name = "Board OrangePi 5 Plus DualGuest robot · Linux/StarryOS + Zephyr"
+runner = "board"
+timeout_minutes = 30
+command = '''
+cargo xtask axvisor test board --board orangepi-5-plus-dualguest-robot
+'''
+
+[[check.suite]]
+kind = "axvisor-board"
+board = "orangepi-5-plus-dualguest-robot"

--- a/docs/docs/architecture/axvisor/guest-configuration.md
+++ b/docs/docs/architecture/axvisor/guest-configuration.md
@@ -158,6 +158,8 @@ Machine 负责选择固定串口、中断控制器与地址池，规划器负责
 
 Machine 的默认 selector 不经过 `PhysicalDeviceRef` 反序列化，因此可以使用内部发现根 `/`。这不放宽用户 schema：在 TOML 中写 `{ path = "/" }` 仍会由 `InvalidPhysicalDevicePath` 拒绝。只有 `guest_type = "passthrough"` 且用户 `passthrough` 为空时，应用层才可能采用 Machine 默认值；用户提供任何具体 path 后就不会注入该默认 selector。
 
+实体板卡使用 `browser-console` 时，`disabled` 还必须覆盖 Axvisor 实体网卡的完整宿主资源闭包。PCIe Host Bridge 被隐式过滤不代表独立 PHY、USB/DP Combo PHY、共享复位和时钟不会进入客户机；Orange Pi 5 Plus 的精确节点、失联现象和验证配置见[客户机控制台的实体板卡网络资源](./guest-console.md#8-实体板卡网络资源)。
+
 一项 `[[devices.virtual]]` 包含固定字段和开放 options：
 
 | 字段 | 类型 | 校验位置 |

--- a/docs/docs/architecture/axvisor/guest-console.md
+++ b/docs/docs/architecture/axvisor/guest-console.md
@@ -260,7 +260,69 @@ HTML、CSS 和 JavaScript 均编译进 Axvisor，不依赖 GitHub、CDN 或开�
 
 SMP 路径仍不能让任意 vCPU poll，那会破坏设备 poll 的 single-owner 假设。线程世代绑定的 vCPU0 kick capability 只解决定向 wait/wake；设备 poll 的所有权仍固定在 vCPU0。
 
-## 8. 故障定位
+## 8. 实体板卡网络资源
+
+板载网页由 Axvisor 直接发布，因此它的可用性不仅取决于 `network_console`、WebSocket 队列和 HTTP task，还取决于宿主实体网卡的完整硬件资源。客户机不需要自己的网络协议栈即可使用网页控制台，但 passthrough 客户机必须避开 Axvisor 网卡使用的控制器、PHY、时钟、复位和电源依赖；否则网页可以先成功监听，再在客户机驱动初始化真实硬件后永久失联。
+
+### 8.1 宿主所有权边界
+
+实体板卡启用网络 Shell 时，构建配置需要同时提供平台总线、实体网卡驱动和 `browser-console`。`AXVM_HTTP_BIND` 只决定 HTTP 监听地址，不会自动隔离客户机设备，也不会让 Axvisor 与客户机共享同一物理控制器。
+
+| 配置或资源 | 所有者 | 维护含义 |
+| --- | --- | --- |
+| `ax-driver/rk3588-pcie` 与 `ax-driver/realtek-rtl8125` | Axvisor | 探测并驱动 Orange Pi 5 Plus 的 RTL8125 管理网卡 |
+| `browser-console` 与 `AXVM_HTTP_BIND` | Axvisor | 发布内嵌页面、`/api/consoles` 和各控制台 WebSocket |
+| PCIe Host Bridge、PCIe PHY 和网卡依赖 | Axvisor | 客户机不得重新配置、复位或关闭这些实体资源 |
+| 客户机虚拟 UART backend | 对应 VM，Axvisor 路由 | 只承载 Shell 字节，不要求客户机拥有实体网卡 |
+
+`guest_type = "passthrough"` 且 `devices.passthrough = []` 会使用隐式根 selector。`setup_guest_fdt_from_vmm()` 会从这种客户机的设备树移除 PCIe Host Bridge，但独立的 PCIe PHY、USB 控制器和 USB/DP PHY 不属于 Bridge 子树，不会随 Bridge 自动删除。配置必须用 `devices.disabled` 明确表达宿主资源闭包，不能把“客户机设备树中没有 PCIe Bridge”等同于“客户机无法修改 PCIe 相关硬件”。
+
+### 8.2 Orange Pi 资源隔离
+
+Orange Pi 5 Plus 的 RTL8125 管理网络需要保留完整 PCIe PHY 集合。此外，Linux 启动和 systemd 的 USB gadget 流程会激活未用于机器人摄像头的 USB0 DWC3/OTG 控制器；其 USB3/DisplayPort Combo PHY 驱动会操作 PLL、lane mux、GRF、时钟和批量复位。当前验证配置把 USB0 控制器与 PHY 作为一个所有权单元留给宿主。
+
+| 必须排除的客户机节点 | 作用 |
+| --- | --- |
+| `/phy@fee00000` | PCIe 2.0 Combo PHY，包含 RTL8125 所用 PCIe 路径之一 |
+| `/phy@fee10000` | PCIe 2.0 Combo PHY，作为宿主 PCIe fabric 的一部分统一保留 |
+| `/phy@fee20000` | PCIe 2.0 Combo PHY，包含 RTL8125 所用 PCIe 路径之一 |
+| `/phy@fee80000` | PCIe 3.0 PHY，作为宿主 PCIe fabric 的一部分统一保留 |
+| `/usbdrd3_0` | 未用于机器人摄像头的 USB0 DWC3/OTG 控制器 |
+| `/phy@fed80000` | USB0 使用的 USB3/DisplayPort Combo PHY |
+
+六个节点在 eMMC 和 SD Linux 配置中保持一致。机器人摄像头实际连接在 `/usbdrd3_1/usb@fc400000`，因此隔离 USB0 不影响摄像头、RKNPU、根存储、IVC 或 Zephyr UART6。配置采用以下固定排除集合：
+
+```toml
+[devices]
+passthrough = []
+disabled = [
+  { path = "/phy@fee00000" },
+  { path = "/phy@fee10000" },
+  { path = "/phy@fee20000" },
+  { path = "/phy@fee80000" },
+  { path = "/usbdrd3_0" },
+  { path = "/phy@fed80000" },
+]
+```
+
+`/usbdrd3_0` 与 `/phy@fed80000` 应同时排除。只移除控制器仍可能让独立 PHY 节点被驱动探测；只移除 PHY 会给 DWC3 留下不完整依赖。即使构建配置暂时注释掉网络 Shell，也保留这些 `disabled` 项，使以后启用网页时不改变客户机可访问的实体硬件集合。
+
+### 8.3 失联判定
+
+硬件所有权冲突与网页任务拥塞的处理方法不同。判断时应同时观察 HTTP、WebSocket、ICMP、物理串口和客户机执行状态，不能仅凭页面上的 `connecting` 状态修改网络线程或调度策略。
+
+| 现象 | 首先检查 | 判定依据 |
+| --- | --- | --- |
+| 网页从未出现 | 三项 feature、`AXVM_HTTP_BIND`、DHCP 和 `Axvisor network ready` | HTTP 服务或宿主网络尚未就绪 |
+| Linux 启动后 HTTP、WebSocket 和 ICMP 持续失联，但物理串口与 VM 继续运行 | Linux TOML 的六个 `disabled` 节点 | 优先判定实体网卡依赖被客户机重配，而不是 Shell 队列拥塞 |
+| 只有一个 WebSocket 返回 `409` | 对应端点是否已有浏览器会话 | 每个端点同时只允许一个会话，宿主网络仍正常 |
+| 高频日志下请求偶发超时后立即恢复 | 输出队列丢弃摘要、HTTP task 调度和请求超时 | 与永久链路失联分开处理，不扩大设备直通范围 |
+
+受控 A/B 测试中，只保护 PCIe PHY 后，网页能够越过 Linux 早期初始化，但仍在 systemd 的 `Manage USB device functions` 附近永久失联；继续排除 `/usbdrd3_0` 与 `/phy@fed80000` 后，eMMC 完成 300 次、SD 完成 229 次连续 HTTP `200` 探测，三路 WebSocket 和完整机器人流程均通过。该证据确认的是设备组冲突；尚未把最终失联归因到单个 CRU、GRF、复位或 IRQ 位。
+
+可直接运行的 eMMC/SD 配置、网络 Shell 注释开关和机器人验收步骤保存在 `test-suit/axvisor/normal/board-orangepi-5-plus/dual-linux-zephyr/README.md`。`clk_ignore_unused` 和 `pd_ignore_unused` 只能阻止 Linux 启动末尾清理未使用资源，不能阻止已绑定驱动主动复位设备或关闭时钟，不能替代上述 `disabled` 集合。
+
+## 9. 故障定位
 
 控制台问题通常表现为丢字符、无响应或输出交错，多数可以从 mux 的状态直接定位。下表把每种现象映射到应首先检查的状态，第三列给出对应的机制事实。
 
@@ -277,7 +339,7 @@ SMP 路径仍不能让任意 vCPU poll，那会破坏设备 poll 的 single-owne
 | 切换前台后少了早期日志 | 该 VM ring 是否超过 16 KiB，是否出现 dropped 摘要，或 lifecycle/reconcile 是否 reset/discard 了 output state | ring 淘汰最旧字节并在回放前报告；stop/remove/replacement/reconcile 会清理相应 output state |
 | detach 后 shell prompt 接在 guest prompt 后 | 检查 `buffer_all()` 是否返回补行、调用方是否写出其结果 | `physical_line_open` 为真时必须先写 `\n` |
 
-## 9. 测试覆盖与验证命令
+## 10. 测试覆盖与验证命令
 
 `os/axvisor/src/guest_console/mux/tests.rs` 的测试覆盖范围应按实际断言理解：
 

--- a/scripts/test/test_ci_plan.py
+++ b/scripts/test/test_ci_plan.py
@@ -3,6 +3,7 @@
 import importlib.util
 import sys
 import tempfile
+import tomllib
 import unittest
 from pathlib import Path
 from typing import Any
@@ -466,6 +467,42 @@ command = "true"
         )
         self.assertEqual(plan["arceos_matrix"]["include"], [])
         self.assertEqual(plan["axvisor_matrix"]["include"], [])
+
+    def test_dualguest_robot_board_runs_both_guest_variants(self) -> None:
+        rows = self.assert_unique_ids(
+            ci_plan.build_main_plan(self.upstream)["axvisor_matrix"]["include"]
+        )
+        dualguest = rows["test-orangepi-5-plus-dualguest-robot"]
+
+        self.assertEqual(dualguest["runs_on"], ["self-hosted", "linux", "board"])
+        self.assertEqual(dualguest["timeout_minutes"], 30)
+        self.assertEqual(
+            dualguest["command"],
+            "cargo xtask axvisor test board "
+            "--board orangepi-5-plus-dualguest-robot",
+        )
+
+    def test_dualguest_robot_board_markers_cannot_match_command_echo(self) -> None:
+        root = MODULE_PATH.parents[2]
+        configs = (
+            root
+            / "test-suit/axvisor/normal/board-orangepi-5-plus/dual-linux-zephyr"
+            / "board-orangepi-5-plus-dualguest-robot.toml",
+            root
+            / "test-suit/axvisor/normal/board-orangepi-5-plus/dual-starry-zephyr"
+            / "board-orangepi-5-plus-dualguest-robot.toml",
+        )
+
+        for path in configs:
+            with self.subTest(config=path):
+                config = tomllib.loads(path.read_text())
+                self.assertEqual(
+                    config["board_type"], "OrangePi-5-Plus-DualGuest-robot"
+                )
+                self.assertNotIn("DUAL_PICK_CI_PASS", config["shell_init_cmd"])
+                self.assertNotIn("DUAL_PICK_CI_FAIL", config["shell_init_cmd"])
+                self.assertIn("marker=DUAL_PICK_CI", config["shell_init_cmd"])
+                self.assertEqual(len(config["success_regex"]), 1)
 
     def test_fork_repository_filters_owner_checks_and_falls_back_from_qcs(
         self,

--- a/test-suit/axvisor/normal/board-orangepi-5-plus/dual-linux-zephyr/README.md
+++ b/test-suit/axvisor/normal/board-orangepi-5-plus/dual-linux-zephyr/README.md
@@ -1,0 +1,238 @@
+# Orange Pi 5 Plus Linux 与 Zephyr 双客户机场景
+
+该场景在 SD 版 Orange Pi 5 Plus 上通过 Axvisor 同时运行 Linux 感知客户机和 Zephyr 控制客户机。Linux 使用 USB 摄像头和 RKNPU 生成感知结果，通过 `robot-ivc` 发送给 Zephyr；Zephyr 独占 UART6，负责底盘、机械臂和输入看门狗。仓库只保留已验证的 SD 配置；eMMC 迁移要求见第6节。
+
+## 1. 工作负载与资产
+
+本场景按设备职责划分客户机，避免 Linux 和 Zephyr 同时操作同一外设。Axvisor 始终保留物理管理串口；启用网络 Shell 时还必须保留 RTL8125 及其宿主依赖。
+
+### 1.1 客户机职责
+
+两个客户机通过同名 `robot-ivc` 虚拟设备建立通道，通道身份和大小由 IVC 模型统一管理。客户机名称来自各自 TOML 的 `base.name`，也用于网页窗格标题。
+
+| 客户机 | 主要职责 | 关键设备 |
+| --- | --- | --- |
+| Linux | 摄像头采集、RKNPU 推理、发布感知结果 | `/usbdrd3_1`、RKNPU、根存储、`robot-ivc` |
+| Zephyr | 接收感知结果、控制底盘和机械臂 | UART6 `/serial@feb90000`、`robot-ivc` |
+| Axvisor | VM 管理、物理串口、可选网页控制台 | RTL8125、宿主 PCIe 路径 |
+
+Linux 配置保留 `clk_ignore_unused` 和 `pd_ignore_unused`，防止启动末尾的通用清理关闭其他系统仍在使用的资源。这两个参数不能阻止已绑定驱动主动复位设备或关闭时钟，因此不能代替第 2 节的设备所有权隔离。
+
+### 1.2 客户机镜像
+
+Axvisor 从宿主文件系统加载 Linux 内核、initramfs 和 Zephyr 镜像。板卡运行命令只上传 Axvisor FIT，不会自动安装这些客户机资产，因此启动前必须确认文件存在且非空。
+
+```text
+/guest/linux/orangepi-5-plus-6.1.99-axivc
+/guest/linux/initramfs.cpio
+/guest/zephyr/orangepi-robot-control-sdk
+/guest/zephyr/orangepi-robot-control-sdk.dtb
+```
+
+Zephyr 控制镜像通过 `tgosimages` 的机器人应用入口构建，不从某个开发者的 AKA 工作目录
+直接产出：
+
+```bash
+# 在 tgosimages 仓库根目录执行
+./scripts/apps/aka-rk3588-zephyr.sh \
+  --image-name orangepi-robot-control-sdk
+```
+
+对应产物为：
+
+```text
+IMAGES/orangepi/zephyr/orangepi-robot-control-sdk
+IMAGES/orangepi/zephyr/orangepi-robot-control-sdk.dtb
+```
+
+Linux 根文件系统还应包含与当前内核版本匹配的 `axvisor.ko`、感知程序、模型和运行脚本。
+这些内容由 Linux 客户机发布包负责安装；本场景只约定 Guest 中的运行接口，不固化某台
+开发板的部署目录。
+
+### 1.3 SD 存储约定
+
+Linux 客户机使用 `linux-smp1-sd.toml`，其根设备是 `/dev/mmcblk1p2`。ostool FIT
+启动会绕过 SD 卡上的 `boot.scr`，因此 board 配置还会显式设置 AxVisor
+宿主的 SD 根设备。宿主和 Linux 客户机中的 `mmcblk` 编号不能相互推导。
+
+## 2. 网络 Shell
+
+当前 SD 构建配置启用板载网络 Shell，用于同时观测 AxVisor、Linux 和 Zephyr。
+
+### 2.1 启用开关
+
+网络 Shell 需要 PCIe、RTL8125、`browser-console` 和监听地址同时存在，当前构建
+配置已按下列方式启用。只启用 `browser-console` 而没有 PCIe 与 RTL8125 驱动时，
+Axvisor 没有可用的实体管理网卡；只启用网卡驱动则不会发布网页服务。
+
+```toml
+features = [
+  "ax-driver/rk3588-pcie",
+  "ax-driver/realtek-rtl8125",
+  "ax-driver/rockchip-sdhci",
+  "ax-driver/rockchip-dwmmc",
+  "browser-console",
+  "fs",
+]
+
+[env]
+AXVM_HTTP_BIND = "0.0.0.0:8080"
+```
+
+`browser-console` 发布 Axvisor、Linux 和 Zephyr 三个独立 WebSocket 字节流。服务没有 TLS 和认证，只能监听可信管理网络；不应把端口 `8080` 暴露到公共网络。
+
+### 2.2 宿主资源隔离
+
+Linux 使用 `guest_type = "passthrough"` 且 `passthrough = []`，因此从整板直通基线开始。AxVM 会自动移除 PCIe Host Bridge，但 PCIe PHY、USB 控制器和 USB/DP PHY 是设备树中的独立节点，不会因为 PCIe Bridge 被移除而自动消失。Linux 与 Axvisor 各自维护时钟和复位状态，无法协调同一真实硬件的所有权。
+
+| 排除节点 | 保留给宿主的资源 | 原因 |
+| --- | --- | --- |
+| `/phy@fee00000`、`/phy@fee10000`、`/phy@fee20000`、`/phy@fee80000` | RK3588 PCIe PHY 集合 | 防止 Linux 重配或复位 Axvisor RTL8125 所在的 PCIe 链路 |
+| `/usbdrd3_0` | 未用于机器人摄像头的 USB0 DWC3/OTG 控制器 | 防止 Linux 在启动和 USB gadget 服务阶段切换该实体控制器状态 |
+| `/phy@fed80000` | USB0 使用的 USB3/DisplayPort Combo PHY | 防止 Linux 修改其 PLL、lane mux、GRF、时钟和批量复位状态 |
+
+`/usbdrd3_0` 与 `/phy@fed80000` 是控制器和 PHY 的完整所有权单元，应同时排除。只移除控制器仍可能让独立 PHY 节点被驱动探测；只移除 PHY 会给 DWC3 留下不完整依赖。机器人摄像头实际连接在 `/usbdrd3_1/usb@fc400000`，上述隔离不影响摄像头、RKNPU、根存储、IVC 或 UART6。
+
+即使以后关闭网络 Shell，也应保留 Linux TOML 中的这些排除项，避免同一场景
+因网页功能开关改变实体设备所有权。
+
+### 2.3 定位证据
+
+受控 A/B 测试把问题分成两个阶段。未隔离时，Axvisor 先取得 DHCP 地址并发布网页，随后 Linux 启动使 HTTP、WebSocket 和 ICMP 永久失联；Linux、Zephyr 和物理串口仍继续运行，因此故障不在网页行编辑器或客户机网络栈。
+
+第一阶段保护 PCIe PHY 后，网页能够越过 Linux 早期设备初始化，但仍在 systemd 的 `Manage USB device functions` 附近失联。继续把 `/usbdrd3_0` 与 `/phy@fed80000` 作为一组排除后，eMMC 和 SD 均完成 Linux 启动、三路 WebSocket 与完整机器人验收。当前证据确认的是设备组冲突；若需要定位到单个 CRU、GRF、复位或 IRQ 位，还需增加寄存器和中断状态采样。
+
+最终实测中，eMMC 在网页就绪后完成 300 次连续 HTTP `200` 探测，SD 完成 229 次连续 HTTP `200` 探测，均无永久失联。两块板上的 Linux 都完成 1860 次推理和 IVC 发送且丢包为零，Zephyr 完成一轮抓取、放置和看门狗停车验证。
+
+## 3. 构建与启动流程
+
+启动前确认机器人活动范围安全、SD CI 板卡空闲，并确认第 1.2 节列出的客户机资产已同步到宿主文件系统。
+
+### 3.1 SD 构建
+
+SD 使用 `linux-smp1-sd.toml`，Linux 根设备为 `/dev/mmcblk1p2`。宿主根设备由 SD 板卡
+配置的 U-Boot 参数另行指定。在标准 `tgoskits` 仓库根目录执行：
+
+```bash
+cargo xtask axvisor build \
+  --arch aarch64 \
+  --config test-suit/axvisor/normal/board-orangepi-5-plus/dual-linux-zephyr/build-aarch64-unknown-none-softfloat.toml
+```
+
+板卡执行环境使用本目录的 `board-orangepi-5-plus-dualguest-robot.toml`。实际上传和启动由
+项目 CI 或部署环境的标准 board runner 完成；ostool 服务地址、端口和板卡租约不属于
+仓库场景说明。
+
+成功时 Linux 应从 `/dev/mmcblk1p2` 挂载根文件系统。不能根据宿主 U-Boot 使用的 `/dev/mmcblk0p2` 推断 Linux 客户机编号。
+
+### 3.2 网页访问
+
+网页由开发板上的 Axvisor 直接发布，不依赖运行 `cargo xtask` 的主机继续提供代理。启用网络 Shell 后，启动日志给出的 `web_console` 才是实际访问地址。
+
+```text
+Axvisor network ready:
+  interface = eth0
+  ipv4 = <board-ip>/24
+  web_console = http://<board-ip>:8080/
+```
+
+浏览器应显示 Axvisor、Linux 和 Zephyr 三个窗格。若 Linux 启动后网页永久失联，首先核对 Linux TOML 的六个 `disabled` 节点，不要先通过绑核、增加网页线程或降低客户机日志量掩盖硬件所有权冲突。
+
+## 4. 验收与退出
+
+验收需要同时证明 Linux 感知、IVC 传输、Zephyr 控制和宿主网页服务；单独看到客户机登录提示符或网页首页不能证明完整场景可用。
+
+### 4.1 机器人验收
+
+进入 Linux，并切换到已安装的机器人工作负载目录后运行一次有限验收。该脚本使用摄像头
+和 NPU，并通过 IVC 驱动 Zephyr 的测试状态机。
+
+```bash
+sudo ./run_dual_pick_ci_once.sh
+```
+
+Linux 应输出 `LINUX_AXIVC_READY`、`STARRY_ROBOT_CI_DONE perf=pass` 和 `STARRY_PERCEPTION_OK ... ivc_dropped=0`。其中 `STARRY_` 是感知程序沿用的日志前缀，不表示当前客户机是 StarryOS。Zephyr 应输出 `ZEPHYR_IVC_READY`、`ZEPHYR_PICK_CYCLE_PASS`、`ZEPHYR_ROBOT_CI_PASS` 和 `ZEPHYR_INPUT_WATCHDOG`。
+
+### 4.2 网络验收
+
+启用网页时，应从同一管理网段持续访问 `/api/consoles`，并分别连接 `/ws/axvisor`、`/ws/vm-1` 和 `/ws/vm-2`。探测必须覆盖 Linux 完整启动和机器人脚本运行期，不能只在 Linux 启动前检查一次。
+
+三路 WebSocket 应分别接受 Axvisor 命令、Linux shell 输入和 Zephyr shell 输入。HTTP 在短期高日志压力下可设置合理请求超时，但出现持续 `000`、ICMP 同时失联或所有 WebSocket 永久断开时，应按第 2.2 节检查实体设备所有权。
+
+### 4.3 安全退出
+
+Linux 与 Axvisor 使用同一实体根存储，结束测试前必须先刷新 Linux 文件系统，再释放板卡会话。直接断电可能造成 ext4 根文件系统损坏。
+
+```text
+Linux:   sync
+Axvisor: vm stop 1
+Axvisor: vm stop 2
+Axvisor: exit
+```
+
+从 Linux 返回 Axvisor shell 时依次按 `Ctrl+X`、松开、再按 `h`。完成关闭后使用 `Ctrl+A`、松开、再按 `x` 退出 ostool 串口会话。
+
+## 5. SD 双客户机 CI
+
+`board-orangepi-5-plus-dualguest-robot.toml` 面向
+`OrangePi-5-Plus-DualGuest-robot`。它在 Zephyr 进入稳定 IVC 等待后向
+Linux Shell 注入以下有限测试：
+
+```text
+sudo -n /home/orangepi/robot/aka-rk3588/run_dual_pick_ci_once.sh
+```
+
+只有脚本返回0并完成 `sync` 后才会输出 `DUAL_PICK_CI_PASS guest=linux-zephyr`。
+成功标志在 Shell 中由变量组合，避免命令回显被误判为测试通过。Linux 根文件系统
+必须为该绝对路径配置限定的免密 `sudo`；不得在仓库中写入密码。
+
+## 6. 如需迁移到 eMMC
+
+当前仓库只提供 SD 配置。如需增加 eMMC，建议在 `dual-linux-zephyr/emmc/`
+中放置三个 eMMC 专用文件，不要把第二个 `build-*.toml` 放到当前 SD
+wrapper 中。
+
+### 6.1 Linux VM 配置
+
+复制 `linux-smp1-sd.toml` 为 `emmc/linux-smp1-emmc.toml`。保留内存布局、镜像路径、
+`disabled` 资源和 `robot-ivc` 不变，只修改 `[kernel].cmdline` 中的 Linux 客户机
+根设备：
+
+```toml
+# SD
+cmdline = "root=/dev/mmcblk1p2 ..."
+
+# eMMC（历史板卡编号，仍需实机确认）
+cmdline = "root=/dev/mmcblk0p2 ..."
+```
+
+### 6.2 AxVisor build 配置
+
+复制当前 `build-aarch64-unknown-none-softfloat.toml` 为
+`emmc/build-aarch64-unknown-none-softfloat.toml`。`features`、`log`、`target` 和 `[env]`
+保持不变，只把 `vm_configs` 的 Linux 项指向 eMMC VM 配置：
+
+```toml
+vm_configs = [
+  "test-suit/axvisor/normal/board-orangepi-5-plus/dual-linux-zephyr/emmc/linux-smp1-emmc.toml",
+  "test-suit/axvisor/normal/board-orangepi-5-plus/dual-starry-zephyr/zephyr-smp1.toml",
+]
+```
+
+### 6.3 board 配置
+
+复制 `board-orangepi-5-plus-dualguest-robot.toml` 为
+`emmc/board-orangepi-5-plus-dualguest-robot-emmc.toml`，并修改 `board_type` 为 eMMC
+板卡在 ostool 中的独立类型，例如：
+
+```toml
+board_type = "OrangePi-5-Plus-DualGuest-robot-emmc"
+```
+
+SD board 配置的 `uboot_cmd` 第一项显式设置了 SD 宿主 bootargs。eMMC 版应将该项
+删除，使用板卡已确认的 eMMC 默认 bootargs；如果板卡没有可用的默认值，则将
+它改为实测的 eMMC 宿主根分区。后续 UART6 时钟、管脚寄存器、
+`shell_prefix`、`shell_init_cmd`、`success_regex`、`fail_regex` 和 `timeout` 均保持不变。
+
+Linux VM 的 `[kernel].cmdline` 控制客户机根分区，board 配置中的 U-Boot
+bootargs 控制 AxVisor 宿主根分区，两者需分别确认，不能互相代替。

--- a/test-suit/axvisor/normal/board-orangepi-5-plus/dual-linux-zephyr/board-orangepi-5-plus-dualguest-robot.toml
+++ b/test-suit/axvisor/normal/board-orangepi-5-plus/dual-linux-zephyr/board-orangepi-5-plus-dualguest-robot.toml
@@ -1,0 +1,38 @@
+board_type = "OrangePi-5-Plus-DualGuest-robot"
+uboot_cmd = [
+  "setenv bootargs root=/dev/mmcblk0p2 rw console=ttyS2,1500000 console=tty1 splash=verbose consoleblank=0 earlycon=uart8250,mmio32,0xfeb50000 cpuidle.off=1 rodata=off rootwait rootfstype=ext4 loglevel=8 usb-storage.quirks= cma=128M cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory swapaccount=1",
+  "mw.l 0xfd7c03cc 0x7e000000",
+  "mw.l 0xfd7c03d0 0x00080129",
+  "mw.l 0xfd7c03d4 0x00030001",
+  "mw.l 0xfd7c0830 0x00800000",
+  "mw.l 0xfd7c0834 0x10000000",
+  "mw.l 0xfd5f8020 0x00ff00aa",
+  "mw.l 0xfd5f9110 0x000f000f",
+  "mw.l 0xfd5f9020 0x00ff0066",
+]
+shell_prefix = "ZEPHYR_IVC_WAIT attempts=60"
+shell_init_cmd = '''
+marker=DUAL_PICK_CI
+cd /home/orangepi/robot/aka-rk3588 &&
+if sudo -n /home/orangepi/robot/aka-rk3588/run_dual_pick_ci_once.sh; then
+  sync
+  echo "${marker}_PASS guest=linux-zephyr"
+else
+  status=$?
+  sync
+  echo "${marker}_FAIL guest=linux-zephyr status=${status}"
+fi
+'''
+success_regex = [
+  '(?m)^DUAL_PICK_CI_PASS guest=linux-zephyr\s*$',
+]
+fail_regex = [
+  '(?i)\bpanic(?:ked)?\b',
+  "Failed to initialize guest VM",
+  "Failed to start VM",
+  "VFS: Cannot open root device",
+  "Waiting for root device",
+  '(?i)segmentation fault',
+  '(?m)^DUAL_PICK_CI_FAIL guest=linux-zephyr .*$'
+]
+timeout = 300

--- a/test-suit/axvisor/normal/board-orangepi-5-plus/dual-linux-zephyr/build-aarch64-unknown-none-softfloat.toml
+++ b/test-suit/axvisor/normal/board-orangepi-5-plus/dual-linux-zephyr/build-aarch64-unknown-none-softfloat.toml
@@ -1,0 +1,17 @@
+features = [
+  "ax-driver/rk3588-pcie",
+  "ax-driver/realtek-rtl8125",
+  "ax-driver/rockchip-sdhci",
+  "ax-driver/rockchip-dwmmc",
+  "browser-console",
+  "fs",
+]
+log = "Error"
+target = "aarch64-unknown-none-softfloat"
+vm_configs = [
+  "test-suit/axvisor/normal/board-orangepi-5-plus/dual-linux-zephyr/linux-smp1-sd.toml",
+  "test-suit/axvisor/normal/board-orangepi-5-plus/dual-starry-zephyr/zephyr-smp1.toml",
+]
+
+[env]
+AXVM_HTTP_BIND = "0.0.0.0:8080"

--- a/test-suit/axvisor/normal/board-orangepi-5-plus/dual-linux-zephyr/linux-smp1-sd.toml
+++ b/test-suit/axvisor/normal/board-orangepi-5-plus/dual-linux-zephyr/linux-smp1-sd.toml
@@ -1,0 +1,42 @@
+[base]
+id = 1
+name = "linux"
+guest_type = "passthrough"
+cpu_num = 1
+phys_cpu_ids = [0x00]
+
+[kernel]
+entry_point = 0x2_4008_0000
+image_location = "fs"
+kernel_load_addr = 0x2_4008_0000
+kernel_path = "/guest/linux/orangepi-5-plus-6.1.99-axivc"
+cmdline = "root=/dev/mmcblk1p2 rw console=ttyS2,1500000 earlycon=uart8250,mmio32,0xfeb50000 cpuidle.off=1 rodata=off rootwait rootfstype=ext4 ignore_loglevel loglevel=8 cma=128M clk_ignore_unused pd_ignore_unused"
+ramdisk_path = "/guest/linux/initramfs.cpio"
+ramdisk_load_addr = 0xc000_0000
+
+memory_regions = [
+  [0xb000_0000, 0x1000_0000, 0x7, 2],
+  [0xc000_0000, 0x3000_0000, 0x7, 2],
+  [0x2_4000_0000, 0x8000_0000, 0x7, 1],
+]
+
+[devices]
+passthrough = []
+disabled = [
+  # Axvisor owns the PCIe fabric used by the RTL8125 management interface.
+  # Keep every PCIe PHY outside Linux even though the PCIe bridges themselves
+  # are already filtered from an implicit root passthrough guest.
+  { path = "/phy@fee00000" },
+  { path = "/phy@fee10000" },
+  { path = "/phy@fee20000" },
+  { path = "/phy@fee80000" },
+  # Keep this unused USB controller and its PHY out of Linux; guest activation
+  # was observed to drop the host management link. The robot camera remains
+  # available through /usbdrd3_1.
+  { path = "/usbdrd3_0" },
+  { path = "/phy@fed80000" },
+]
+
+[[devices.virtual]]
+id = "robot-ivc"
+model = "ivc-channel"

--- a/test-suit/axvisor/normal/board-orangepi-5-plus/dual-starry-zephyr/README.md
+++ b/test-suit/axvisor/normal/board-orangepi-5-plus/dual-starry-zephyr/README.md
@@ -1,0 +1,168 @@
+# Orange Pi 5 Plus StarryOS + Zephyr 双客户机机器人测试
+
+该场景通过 AxVisor 同时启动 StarryOS 感知客户机和 Zephyr 控制客户机：
+
+- StarryOS 使用最新 `ivc-sdk` 的 `axivc_publish/send/close` 发布48字节
+  `PerceptionResultV2`；
+- Zephyr 将 `ivc-sdk` 作为 module 链入镜像，使用
+  `axivc_subscribe/recv/close`；
+- IVC key 为 `0x49564301`，channel 大小为64 KiB；
+- Zephyr 保留1 ms非阻塞轮询、最新帧策略、50 ms机械臂插值和350 ms输入看门狗；
+- UART6 只分配给 Zephyr，摄像头、NPU 和 SD 根存储由 StarryOS 使用。
+- RTL8125 及其 PCIe、ITS/LPI 资源由 AxVisor 独占，用于 `8080` 网页 Shell。
+- 未使用的 USB0 控制器及其 Combo PHY 也保留给 AxVisor，避免 StarryOS 重置宿主管理资源。
+
+本场景不实现 SDK timeout 语义统一、事件驱动通知、断开检测或自动重连。
+
+## 仓库职责
+
+- `tgoskits` 维护 AxVisor、双客户机 VM 配置和板卡测试场景；
+- `tgosimages` 维护 StarryOS 与 Zephyr 的系统构建环境和发布产物；
+- `aka-rk3588` 维护感知、公共消息协议和 Zephyr 机器人控制应用；
+- `ivc-sdk` 维护 StarryOS/Linux 与 Zephyr 共用的 AXIVC 实现。
+
+这些是独立 Git 仓库，不要求使用某个固定的父目录名称。下文命令分别从对应仓库根目录
+执行；`tgoskits` 表示标准仓库名，不使用开发者本机 checkout 的别名。
+
+## 构建客户机镜像
+
+StarryOS 与 Zephyr 客户机均通过 `tgosimages` 的标准入口构建。为确保与 AxVisor 主线
+对齐，StarryOS 构建应显式记录所使用的 `tgoskits` 提交：
+
+```bash
+# 在 tgosimages 仓库根目录执行
+./build.sh platform orangepi-5-plus starry --ref <tgoskits-commit>
+
+./scripts/apps/aka-rk3588-zephyr.sh \
+  --image-name orangepi-robot-control-sdk
+```
+
+Zephyr 专用入口会查找或下载 `aka-rk3588` 和 `ivc-sdk`，再调用 `tgosimages` 管理的
+Zephyr 源码、补丁、工具链和 Orange Pi 5 Plus board 完成构建。复现固定版本时，应使用
+干净 checkout，并记录 `tgosimages`、`aka-rk3588`、`ivc-sdk` 和 `tgoskits` 的完整提交号；
+已有 checkout 不会被构建脚本自动更新或清理。
+
+构建产物位于 `IMAGES/orangepi/starry/orangepi-5-plus`，部署到板卡宿主文件系统的
+`/guest/starry/orangepi-5-plus`。TGOSKits 双客户机场景只维护 VM 配置，不再维护或调用
+独立的 StarryOS 构建配置。
+
+两份客户机配置都使用标准宿主文件系统路径，并由 AxVisor 根据各自准备后的内存布局自动
+选择 DTB GPA。构建产物与安装目标如下：
+
+| `tgosimages` 构建产物 | 板卡宿主文件系统目标 |
+| --- | --- |
+| `IMAGES/orangepi/starry/orangepi-5-plus` | `/guest/starry/orangepi-5-plus` |
+| `IMAGES/orangepi/zephyr/orangepi-robot-control-sdk` | `/guest/zephyr/orangepi-robot-control-sdk` |
+| `IMAGES/orangepi/zephyr/orangepi-robot-control-sdk.dtb` | `/guest/zephyr/orangepi-robot-control-sdk.dtb` |
+
+板卡测试只构建并上传 AxVisor，不会自动安装这些客户机资产。部署流程应校验文件非空并在
+启动前完成 `sync`。StarryOS 感知程序、模型和运行脚本属于机器人工作负载发布包，不在
+本场景 README 中固化某台开发板的安装目录。
+
+## 构建与启动 AxVisor
+
+在标准 `tgoskits` 仓库根目录构建该场景：
+
+```bash
+cargo xtask axvisor build \
+  --arch aarch64 \
+  --config test-suit/axvisor/normal/board-orangepi-5-plus/dual-starry-zephyr/build-aarch64-unknown-none-softfloat.toml
+```
+
+构建配置同时启用 `rockchip-sdhci` 和 `rockchip-dwmmc`，但当前只发布并验证 SD 板卡
+场景。板卡执行使用本目录的 `board-orangepi-5-plus-dualguest-robot.toml`。
+
+实际上传和启动由项目 CI 或部署环境的标准 board runner 完成。ostool 服务地址、端口和
+板卡租约属于运行环境配置，不写入仓库场景说明。启动前必须确认车轮架起且机械臂活动范围
+安全。
+
+AxVisor 与 StarryOS 都按发现顺序把 SD 卡
+作为 `/dev/mmcblk0p2` 挂载，因此 StarryOS 沿用宿主 bootargs；Linux Guest 的
+驱动按 RK3588 设备树别名编号，正式 CI 中才使用 `/dev/mmcblk1p2`。ostool 直接
+启动 AxVisor FIT 镜像时不会执行 SD 卡中的 `boot.scr`，所以板配置仍需显式设置
+宿主的 SD 根设备。
+
+进入 StarryOS，并切换到已安装的机器人工作负载目录后运行一次有限验收：
+
+```bash
+./run_dual_pick_ci_once.sh
+```
+
+生产模式使用：
+
+```bash
+./run_dual_pick.sh
+```
+
+控制台快捷键需要依次按下：按 `Ctrl+X`，松开后再按 `h`、`[` 或 `]`。
+
+## 网页控制台
+
+AxVisor 通过板载 RTL8125 网卡获取 DHCP 地址，并在可信管理网络的
+`http://<board-ip>:8080/` 提供 AxVisor、StarryOS 和 Zephyr 三个独立 Shell 窗格。
+启动日志中的 `web_console` 字段会给出实际访问地址。网页控制台不启用 TLS 或认证，
+不要将端口 `8080` 暴露到非可信网络；物理串口控制台仍可同时使用。
+
+## 安全退出
+
+StarryOS 和 AxVisor 会同时使用机器人根分区。测试结束后不要直接退出板卡会话或
+切断电源，应按以下顺序刷新并关闭文件系统：
+
+1. 在 StarryOS Shell 中执行 `sync`；
+2. 按 `Ctrl+X`，松开后按 `h` 返回 AxVisor Shell；
+3. 依次执行 `vm stop 1`、`vm stop 2` 和 `exit`；
+4. 看到 `Goodbye!` 后，按 `Ctrl+A`，松开后按 `x` 释放板卡会话。
+
+AxVisor 的 `exit` 会先调用宿主文件系统关闭流程。StarryOS 用户空间没有以 systemd
+作为 PID 1，直接执行 `poweroff` 会失败，不能代替上述流程。SD 测试后应再进行一次
+原生 Linux 冷启动，确认启动日志包含 `opi_root: clean`。
+
+## 验收标志
+
+StarryOS：
+
+```text
+STARRY_ROBOT_CI_DONE perf=pass
+STARRY_PERCEPTION_OK ... ivc_dropped=0
+```
+
+Zephyr：
+
+```text
+ZEPHYR_IVC_READY ... transport=ivc-sdk
+ZEPHYR_CONTROL_STATUS ... invalid=0
+ZEPHYR_PICK_CYCLE_PASS cycles=1
+ZEPHYR_ROBOT_CI_PASS cycles=1 wheels=verified arm=verified watchdog=verified
+ZEPHYR_INPUT_WATCHDOG ... timeout_ms=350
+```
+
+2026-09-01 实机验收中，StarryOS 发送1340条结果、丢弃0条；Zephyr 的接收和控制频率约
+21～22 FPS，`invalid=0`、`coalesced=0`，完整底盘、抓取、放置和停车流程通过。
+
+## SD 双客户机 CI
+
+`board-orangepi-5-plus-dualguest-robot.toml` 使用与 Linux+Zephyr CI 相同的板卡类型
+`OrangePi-5-Plus-DualGuest-robot`。Zephyr 进入稳定 IVC 等待后，测试会在 StarryOS 中运行：
+
+```text
+/home/orangepi/robot/aka-rk3588/run_dual_pick_ci_once.sh
+```
+
+脚本返回0并完成 `sync` 后才会输出
+`DUAL_PICK_CI_PASS guest=starry-zephyr`。成功标志同样由变量组合，不会因 Shell 回显
+板卡配置中的命令文本而提前通过。CI 使用同一块 SD 机器人依次运行
+Linux+Zephyr 和 StarryOS+Zephyr，两个场景不会并行占用板卡。
+
+## 如需迁移到 eMMC
+
+当前仓库不提供可直接运行的 eMMC board 配置。StarryOS VM 本身无需改变 IVC、
+UART6 或内存布局，但迁移时必须：
+
+1. 创建 eMMC 专用 board type 和 board 配置，不与 SD CI 共用板卡池。
+2. 根据 U-Boot 和 AxVisor 中的实际枚举结果，删除 SD 专用的显式
+   `setenv bootargs`，或将它改为 eMMC 宿主根分区。
+3. 将 StarryOS、Zephyr 镜像、用户态运行包和机器人标定部署到 eMMC 根文件系统，
+   完成 `sync` 后再冷启动。
+4. 保留 `starry-smp1.toml` 中的 UART6、PCIe PHY、USB0 控制器和 Combo PHY 排除项。
+5. 重新验证根分区、摄像头、NPU、IVC、UART6、网络 Shell 和完整
+   `run_dual_pick_ci_once.sh`；SD 的通过结果不能代替 eMMC 实机验收。

--- a/test-suit/axvisor/normal/board-orangepi-5-plus/dual-starry-zephyr/board-orangepi-5-plus-dualguest-robot.toml
+++ b/test-suit/axvisor/normal/board-orangepi-5-plus/dual-starry-zephyr/board-orangepi-5-plus-dualguest-robot.toml
@@ -1,0 +1,36 @@
+board_type = "OrangePi-5-Plus-DualGuest-robot"
+uboot_cmd = [
+  "setenv bootargs root=/dev/mmcblk0p2 rw console=ttyS2,1500000 console=tty1 splash=verbose consoleblank=0 earlycon=uart8250,mmio32,0xfeb50000 cpuidle.off=1 rodata=off rootwait rootfstype=ext4 loglevel=8 usb-storage.quirks= cma=128M cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory swapaccount=1",
+  "mw.l 0xfd7c03cc 0x7e000000",
+  "mw.l 0xfd7c03d0 0x00080129",
+  "mw.l 0xfd7c03d4 0x00030001",
+  "mw.l 0xfd7c0830 0x00800000",
+  "mw.l 0xfd7c0834 0x10000000",
+  "mw.l 0xfd5f8020 0x00ff00aa",
+  "mw.l 0xfd5f9110 0x000f000f",
+  "mw.l 0xfd5f9020 0x00ff0066",
+]
+shell_prefix = "ZEPHYR_IVC_WAIT attempts=60"
+shell_init_cmd = '''
+marker=DUAL_PICK_CI
+cd /home/orangepi/robot/aka-rk3588 &&
+if ./run_dual_pick_ci_once.sh; then
+  sync
+  echo "${marker}_PASS guest=starry-zephyr"
+else
+  status=$?
+  sync
+  echo "${marker}_FAIL guest=starry-zephyr status=${status}"
+fi
+'''
+success_regex = [
+  '(?m)^DUAL_PICK_CI_PASS guest=starry-zephyr\s*$',
+]
+fail_regex = [
+  '(?i)\bpanic(?:ked)?\b',
+  "Failed to initialize guest VM",
+  "Failed to start VM",
+  '(?i)segmentation fault',
+  '(?m)^DUAL_PICK_CI_FAIL guest=starry-zephyr .*$'
+]
+timeout = 300

--- a/test-suit/axvisor/normal/board-orangepi-5-plus/dual-starry-zephyr/build-aarch64-unknown-none-softfloat.toml
+++ b/test-suit/axvisor/normal/board-orangepi-5-plus/dual-starry-zephyr/build-aarch64-unknown-none-softfloat.toml
@@ -1,0 +1,17 @@
+features = [
+  "ax-driver/rk3588-pcie",
+  "ax-driver/realtek-rtl8125",
+  "ax-driver/rockchip-sdhci",
+  "ax-driver/rockchip-dwmmc",
+  "browser-console",
+  "fs",
+]
+log = "Error"
+target = "aarch64-unknown-none-softfloat"
+vm_configs = [
+  "test-suit/axvisor/normal/board-orangepi-5-plus/dual-starry-zephyr/starry-smp1.toml",
+  "test-suit/axvisor/normal/board-orangepi-5-plus/dual-starry-zephyr/zephyr-smp1.toml",
+]
+
+[env]
+AXVM_HTTP_BIND = "0.0.0.0:8080"

--- a/test-suit/axvisor/normal/board-orangepi-5-plus/dual-starry-zephyr/starry-smp1.toml
+++ b/test-suit/axvisor/normal/board-orangepi-5-plus/dual-starry-zephyr/starry-smp1.toml
@@ -1,0 +1,42 @@
+[base]
+id = 1
+name = "starry"
+guest_type = "passthrough"
+cpu_num = 1
+phys_cpu_ids = [0x00]
+
+[kernel]
+entry_point = 0x4008_0000
+image_location = "fs"
+kernel_load_addr = 0x4008_0000
+kernel_path = "/guest/starry/orangepi-5-plus"
+# DTB GPA is selected automatically from the prepared guest memory layout.
+
+memory_regions = [
+  [0x4000_0000, 0x1000_0000, 0x7, 2],
+  [0x2_4000_0000, 0x8000_0000, 0x7, 1],
+]
+
+[devices]
+passthrough = []
+# AxVisor owns the PCIe controllers and RTL8125 NICs used by the browser console.
+disabled = [
+  { path = "/serial@feb90000" },
+  { path = "/pcie@fe150000" },
+  { path = "/pcie@fe160000" },
+  { path = "/pcie@fe170000" },
+  { path = "/pcie@fe180000" },
+  { path = "/pcie@fe190000" },
+  { path = "/phy@fee00000" },
+  { path = "/phy@fee10000" },
+  { path = "/phy@fee20000" },
+  { path = "/phy@fee80000" },
+  # Keep the unused USB0 controller and its Combo PHY with the AxVisor host.
+  # StarryOS still owns the robot camera on USB1.
+  { path = "/usbdrd3_0" },
+  { path = "/phy@fed80000" },
+]
+
+[[devices.virtual]]
+id = "robot-ivc"
+model = "ivc-channel"

--- a/test-suit/axvisor/normal/board-orangepi-5-plus/dual-starry-zephyr/zephyr-smp1.toml
+++ b/test-suit/axvisor/normal/board-orangepi-5-plus/dual-starry-zephyr/zephyr-smp1.toml
@@ -1,0 +1,26 @@
+[base]
+id = 2
+name = "zephyr"
+guest_type = "virtualized"
+cpu_num = 1
+phys_cpu_ids = [0x200]
+
+[kernel]
+entry_point = 0x4000_100c
+image_location = "fs"
+kernel_load_addr = 0x4000_0000
+kernel_path = "/guest/zephyr/orangepi-robot-control-sdk"
+dtb_path = "/guest/zephyr/orangepi-robot-control-sdk.dtb"
+# DTB GPA is selected automatically from the prepared guest memory layout.
+
+memory_regions = [
+  [0x4000_0000, 0x0800_0000, 0x7, 0],
+]
+
+[devices]
+passthrough = [{ path = "/serial@feb90000" }]
+disabled = []
+
+[[devices.virtual]]
+id = "robot-ivc"
+model = "ivc-channel"


### PR DESCRIPTION
## 背景

为 Orange Pi 5 Plus SD 机器人增加 AxVisor 双客户机自动 CI，使用同一块板卡依次验证：

- Linux 感知客户机 + Zephyr 控制客户机
- StarryOS 感知客户机 + Zephyr 控制客户机

两个场景均执行根文件系统中已有的 `run_dual_pick_ci_once.sh`，不在 TGOSKits 中构建或部署机器人用户态程序。

## 修改内容

- 新增 Linux+Zephyr SD 双客户机场景：
  - Linux VM1 使用摄像头、RKNPU 和 `robot-ivc`
  - Linux 根设备为 `/dev/mmcblk1p2`
  - Zephyr VM2 独占 UART6
- 新增 StarryOS+Zephyr SD 双客户机场景。
- 两个场景共用：
  - IVC publisher VM ID 1
  - IVC key `0x49564301`
  - 64 KiB IVC channel
  - Zephyr 控制镜像和 UART6 配置
- 保留 PCIe PHY、USB0 控制器及 Combo PHY 给 AxVisor，避免客户机重置宿主 RTL8125 网络控制台资源。
- 注册正式 ostool 板卡类型：
  ```text
  OrangePi-5-Plus-DualGuest-robot