### PR TITLE
fix(axfs-ng-vfs): validate admitted unmounts by affected topology

### DIFF
--- a/fs/axfs-ng-vfs/src/mount/mod.rs
+++ b/fs/axfs-ng-vfs/src/mount/mod.rs
@@ -1211,13 +1211,13 @@ impl Location {
         assert!(self.entry.ptr_eq(&self.mountpoint.root));
 
         let plan = self.mountpoint.plan_unmount(UnmountKind::Normal)?;
-        self.filesystem().flush()?;
-        self.mountpoint.commit_normal_after_flush(plan)?;
-        self.finish_unmount();
-        Ok(())
+        self.commit_unmount(plan)
     }
 
-    /// Flushes this mount once and commits an already admitted unmount plan.
+    /// Flushes this mount once and commits an already admitted normal unmount.
+    ///
+    /// The original attachments and complete propagation set must still match
+    /// admission. Unrelated namespace mutations do not invalidate the plan.
     pub fn commit_unmount(&self, plan: UnmountPlan) -> VfsResult<()> {
         if !self.is_root_of_mount()
             || !plan
@@ -1227,7 +1227,7 @@ impl Location {
             return Err(VfsError::InvalidInput);
         }
         self.filesystem().flush()?;
-        plan.commit()?;
+        self.mountpoint.commit_normal_after_flush(plan)?;
         self.finish_unmount();
         Ok(())
     }

--- a/fs/axfs-ng-vfs/src/mount/unmount.rs
+++ b/fs/axfs-ng-vfs/src/mount/unmount.rs
@@ -48,12 +48,13 @@ impl UnmountPlan {
             .any(|target| !target.mountpoint.children.lock().is_empty())
     }
 
-    fn has_same_targets(&self, expected: &[Arc<Mountpoint>]) -> bool {
-        self.targets.len() == expected.len()
+    fn has_same_targets(&self, expected: &Self) -> bool {
+        self.targets.len() == expected.targets.len()
             && self.targets.iter().all(|target| {
                 expected
+                    .targets
                     .iter()
-                    .any(|mountpoint| Arc::ptr_eq(&target.mountpoint, mountpoint))
+                    .any(|other| Arc::ptr_eq(&target.mountpoint, &other.mountpoint))
             })
     }
 
@@ -122,25 +123,25 @@ impl UnmountPlan {
 impl Mountpoint {
     /// Commits a normal unmount after filesystem callbacks have completed.
     ///
-    /// A callback may overlap an unrelated mount-tree mutation. Replan under
-    /// the topology guard in that case, but commit only when the complete
-    /// target set is unchanged. A new target may belong to an unflushed
-    /// filesystem and therefore cannot join the current transaction.
+    /// Like Linux's locked checks in `do_umount`, admission is about the
+    /// affected mounts, not activity in an unrelated namespace. Validate the
+    /// original attachment points and propagation set under one topology
+    /// guard before detaching anything. Callbacks run before this guard.
     pub(super) fn commit_normal_after_flush(self: &Arc<Self>, plan: UnmountPlan) -> VfsResult<()> {
-        debug_assert_eq!(plan.kind, UnmountKind::Normal);
-        let planned_targets: Vec<_> = plan.targets().cloned().collect();
-        let _topology = MOUNT_TOPOLOGY_MUTATION.lock();
-        match plan.commit_locked() {
-            Ok(()) => Ok(()),
-            Err(UnmountCommitError::TopologyChanged) => {
-                let current_plan = self.plan_unmount_locked(UnmountKind::Normal)?;
-                if !current_plan.has_same_targets(&planned_targets) {
-                    return Err(UnmountCommitError::TopologyChanged.into());
-                }
-                current_plan.commit_current_locked().map_err(VfsError::from)
-            }
-            Err(error) => Err(error.into()),
+        if plan.kind != UnmountKind::Normal {
+            return Err(VfsError::InvalidInput);
         }
+        let _topology = MOUNT_TOPOLOGY_MUTATION.lock();
+        plan.revalidate_targets_locked()?;
+        if MOUNT_TOPOLOGY_VERSION.load(Ordering::Acquire) != plan.topology_version {
+            let current_plan = self.plan_unmount_locked(UnmountKind::Normal)?;
+            // A changed propagation set has not passed the caller's busy
+            // checks and cannot join (or leave) this admitted transaction.
+            if !current_plan.has_same_targets(&plan) {
+                return Err(UnmountCommitError::TopologyChanged.into());
+            }
+        }
+        plan.detach_targets_locked().map_err(VfsError::from)
     }
 
     pub fn plan_unmount(self: &Arc<Self>, kind: UnmountKind) -> VfsResult<UnmountPlan> {

--- a/os/StarryOS/kernel/src/syscall/fs/mount.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/mount.rs
@@ -26,6 +26,9 @@ use crate::{
     task::tasks,
 };
 
+#[cfg(all(test, axtest))]
+mod tests;
+
 const MNT_FORCE: i32 = 1;
 const MNT_DETACH: i32 = 2;
 const MNT_EXPIRE: i32 = 4;

--- a/os/StarryOS/kernel/src/syscall/fs/mount/tests.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/mount/tests.rs
@@ -1,0 +1,118 @@
+use alloc::sync::Arc;
+
+use axfs_ng_vfs::{Location, Mountpoint, NodePermission, NodeType, UnmountKind, VfsError};
+
+use crate::pseudofs::MemoryFs;
+
+fn directory(parent: &Location, name: &str) -> Location {
+    parent
+        .create(
+            name,
+            NodeType::Directory,
+            NodePermission::from_bits_truncate(0o755),
+            0,
+            0,
+        )
+        .expect("create mount directory")
+}
+
+fn mounted_tree() -> (Location, Arc<Mountpoint>) {
+    let root = Mountpoint::new_root(&MemoryFs::new()).root_location();
+    let mounted = directory(&root, "mnt")
+        .mount(&MemoryFs::new())
+        .expect("mount tmpfs");
+    (root, mounted)
+}
+
+#[axtest::axtest]
+fn admitted_unmount_survives_unrelated_namespace_clone() {
+    let (root, mounted) = mounted_tree();
+    let plan = mounted
+        .plan_unmount(UnmountKind::Normal)
+        .expect("admit unmount");
+
+    // Reproduce the exact plan/commit interleaving without scheduling luck.
+    // This is a separate tree with no propagation relationship to the target.
+    let unrelated = Mountpoint::new_root(&MemoryFs::new());
+    let cloned_namespace = unrelated.clone_tree();
+    mounted
+        .root_location()
+        .commit_unmount(plan)
+        .expect("unrelated namespace mutation must not cause EBUSY");
+
+    assert!(!root.lookup_no_follow("mnt").unwrap().is_root_of_mount());
+    assert!(mounted.location().is_none());
+    assert!(cloned_namespace.is_root());
+}
+
+#[axtest::axtest]
+fn admitted_unmount_rejects_moved_target() {
+    let (root, mounted) = mounted_tree();
+    let destination = directory(&root, "moved");
+    let plan = mounted
+        .plan_unmount(UnmountKind::Normal)
+        .expect("admit unmount");
+    mounted
+        .root_location()
+        .move_mount(&destination)
+        .expect("move target");
+
+    assert_eq!(
+        mounted.root_location().commit_unmount(plan),
+        Err(VfsError::ResourceBusy)
+    );
+    assert!(root.lookup_no_follow("moved").unwrap().is_root_of_mount());
+    mounted
+        .root_location()
+        .unmount()
+        .expect("unmount with fresh admission");
+}
+
+#[axtest::axtest]
+fn admitted_unmount_rejects_new_propagation_target() {
+    let (root, mounted) = mounted_tree();
+    root.mountpoint().set_shared();
+    let plan = mounted
+        .plan_unmount(UnmountKind::Normal)
+        .expect("admit unmount");
+    let peer_namespace = root.mountpoint().clone_tree();
+
+    assert_eq!(
+        mounted.root_location().commit_unmount(plan),
+        Err(VfsError::ResourceBusy)
+    );
+    assert!(root.lookup_no_follow("mnt").unwrap().is_root_of_mount());
+    assert!(
+        peer_namespace
+            .root_location()
+            .lookup_no_follow("mnt")
+            .unwrap()
+            .is_root_of_mount()
+    );
+    mounted
+        .root_location()
+        .unmount()
+        .expect("unmount both peers with fresh admission");
+}
+
+#[axtest::axtest]
+fn admitted_unmount_rejects_new_child_mount() {
+    let (root, mounted) = mounted_tree();
+    let child_dir = directory(&mounted.root_location(), "child");
+    let plan = mounted
+        .plan_unmount(UnmountKind::Normal)
+        .expect("admit unmount");
+    let child = child_dir.mount(&MemoryFs::new()).expect("mount child");
+
+    assert_eq!(
+        mounted.root_location().commit_unmount(plan),
+        Err(VfsError::ResourceBusy)
+    );
+    assert!(root.lookup_no_follow("mnt").unwrap().is_root_of_mount());
+    assert!(child.location().is_some());
+    child.root_location().unmount().expect("unmount child");
+    mounted
+        .root_location()
+        .unmount()
+        .expect("unmount parent with fresh admission");
+}


### PR DESCRIPTION
## 问题与根因

修复 [PR #2307 的 LoongArch64 Starry QEMU 失败](https://github.com/rcore-os/tgoskits/actions/runs/34198120106/job/101973284540)：`test-per-ns-mounts` 在私有挂载命名空间中执行 `umount /mnt` 返回 `EBUSY`。

Starry 的调用链是 `sys_umount2 → Location::commit_unmount → UnmountPlan::commit`。最后一步将全局 `MOUNT_TOPOLOGY_VERSION` 的任何变化视为计划失效，再映射为 `ResourceBusy`。因此，计划生成后，即使只有无关命名空间被克隆，本次卸载也会错误返回 `EBUSY`。另一条 `Location::unmount` 路径有自己的重规划逻辑，两条普通卸载入口的提交语义不一致；原有重规划还会丢失最初的挂载位置，可能把已经移动的目标当作原计划继续卸载。

原 CI 日志只保留了 `EBUSY`，没有记录当时修改拓扑的具体任务。本次使用真实内核中的受控交错，确定性证明了上述错误来源，避免把一次重跑通过当作根因证据。

## Linux RT 对照与修改

参考本地 Linux 7.1，提交 `8cd9520d35a6c38db6567e97dd93b1f11f185dc6`：

- [`do_umount()`](https://github.com/torvalds/linux/blob/8cd9520d35a6c38db6567e97dd93b1f11f185dc6/fs/namespace.c#L1933) 在命名空间及挂载锁内重验实际目标，再检查传播占用并解除挂载。全局事件变化本身不构成挂载忙。
- [PREEMPT_RT 的 rwsem](https://github.com/torvalds/linux/blob/8cd9520d35a6c38db6567e97dd93b1f11f185dc6/include/linux/rwsem.h#L149) 使用 RT rwbase；本项目继续使用现有可睡眠拓扑锁，文件系统回调在取得该锁之前完成。

修改集中到普通卸载事务：

1. `Location::unmount` 统一转入 `commit_unmount`，两种入口共享同一个提交实现。
2. 在同一拓扑锁内先验证原挂载位置、父子关系和新增子挂载。目标已经移动时拒绝原计划，避免重规划覆盖原计划的准入范围。
3. 全局版本改变时只重验完整传播目标集合；集合保持相同才提交原计划。新增或移除传播目标都要求重新进行完整准入，不能直接加入尚未通过占用检查的对象。
4. 保留原有 FD、cwd/root 忙检查以及写回错误传播。没有重试、扩大超时、忽略错误或降低断言。

新增四项 Starry 内核 QEMU 回归，使用真实 `MemoryFs`、挂载树和运行时锁：无关命名空间克隆后仍能卸载；目标移动、新增传播目标、新增子挂载时拒绝旧计划，并保留挂载。通过公开 VFS 操作控制计划与提交之间的交错，不依赖概率性调度。

## 验证

当前提交 `0c5c9eeb4ffe3ad5923b24a6eb6fe668830d650e` 基于 `dev` 的 `cbed9ea5f0`，变基无冲突，以下本地检查均已完成：

- `cargo xtask clippy --package axfs-ng-vfs --package starry-kernel`：95/95 项通过，覆盖 AArch64、LoongArch64、RISC-V 和 x86_64 配置。
- `cargo xtask ktest qemu -p starry-kernel --arch loongarch64`：174/174 通过，四项新增事务回归均执行通过。
- `cargo xtask starry test qemu --arch loongarch64`：系统套件 499/499，通过原失败的 `test-per-ns-mounts`；TTY 独立用例也通过，总计 2/2 QEMU 用例通过。
- `cargo fmt`、补充内核 include 模块的 Rustfmt 检查、最终差异检查通过。

确定性红绿证据：修复前，在真实 LoongArch64 内核中执行同一个 `admitted_unmount_survives_unrelated_namespace_clone`，因 `ResourceBusy` 触发预期失败；修复后同一测试通过。目标移动、新增传播目标、新增子挂载时仍返回 `ResourceBusy` 并保留挂载，后续按当前状态重新准入能够完成清理。

宿主 `cross-test` 尝试受现有 `ax-sync` 的 `SpinOps` 链接符号缺失阻碍；新增回归最终采用上述真实内核 QEMU 入口，未增加伪运行时。

当前提交的实际 [push CI](https://github.com/rcore-os/tgoskits/actions/runs/34204181667) 中，四架构 Starry QEMU 均成功，包含原失败的 [LoongArch64 任务](https://github.com/rcore-os/tgoskits/actions/runs/34204181667/job/101991194225)。目前 30 项成功、2 项取消、1 项失败，增量 Clippy 仍在运行，整体 CI 不是全绿。

独立失败为 [ASUS NUC15CRH Linux 客户机](https://github.com/rcore-os/tgoskits/actions/runs/34204181667/job/101991194462)：Linux 输出 `smpboot: Total of 1 processors activated` 后停止推进，达到原有 300 秒启动超时。其构建配置 `features = []`，客户机镜像使用 `image_location = "memory"`；AxVisor 默认功能也为空，文件系统卸载路径由 `feature = "fs"` 门控，因此该任务未执行本次修改的卸载逻辑。本 PR 没有修改客户机启动或测试超时，也不将取消的两个任务计为通过。

## 系统调用兼容性对照

下表结论限定于本次普通卸载提交的拓扑重验及占用保护路径。

| 系统调用/编号 | Linux 基准与稳定链接 | Linux 可观察语义 | StarryOS 入口与调用链 | 实现结论 | 测试与证据 |
| --- | --- | --- | --- | --- | --- |
| `umount2` / LoongArch64:39 | Linux 7.1 [`do_umount`](https://github.com/torvalds/linux/blob/8cd9520d35a6c38db6567e97dd93b1f11f185dc6/fs/namespace.c#L1933) | 无关命名空间活动不构成 `EBUSY`；实际占用仍拒绝卸载 | `sys_umount2 → Location::commit_unmount → Mountpoint::commit_normal_after_flush`；VFS 拓扑锁内验证并提交 | 正确 | 四项真实内核回归红绿证据；原失败用例及 499 项系统测试通过 |
