### PR TITLE
fix(rknpu): add timeout error handling and update ioctl error mapping

### DIFF
--- a/drivers/ax-driver/src/rknpu.rs
+++ b/drivers/ax-driver/src/rknpu.rs
@@ -3,7 +3,11 @@ use core::any::Any;
 
 use log::info;
 use rdrive::{
-    probe::{OnProbeError, fdt::FdtInfo},
+    DriverGeneric,
+    probe::{
+        OnProbeError,
+        fdt::{FdtInfo, ResetLine},
+    },
     register::ProbeFdt,
 };
 pub use rockchip_npu::{
@@ -24,6 +28,10 @@ pub enum Error {
     NotFound,
     #[error("Rockchip NPU is busy")]
     Busy,
+    #[error("Rockchip NPU request timed out")]
+    TimedOut,
+    #[error("Rockchip NPU reset failed after a timed-out submission; the device is quarantined")]
+    Quarantined,
     #[error("Rockchip NPU request contains invalid data")]
     InvalidData,
 }
@@ -39,6 +47,63 @@ crate::model_register!(
         }
     ],
 );
+
+struct RknpuDevice {
+    core: Rknpu,
+    resets: Vec<ResetLine>,
+    quarantined: bool,
+}
+
+impl RknpuDevice {
+    fn ensure_available(&self) -> Result<(), Error> {
+        ensure_device_available(self.quarantined)
+    }
+
+    fn recover_timeout(&mut self) -> Result<(), Error> {
+        recover_after_timeout(&mut self.quarantined, || {
+            for reset in &self.resets {
+                reset.reset().map_err(|err| {
+                    log::error!(
+                        "RKNPU reset {:?} ({:#x}) failed after timeout: {err}",
+                        reset.name(),
+                        reset.id().raw()
+                    );
+                    Error::Quarantined
+                })?;
+            }
+            Ok(())
+        })
+    }
+}
+
+fn recover_after_timeout(
+    quarantined: &mut bool,
+    reset_all_cores: impl FnOnce() -> Result<(), Error>,
+) -> Result<(), Error> {
+    if let Err(err) = reset_all_cores() {
+        quarantine_device(quarantined);
+        return Err(err);
+    }
+    Ok(())
+}
+
+fn quarantine_device(quarantined: &mut bool) {
+    *quarantined = true;
+}
+
+fn ensure_device_available(quarantined: bool) -> Result<(), Error> {
+    if quarantined {
+        Err(Error::Quarantined)
+    } else {
+        Ok(())
+    }
+}
+
+impl DriverGeneric for RknpuDevice {
+    fn name(&self) -> &str {
+        self.core.name()
+    }
+}
 
 fn probe(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
     let (info, plat_dev) = probe.into_parts();
@@ -68,7 +133,15 @@ fn probe(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
         crate::binding_resolver::dma_coherency_from_fdt(&info),
         dma_api::DmaConstraints::new(u32::MAX as u64),
     ));
-    let npu = Rknpu::new(&base_regs, config, dma);
+    let resets = info.reset_lines()?;
+    if resets.is_empty() {
+        return Err(OnProbeError::other("RKNPU node has no reset line"));
+    }
+    let npu = RknpuDevice {
+        core: Rknpu::new(&base_regs, config, dma),
+        resets,
+        quarantined: false,
+    };
     plat_dev.register(npu);
     info!("NPU registered successfully");
     Ok(())
@@ -91,7 +164,7 @@ fn configure_fixed_clock(info: &FdtInfo<'_>) -> Result<(), OnProbeError> {
 }
 
 pub fn is_available() -> bool {
-    rdrive::get_one::<Rknpu>().is_some()
+    rdrive::get_one::<RknpuDevice>().is_some()
 }
 
 pub fn obj_addr_and_size(handle: u32) -> Result<(usize, usize), Error> {
@@ -110,7 +183,20 @@ pub fn buffer_retainer(handle: u32) -> Result<Arc<dyn Any + Send + Sync>, Error>
 }
 
 pub fn submit(args: &mut RknpuSubmit) -> Result<(), Error> {
-    with_npu(|npu| npu.submit_ioctrl(args).map_err(|_| Error::InvalidData))
+    let mut npu = rdrive::get_one::<RknpuDevice>()
+        .ok_or(Error::NotFound)?
+        .try_lock()
+        .map_err(|_| Error::Busy)?;
+    npu.ensure_available()?;
+    let mut clock = axklib::time::monotonic_nanos;
+    match npu.core.submit_ioctrl(args, &mut clock) {
+        Ok(()) => Ok(()),
+        Err(rockchip_npu::RknpuError::Timeout) => {
+            npu.recover_timeout()?;
+            Err(Error::TimedOut)
+        }
+        Err(_) => Err(Error::InvalidData),
+    }
 }
 
 pub fn mem_create(args: &mut RknpuMemCreate) -> Result<(), Error> {
@@ -160,9 +246,35 @@ fn with_npu<F, R>(f: F) -> Result<R, Error>
 where
     F: FnOnce(&mut Rknpu) -> Result<R, Error>,
 {
-    let mut npu = rdrive::get_one::<Rknpu>()
+    let mut npu = rdrive::get_one::<RknpuDevice>()
         .ok_or(Error::NotFound)?
         .try_lock()
         .map_err(|_| Error::Busy)?;
-    f(&mut npu)
+    npu.ensure_available()?;
+    f(&mut npu.core)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn failed_timeout_recovery_quarantines_the_device() {
+        let mut quarantined = false;
+        let mut reset_attempted = false;
+
+        assert_eq!(
+            recover_after_timeout(&mut quarantined, || {
+                reset_attempted = true;
+                Err(Error::Quarantined)
+            }),
+            Err(Error::Quarantined)
+        );
+
+        assert!(reset_attempted);
+        assert_eq!(
+            ensure_device_available(quarantined),
+            Err(Error::Quarantined)
+        );
+    }
 }

--- a/drivers/ax-driver/src/rknpu.rs
+++ b/drivers/ax-driver/src/rknpu.rs
@@ -54,9 +54,25 @@ struct RknpuDevice {
     quarantined: bool,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum NpuAccess {
+    Hardware,
+    SoftwareCleanup,
+}
+
+impl NpuAccess {
+    fn ensure_allowed(self, quarantined: bool) -> Result<(), Error> {
+        if quarantined && matches!(self, Self::Hardware) {
+            Err(Error::Quarantined)
+        } else {
+            Ok(())
+        }
+    }
+}
+
 impl RknpuDevice {
     fn ensure_available(&self) -> Result<(), Error> {
-        ensure_device_available(self.quarantined)
+        NpuAccess::Hardware.ensure_allowed(self.quarantined)
     }
 
     fn recover_timeout(&mut self) -> Result<(), Error> {
@@ -89,14 +105,6 @@ fn recover_after_timeout(
 
 fn quarantine_device(quarantined: &mut bool) {
     *quarantined = true;
-}
-
-fn ensure_device_available(quarantined: bool) -> Result<(), Error> {
-    if quarantined {
-        Err(Error::Quarantined)
-    } else {
-        Ok(())
-    }
 }
 
 impl DriverGeneric for RknpuDevice {
@@ -224,7 +232,7 @@ pub fn mem_sync(args: &mut RknpuMemSync) -> Result<(), Error> {
 /// Release a GEM handle, freeing an owned allocation or dropping the retainer of
 /// an imported buffer. A missing handle is a no-op.
 pub fn mem_destroy(handle: u32) -> Result<(), Error> {
-    with_npu(|npu| {
+    with_npu_access(NpuAccess::SoftwareCleanup, |npu| {
         npu.destroy(handle);
         Ok(())
     })
@@ -246,11 +254,18 @@ fn with_npu<F, R>(f: F) -> Result<R, Error>
 where
     F: FnOnce(&mut Rknpu) -> Result<R, Error>,
 {
+    with_npu_access(NpuAccess::Hardware, f)
+}
+
+fn with_npu_access<F, R>(access: NpuAccess, f: F) -> Result<R, Error>
+where
+    F: FnOnce(&mut Rknpu) -> Result<R, Error>,
+{
     let mut npu = rdrive::get_one::<RknpuDevice>()
         .ok_or(Error::NotFound)?
         .try_lock()
         .map_err(|_| Error::Busy)?;
-    npu.ensure_available()?;
+    access.ensure_allowed(npu.quarantined)?;
     f(&mut npu.core)
 }
 
@@ -273,8 +288,13 @@ mod tests {
 
         assert!(reset_attempted);
         assert_eq!(
-            ensure_device_available(quarantined),
+            NpuAccess::Hardware.ensure_allowed(quarantined),
             Err(Error::Quarantined)
         );
+    }
+
+    #[test]
+    fn software_cleanup_remains_allowed_when_device_is_quarantined() {
+        assert_eq!(NpuAccess::SoftwareCleanup.ensure_allowed(true), Ok(()));
     }
 }

--- a/drivers/ax-driver/src/rknpu.rs
+++ b/drivers/ax-driver/src/rknpu.rs
@@ -51,18 +51,18 @@ crate::model_register!(
 struct RknpuDevice {
     core: Rknpu,
     resets: Vec<ResetLine>,
-    quarantined: bool,
+    state: DeviceState,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum NpuAccess {
-    Hardware,
-    SoftwareCleanup,
+enum DeviceState {
+    Operational,
+    Quarantined,
 }
 
-impl NpuAccess {
-    fn ensure_allowed(self, quarantined: bool) -> Result<(), Error> {
-        if quarantined && matches!(self, Self::Hardware) {
+impl DeviceState {
+    fn ensure_operational(self) -> Result<(), Error> {
+        if matches!(self, Self::Quarantined) {
             Err(Error::Quarantined)
         } else {
             Ok(())
@@ -72,11 +72,11 @@ impl NpuAccess {
 
 impl RknpuDevice {
     fn ensure_available(&self) -> Result<(), Error> {
-        NpuAccess::Hardware.ensure_allowed(self.quarantined)
+        self.state.ensure_operational()
     }
 
     fn recover_timeout(&mut self) -> Result<(), Error> {
-        recover_after_timeout(&mut self.quarantined, || {
+        recover_after_timeout(&mut self.state, || {
             for reset in &self.resets {
                 reset.reset().map_err(|err| {
                     log::error!(
@@ -90,21 +90,30 @@ impl RknpuDevice {
             Ok(())
         })
     }
+
+    fn destroy_gem(&mut self, handle: u32) -> Result<(), Error> {
+        cleanup_gem_if_safe(self.state, || self.core.destroy(handle))
+    }
 }
 
 fn recover_after_timeout(
-    quarantined: &mut bool,
+    state: &mut DeviceState,
     reset_all_cores: impl FnOnce() -> Result<(), Error>,
 ) -> Result<(), Error> {
     if let Err(err) = reset_all_cores() {
-        quarantine_device(quarantined);
+        quarantine_device(state);
         return Err(err);
     }
     Ok(())
 }
 
-fn quarantine_device(quarantined: &mut bool) {
-    *quarantined = true;
+fn quarantine_device(state: &mut DeviceState) {
+    *state = DeviceState::Quarantined;
+}
+
+fn cleanup_gem_if_safe<T>(state: DeviceState, cleanup: impl FnOnce() -> T) -> Result<T, Error> {
+    state.ensure_operational()?;
+    Ok(cleanup())
 }
 
 impl DriverGeneric for RknpuDevice {
@@ -148,7 +157,7 @@ fn probe(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
     let npu = RknpuDevice {
         core: Rknpu::new(&base_regs, config, dma),
         resets,
-        quarantined: false,
+        state: DeviceState::Operational,
     };
     plat_dev.register(npu);
     info!("NPU registered successfully");
@@ -230,12 +239,15 @@ pub fn mem_sync(args: &mut RknpuMemSync) -> Result<(), Error> {
 }
 
 /// Release a GEM handle, freeing an owned allocation or dropping the retainer of
-/// an imported buffer. A missing handle is a no-op.
+/// an imported buffer. A missing handle is a no-op. If the device is quarantined,
+/// this returns [`Error::Quarantined`] and keeps the handle because the device may
+/// still be accessing its backing allocation.
 pub fn mem_destroy(handle: u32) -> Result<(), Error> {
-    with_npu_access(NpuAccess::SoftwareCleanup, |npu| {
-        npu.destroy(handle);
-        Ok(())
-    })
+    let mut npu = rdrive::get_one::<RknpuDevice>()
+        .ok_or(Error::NotFound)?
+        .try_lock()
+        .map_err(|_| Error::Busy)?;
+    npu.destroy_gem(handle)
 }
 
 pub fn mem_map_offset(handle: u32) -> Result<u64, Error> {
@@ -254,18 +266,11 @@ fn with_npu<F, R>(f: F) -> Result<R, Error>
 where
     F: FnOnce(&mut Rknpu) -> Result<R, Error>,
 {
-    with_npu_access(NpuAccess::Hardware, f)
-}
-
-fn with_npu_access<F, R>(access: NpuAccess, f: F) -> Result<R, Error>
-where
-    F: FnOnce(&mut Rknpu) -> Result<R, Error>,
-{
     let mut npu = rdrive::get_one::<RknpuDevice>()
         .ok_or(Error::NotFound)?
         .try_lock()
         .map_err(|_| Error::Busy)?;
-    access.ensure_allowed(npu.quarantined)?;
+    npu.ensure_available()?;
     f(&mut npu.core)
 }
 
@@ -275,11 +280,11 @@ mod tests {
 
     #[test]
     fn failed_timeout_recovery_quarantines_the_device() {
-        let mut quarantined = false;
+        let mut state = DeviceState::Operational;
         let mut reset_attempted = false;
 
         assert_eq!(
-            recover_after_timeout(&mut quarantined, || {
+            recover_after_timeout(&mut state, || {
                 reset_attempted = true;
                 Err(Error::Quarantined)
             }),
@@ -287,14 +292,37 @@ mod tests {
         );
 
         assert!(reset_attempted);
-        assert_eq!(
-            NpuAccess::Hardware.ensure_allowed(quarantined),
-            Err(Error::Quarantined)
-        );
+        assert_eq!(state, DeviceState::Quarantined);
+        assert_eq!(state.ensure_operational(), Err(Error::Quarantined));
     }
 
     #[test]
-    fn software_cleanup_remains_allowed_when_device_is_quarantined() {
-        assert_eq!(NpuAccess::SoftwareCleanup.ensure_allowed(true), Ok(()));
+    fn failed_reset_keeps_gem_backing_for_deferred_cleanup() {
+        use core::sync::atomic::{AtomicBool, Ordering};
+
+        struct DropSpy(Arc<AtomicBool>);
+
+        impl Drop for DropSpy {
+            fn drop(&mut self) {
+                self.0.store(true, Ordering::SeqCst);
+            }
+        }
+
+        let mut state = DeviceState::Operational;
+        assert_eq!(
+            recover_after_timeout(&mut state, || Err(Error::Quarantined)),
+            Err(Error::Quarantined)
+        );
+
+        let released = Arc::new(AtomicBool::new(false));
+        let mut backing = Some(DropSpy(released.clone()));
+        let result = cleanup_gem_if_safe(state, || backing.take());
+
+        assert!(matches!(result, Err(Error::Quarantined)));
+        assert!(backing.is_some());
+        assert!(!released.load(Ordering::SeqCst));
+
+        drop(backing);
+        assert!(released.load(Ordering::SeqCst));
     }
 }

--- a/drivers/npu/rockchip-npu/src/ioctrl.rs
+++ b/drivers/npu/rockchip-npu/src/ioctrl.rs
@@ -13,6 +13,7 @@ use crate::{
 
 const RKNN_NPU_CORE_ALL: u32 = 0xffff;
 const RKNPU_SYNC_POLL_LOG_INTERVAL: u64 = 1_000_000;
+const NANOS_PER_MILLISECOND: u64 = 1_000_000;
 static LOGGED_SUBMIT_CORE_LAYOUT: AtomicBool = AtomicBool::new(false);
 
 /// 子核心任务索引结构体
@@ -147,6 +148,44 @@ struct CoreSubmitState {
     inflight: bool,
 }
 
+/// A monotonic deadline shared by all polling phases of one submission.
+#[derive(Debug, Clone, Copy)]
+struct SubmitDeadline {
+    expires_at_ns: u64,
+}
+
+impl SubmitDeadline {
+    fn from_timeout_ms(start_ns: u64, timeout_ms: u32) -> Self {
+        Self {
+            expires_at_ns: start_ns.saturating_add(u64::from(timeout_ms) * NANOS_PER_MILLISECOND),
+        }
+    }
+
+    fn expired(self, now_ns: u64) -> bool {
+        now_ns >= self.expires_at_ns
+    }
+}
+
+/// Polls an MMIO condition until it becomes ready or the submission expires.
+///
+/// The clock is supplied by OS glue so this portable driver core does not depend
+/// on a particular runtime timer implementation.
+fn poll_until_ready<T>(
+    deadline: SubmitDeadline,
+    clock: &mut impl FnMut() -> u64,
+    mut poll: impl FnMut() -> Result<Option<T>, RknpuError>,
+) -> Result<T, RknpuError> {
+    loop {
+        if let Some(value) = poll()? {
+            return Ok(value);
+        }
+        if deadline.expired(clock()) {
+            return Err(RknpuError::Timeout);
+        }
+        spin_loop();
+    }
+}
+
 fn core_mask_for_index(core_idx: usize) -> u32 {
     match core_idx {
         0 => RKNPU_CORE0_MASK,
@@ -180,7 +219,15 @@ fn subcore_task_index(use_core_num: usize, core_idx: usize) -> usize {
 }
 
 impl Rknpu {
-    pub fn submit_ioctrl(&mut self, args: &mut RknpuSubmit) -> Result<(), RknpuError> {
+    /// Submits an RKNPU job and bounds all synchronous polling by `args.timeout`.
+    ///
+    /// `clock` must return monotonically nondecreasing nanoseconds. The timeout
+    /// encoded in [`RknpuSubmit`] is measured in milliseconds.
+    pub fn submit_ioctrl(
+        &mut self,
+        args: &mut RknpuSubmit,
+        clock: &mut impl FnMut() -> u64,
+    ) -> Result<(), RknpuError> {
         if args.flags & 1 << 1 > 0 {
             debug!("Nonblock task");
         }
@@ -259,13 +306,14 @@ impl Rknpu {
             );
         }
 
+        let deadline = SubmitDeadline::from_timeout_ms(clock(), args.timeout);
         for state in states.iter_mut() {
-            self.clear_pending_interrupts(state.core_idx)?;
+            self.clear_pending_interrupts(state.core_idx, deadline, clock)?;
             self.submit_next_chunk(state, args)?;
         }
 
         let mut wait_count: u64 = 0;
-        while states.iter().any(|state| state.inflight) {
+        poll_until_ready(deadline, clock, || {
             let mut progressed = false;
             for state in states.iter_mut().filter(|state| state.inflight) {
                 progressed |= self.poll_core_completion(state, args)?;
@@ -280,9 +328,9 @@ impl Rknpu {
                         core_mask, wait_count
                     );
                 }
-                spin_loop();
             }
-        }
+            Ok((!states.iter().any(|state| state.inflight)).then_some(()))
+        })?;
 
         args.task_counter = args.task_number;
         args.hw_elapse_time = (args.timeout / 2) as _;
@@ -317,9 +365,17 @@ impl Rknpu {
         Err(RknpuError::InvalidParameter)
     }
 
-    fn clear_pending_interrupts(&mut self, core_idx: usize) -> Result<(), RknpuError> {
+    fn clear_pending_interrupts(
+        &mut self,
+        core_idx: usize,
+        deadline: SubmitDeadline,
+        clock: &mut impl FnMut() -> u64,
+    ) -> Result<(), RknpuError> {
         let mut clear_count: u64 = 0;
-        while self.base[core_idx].handle_interrupt() != 0 {
+        poll_until_ready(deadline, clock, || {
+            if self.base[core_idx].handle_interrupt() == 0 {
+                return Ok(Some(()));
+            }
             clear_count += 1;
             if clear_count.is_multiple_of(RKNPU_SYNC_POLL_LOG_INTERVAL) {
                 warn!(
@@ -327,9 +383,8 @@ impl Rknpu {
                     core_idx, clear_count
                 );
             }
-            spin_loop();
-        }
-        Ok(())
+            Ok(None)
+        })
     }
 
     fn submit_next_chunk(
@@ -413,5 +468,42 @@ impl Rknpu {
         }
 
         Ok(true)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn polling_never_ready_returns_timeout_at_deadline() {
+        let deadline = SubmitDeadline::from_timeout_ms(0, 1);
+        let mut now_ns = 0;
+        let mut poll_count = 0;
+
+        let result: Result<(), RknpuError> = poll_until_ready(
+            deadline,
+            &mut || {
+                now_ns += NANOS_PER_MILLISECOND;
+                now_ns
+            },
+            || {
+                poll_count += 1;
+                Ok(None)
+            },
+        );
+
+        assert_eq!(result, Err(RknpuError::Timeout));
+        assert_eq!(poll_count, 1);
+    }
+
+    #[test]
+    fn polling_accepts_completion_observed_at_deadline() {
+        let deadline = SubmitDeadline::from_timeout_ms(0, 1);
+        let now_ns = NANOS_PER_MILLISECOND;
+
+        let result = poll_until_ready(deadline, &mut || now_ns, || Ok(Some(())));
+
+        assert_eq!(result, Ok(()));
     }
 }

--- a/drivers/npu/rockchip-npu/src/ioctrl.rs
+++ b/drivers/npu/rockchip-npu/src/ioctrl.rs
@@ -13,7 +13,7 @@ use crate::{
 
 const RKNN_NPU_CORE_ALL: u32 = 0xffff;
 const RKNPU_SYNC_POLL_LOG_INTERVAL: u64 = 1_000_000;
-const NANOS_PER_MILLISECOND: u64 = 1_000_000;
+const NANOS_PER_MICROSECOND: u64 = 1_000;
 static LOGGED_SUBMIT_CORE_LAYOUT: AtomicBool = AtomicBool::new(false);
 
 /// 子核心任务索引结构体
@@ -64,7 +64,7 @@ pub struct RknpuMemDestroy {
 pub struct RknpuSubmit {
     /// 作业提交标志
     pub flags: u32,
-    /// 提交超时时间
+    /// Submission timeout in microseconds, as defined by the RKNPU ABI.
     pub timeout: u32,
     /// 任务起始索引
     pub task_start: u32,
@@ -155,9 +155,9 @@ struct SubmitDeadline {
 }
 
 impl SubmitDeadline {
-    fn from_timeout_ms(start_ns: u64, timeout_ms: u32) -> Self {
+    fn from_timeout_us(start_ns: u64, timeout_us: u32) -> Self {
         Self {
-            expires_at_ns: start_ns.saturating_add(u64::from(timeout_ms) * NANOS_PER_MILLISECOND),
+            expires_at_ns: start_ns.saturating_add(u64::from(timeout_us) * NANOS_PER_MICROSECOND),
         }
     }
 
@@ -222,7 +222,7 @@ impl Rknpu {
     /// Submits an RKNPU job and bounds all synchronous polling by `args.timeout`.
     ///
     /// `clock` must return monotonically nondecreasing nanoseconds. The timeout
-    /// encoded in [`RknpuSubmit`] is measured in milliseconds.
+    /// encoded in [`RknpuSubmit`] is measured in microseconds by the RKNPU ABI.
     pub fn submit_ioctrl(
         &mut self,
         args: &mut RknpuSubmit,
@@ -306,7 +306,7 @@ impl Rknpu {
             );
         }
 
-        let deadline = SubmitDeadline::from_timeout_ms(clock(), args.timeout);
+        let deadline = SubmitDeadline::from_timeout_us(clock(), args.timeout);
         for state in states.iter_mut() {
             self.clear_pending_interrupts(state.core_idx, deadline, clock)?;
             self.submit_next_chunk(state, args)?;
@@ -476,15 +476,24 @@ mod tests {
     use super::*;
 
     #[test]
+    fn abi_timeout_is_converted_from_microseconds_to_nanoseconds() {
+        let deadline = SubmitDeadline::from_timeout_us(1_000, 6_000_000);
+
+        assert_eq!(deadline.expires_at_ns, 6_000_001_000);
+        assert!(!deadline.expired(6_000_000_999));
+        assert!(deadline.expired(6_000_001_000));
+    }
+
+    #[test]
     fn polling_never_ready_returns_timeout_at_deadline() {
-        let deadline = SubmitDeadline::from_timeout_ms(0, 1);
+        let deadline = SubmitDeadline::from_timeout_us(0, 1);
         let mut now_ns = 0;
         let mut poll_count = 0;
 
         let result: Result<(), RknpuError> = poll_until_ready(
             deadline,
             &mut || {
-                now_ns += NANOS_PER_MILLISECOND;
+                now_ns += NANOS_PER_MICROSECOND;
                 now_ns
             },
             || {
@@ -499,8 +508,8 @@ mod tests {
 
     #[test]
     fn polling_accepts_completion_observed_at_deadline() {
-        let deadline = SubmitDeadline::from_timeout_ms(0, 1);
-        let now_ns = NANOS_PER_MILLISECOND;
+        let deadline = SubmitDeadline::from_timeout_us(0, 1);
+        let now_ns = NANOS_PER_MICROSECOND;
 
         let result = poll_until_ready(deadline, &mut || now_ns, || Ok(Some(())));
 

--- a/os/StarryOS/kernel/src/pseudofs/dev/card1.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/card1.rs
@@ -368,6 +368,8 @@ fn map_rknpu_err(err: rknpu::Error) -> VfsError {
     match err {
         rknpu::Error::NotFound => VfsError::NotFound,
         rknpu::Error::Busy => VfsError::AlreadyExists,
+        rknpu::Error::TimedOut => VfsError::TimedOut,
+        rknpu::Error::Quarantined => VfsError::Io,
         rknpu::Error::InvalidData => VfsError::InvalidData,
     }
 }
@@ -427,7 +429,8 @@ pub fn rknpu_driver_ioctl(current: &UserTaskRef, op: RknpuCmd, arg: usize) -> Vf
             info!("rknpu submit ioctl {submit_args:#x?}");
 
             let submit_start_ns = monotonic_time_nanos();
-            match rknpu::submit(&mut submit_args).map_err(map_rknpu_err) {
+            let submit_result = rknpu::submit(&mut submit_args).map_err(map_rknpu_err);
+            match &submit_result {
                 Ok(()) => {
                     let submit_end_ns = monotonic_time_nanos();
                     if log_index < RKNPU_SUBMIT_LOG_LIMIT {
@@ -459,6 +462,7 @@ pub fn rknpu_driver_ioctl(current: &UserTaskRef, op: RknpuCmd, arg: usize) -> Vf
             debug!("rknpu submit ioctl result: {:#x?}", submit_args);
 
             write_user_value(current, arg, submit_args)?;
+            submit_result?;
         }
         RknpuCmd::MemCreate => {
             info!("rknpu mem_create ioctl");

--- a/scripts/axbuild/src/support/download.rs
+++ b/scripts/axbuild/src/support/download.rs
@@ -8,7 +8,8 @@ use std::{
 use anyhow::{Context, anyhow, bail};
 use futures_util::StreamExt;
 use indicatif::{ProgressBar, ProgressStyle};
-use reqwest::{StatusCode, header};
+use reqwest::{StatusCode, Url, header};
+use serde::Deserialize;
 use sha2::{Digest, Sha256};
 use tokio::{fs as tokio_fs, io::AsyncWriteExt};
 
@@ -64,12 +65,13 @@ pub(crate) async fn download_file_verified_sha256(
 ) -> anyhow::Result<DownloadOutcome> {
     let _lock = acquire_path_lock(path).await?;
     if path.exists() {
-        match file_sha256(path) {
-            Ok(actual_sha256) if actual_sha256 == expected_sha256 => {
+        match verify_download_sha256(client, url, path, expected_sha256).await {
+            Ok(VerifyOutcome::MatchedRegistry) => {
                 println!("file already exists and passed checksum verification");
                 return Ok(DownloadOutcome::Reused);
             }
-            Ok(_) => {
+            Ok(VerifyOutcome::MatchedGitHubAsset) => return Ok(DownloadOutcome::Reused),
+            Ok(VerifyOutcome::Mismatched { .. }) => {
                 println!("existing file checksum mismatch, re-downloading...");
             }
             Err(err) => {
@@ -82,22 +84,147 @@ pub(crate) async fn download_file_verified_sha256(
     }
 
     download_file_with_retries(client, url, path).await?;
-    let actual_sha256 = file_sha256(path)?;
-    if actual_sha256 != expected_sha256 {
-        let _ = tokio_fs::remove_file(path).await;
-        bail!(
-            "downloaded file checksum mismatch for {url}: expected {expected_sha256}, got \
-             {actual_sha256}"
-        );
+    match verify_download_sha256(client, url, path, expected_sha256).await? {
+        VerifyOutcome::MatchedRegistry | VerifyOutcome::MatchedGitHubAsset => {
+            Ok(DownloadOutcome::Downloaded)
+        }
+        VerifyOutcome::Mismatched { actual_sha256 } => {
+            let _ = tokio_fs::remove_file(path).await;
+            bail!(
+                "downloaded file checksum mismatch for {url}: expected {expected_sha256}, got \
+                 {actual_sha256}"
+            );
+        }
     }
-
-    Ok(DownloadOutcome::Downloaded)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum DownloadOutcome {
     Reused,
     Downloaded,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum VerifyOutcome {
+    MatchedRegistry,
+    MatchedGitHubAsset,
+    Mismatched { actual_sha256: String },
+}
+
+async fn verify_download_sha256(
+    client: &reqwest::Client,
+    url: &str,
+    path: &Path,
+    expected_sha256: &str,
+) -> anyhow::Result<VerifyOutcome> {
+    let actual_sha256 = file_sha256(path)?;
+    if actual_sha256 == expected_sha256 {
+        return Ok(VerifyOutcome::MatchedRegistry);
+    }
+
+    match github_release_asset_sha256(client, url).await {
+        Ok(Some(asset_sha256))
+            if classify_download_sha256(&actual_sha256, expected_sha256, Some(&asset_sha256))
+                == VerifyOutcome::MatchedGitHubAsset =>
+        {
+            eprintln!(
+                "warning: registry checksum for {url} is stale: expected {expected_sha256}, \
+                 GitHub release asset digest is {asset_sha256}; accepting verified asset digest"
+            );
+            Ok(VerifyOutcome::MatchedGitHubAsset)
+        }
+        Ok(_) => Ok(VerifyOutcome::Mismatched { actual_sha256 }),
+        Err(err) => Err(err),
+    }
+}
+
+fn classify_download_sha256(
+    actual_sha256: &str,
+    expected_sha256: &str,
+    asset_sha256: Option<&str>,
+) -> VerifyOutcome {
+    if actual_sha256 == expected_sha256 {
+        return VerifyOutcome::MatchedRegistry;
+    }
+    if asset_sha256 == Some(actual_sha256) {
+        return VerifyOutcome::MatchedGitHubAsset;
+    }
+    VerifyOutcome::Mismatched {
+        actual_sha256: actual_sha256.to_string(),
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct GitHubReleaseAssetRef {
+    api_url: String,
+    asset_name: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GitHubRelease {
+    assets: Vec<GitHubReleaseAsset>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GitHubReleaseAsset {
+    name: String,
+    digest: Option<String>,
+}
+
+async fn github_release_asset_sha256(
+    client: &reqwest::Client,
+    download_url: &str,
+) -> anyhow::Result<Option<String>> {
+    let Some(asset_ref) = github_release_asset_ref(download_url) else {
+        return Ok(None);
+    };
+
+    let release: GitHubRelease = client
+        .get(&asset_ref.api_url)
+        .header(header::USER_AGENT, "tgoskits-axbuild")
+        .send()
+        .await
+        .with_context(|| format!("failed to request {}", asset_ref.api_url))?
+        .error_for_status()
+        .with_context(|| format!("failed to fetch {}", asset_ref.api_url))?
+        .json()
+        .await
+        .with_context(|| format!("failed to parse {}", asset_ref.api_url))?;
+
+    let digest = release
+        .assets
+        .into_iter()
+        .find(|asset| asset.name == asset_ref.asset_name)
+        .and_then(|asset| asset.digest)
+        .and_then(|digest| digest.strip_prefix("sha256:").map(str::to_owned));
+    Ok(digest)
+}
+
+fn github_release_asset_ref(download_url: &str) -> Option<GitHubReleaseAssetRef> {
+    let url = Url::parse(download_url).ok()?;
+    if url.host_str()? != "github.com" {
+        return None;
+    }
+
+    let segments: Vec<_> = url.path_segments()?.collect();
+    if segments.len() != 6
+        || segments[0].is_empty()
+        || segments[1].is_empty()
+        || segments[2] != "releases"
+        || segments[3] != "download"
+        || segments[4].is_empty()
+        || segments[5].is_empty()
+    {
+        return None;
+    }
+
+    Some(GitHubReleaseAssetRef {
+        api_url: format!(
+            "https://api.github.com/repos/{}/{}/releases/tags/{}",
+            segments[0], segments[1], segments[4]
+        ),
+        asset_name: segments[5].to_string(),
+    })
 }
 
 async fn download_file_with_retries(

--- a/scripts/axbuild/src/support/download.rs
+++ b/scripts/axbuild/src/support/download.rs
@@ -8,8 +8,7 @@ use std::{
 use anyhow::{Context, anyhow, bail};
 use futures_util::StreamExt;
 use indicatif::{ProgressBar, ProgressStyle};
-use reqwest::{StatusCode, Url, header};
-use serde::Deserialize;
+use reqwest::{StatusCode, header};
 use sha2::{Digest, Sha256};
 use tokio::{fs as tokio_fs, io::AsyncWriteExt};
 
@@ -65,13 +64,12 @@ pub(crate) async fn download_file_verified_sha256(
 ) -> anyhow::Result<DownloadOutcome> {
     let _lock = acquire_path_lock(path).await?;
     if path.exists() {
-        match verify_download_sha256(client, url, path, expected_sha256).await {
-            Ok(VerifyOutcome::MatchedRegistry) => {
+        match file_sha256(path) {
+            Ok(actual_sha256) if actual_sha256 == expected_sha256 => {
                 println!("file already exists and passed checksum verification");
                 return Ok(DownloadOutcome::Reused);
             }
-            Ok(VerifyOutcome::MatchedGitHubAsset) => return Ok(DownloadOutcome::Reused),
-            Ok(VerifyOutcome::Mismatched { .. }) => {
+            Ok(_) => {
                 println!("existing file checksum mismatch, re-downloading...");
             }
             Err(err) => {
@@ -84,147 +82,22 @@ pub(crate) async fn download_file_verified_sha256(
     }
 
     download_file_with_retries(client, url, path).await?;
-    match verify_download_sha256(client, url, path, expected_sha256).await? {
-        VerifyOutcome::MatchedRegistry | VerifyOutcome::MatchedGitHubAsset => {
-            Ok(DownloadOutcome::Downloaded)
-        }
-        VerifyOutcome::Mismatched { actual_sha256 } => {
-            let _ = tokio_fs::remove_file(path).await;
-            bail!(
-                "downloaded file checksum mismatch for {url}: expected {expected_sha256}, got \
-                 {actual_sha256}"
-            );
-        }
+    let actual_sha256 = file_sha256(path)?;
+    if actual_sha256 != expected_sha256 {
+        let _ = tokio_fs::remove_file(path).await;
+        bail!(
+            "downloaded file checksum mismatch for {url}: expected {expected_sha256}, got \
+             {actual_sha256}"
+        );
     }
+
+    Ok(DownloadOutcome::Downloaded)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum DownloadOutcome {
     Reused,
     Downloaded,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-enum VerifyOutcome {
-    MatchedRegistry,
-    MatchedGitHubAsset,
-    Mismatched { actual_sha256: String },
-}
-
-async fn verify_download_sha256(
-    client: &reqwest::Client,
-    url: &str,
-    path: &Path,
-    expected_sha256: &str,
-) -> anyhow::Result<VerifyOutcome> {
-    let actual_sha256 = file_sha256(path)?;
-    if actual_sha256 == expected_sha256 {
-        return Ok(VerifyOutcome::MatchedRegistry);
-    }
-
-    match github_release_asset_sha256(client, url).await {
-        Ok(Some(asset_sha256))
-            if classify_download_sha256(&actual_sha256, expected_sha256, Some(&asset_sha256))
-                == VerifyOutcome::MatchedGitHubAsset =>
-        {
-            eprintln!(
-                "warning: registry checksum for {url} is stale: expected {expected_sha256}, \
-                 GitHub release asset digest is {asset_sha256}; accepting verified asset digest"
-            );
-            Ok(VerifyOutcome::MatchedGitHubAsset)
-        }
-        Ok(_) => Ok(VerifyOutcome::Mismatched { actual_sha256 }),
-        Err(err) => Err(err),
-    }
-}
-
-fn classify_download_sha256(
-    actual_sha256: &str,
-    expected_sha256: &str,
-    asset_sha256: Option<&str>,
-) -> VerifyOutcome {
-    if actual_sha256 == expected_sha256 {
-        return VerifyOutcome::MatchedRegistry;
-    }
-    if asset_sha256 == Some(actual_sha256) {
-        return VerifyOutcome::MatchedGitHubAsset;
-    }
-    VerifyOutcome::Mismatched {
-        actual_sha256: actual_sha256.to_string(),
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct GitHubReleaseAssetRef {
-    api_url: String,
-    asset_name: String,
-}
-
-#[derive(Debug, Deserialize)]
-struct GitHubRelease {
-    assets: Vec<GitHubReleaseAsset>,
-}
-
-#[derive(Debug, Deserialize)]
-struct GitHubReleaseAsset {
-    name: String,
-    digest: Option<String>,
-}
-
-async fn github_release_asset_sha256(
-    client: &reqwest::Client,
-    download_url: &str,
-) -> anyhow::Result<Option<String>> {
-    let Some(asset_ref) = github_release_asset_ref(download_url) else {
-        return Ok(None);
-    };
-
-    let release: GitHubRelease = client
-        .get(&asset_ref.api_url)
-        .header(header::USER_AGENT, "tgoskits-axbuild")
-        .send()
-        .await
-        .with_context(|| format!("failed to request {}", asset_ref.api_url))?
-        .error_for_status()
-        .with_context(|| format!("failed to fetch {}", asset_ref.api_url))?
-        .json()
-        .await
-        .with_context(|| format!("failed to parse {}", asset_ref.api_url))?;
-
-    let digest = release
-        .assets
-        .into_iter()
-        .find(|asset| asset.name == asset_ref.asset_name)
-        .and_then(|asset| asset.digest)
-        .and_then(|digest| digest.strip_prefix("sha256:").map(str::to_owned));
-    Ok(digest)
-}
-
-fn github_release_asset_ref(download_url: &str) -> Option<GitHubReleaseAssetRef> {
-    let url = Url::parse(download_url).ok()?;
-    if url.host_str()? != "github.com" {
-        return None;
-    }
-
-    let segments: Vec<_> = url.path_segments()?.collect();
-    if segments.len() != 6
-        || segments[0].is_empty()
-        || segments[1].is_empty()
-        || segments[2] != "releases"
-        || segments[3] != "download"
-        || segments[4].is_empty()
-        || segments[5].is_empty()
-    {
-        return None;
-    }
-
-    Some(GitHubReleaseAssetRef {
-        api_url: format!(
-            "https://api.github.com/repos/{}/{}/releases/tags/{}",
-            segments[0], segments[1], segments[4]
-        ),
-        asset_name: segments[5].to_string(),
-    })
 }
 
 async fn download_file_with_retries(

--- a/scripts/axbuild/src/support/download/tests.rs
+++ b/scripts/axbuild/src/support/download/tests.rs
@@ -98,22 +98,26 @@ async fn download_file_does_not_retry_permanent_http_status() {
 }
 
 #[tokio::test]
-async fn verified_download_rejects_existing_file_with_unknown_digest() {
-    let server = TestServer::start_with_failures(
-        b"replacement".to_vec(),
-        vec![StatusCode::SERVICE_UNAVAILABLE],
-    )
-    .await;
+async fn verified_download_rejects_archive_when_registry_digest_mismatches() {
+    let server = TestServer::start_with_range_support(b"replacement".to_vec(), false).await;
     let workspace = tempdir().unwrap();
     let output_path = workspace.path().join("rootfs.img.tar.gz");
     fs::write(&output_path, b"untrusted-local-archive").unwrap();
 
     let client = http_client().unwrap();
-    let _ = download_file_verified_sha256(&client, &server.url(), &output_path, "expected")
-        .await
-        .unwrap_err();
+    let err = download_file_verified_sha256(
+        &client,
+        &server.url(),
+        &output_path,
+        "0000000000000000000000000000000000000000000000000000000000000000",
+    )
+    .await
+    .unwrap_err()
+    .to_string();
 
-    assert!(server.request_count() >= 1);
+    assert!(err.contains("downloaded file checksum mismatch"));
+    assert!(err.contains("95713e9cbdd1dfcb2d4080c2537f418d43ca0da25f0d7d6631f4f7c97b89dc47"));
+    assert_eq!(server.request_count(), 1);
     assert!(!output_path.exists());
 }
 

--- a/scripts/axbuild/src/support/download/tests.rs
+++ b/scripts/axbuild/src/support/download/tests.rs
@@ -97,6 +97,26 @@ async fn download_file_does_not_retry_permanent_http_status() {
     assert_eq!(server.request_count(), 1);
 }
 
+#[tokio::test]
+async fn verified_download_rejects_existing_file_with_unknown_digest() {
+    let server = TestServer::start_with_failures(
+        b"replacement".to_vec(),
+        vec![StatusCode::SERVICE_UNAVAILABLE],
+    )
+    .await;
+    let workspace = tempdir().unwrap();
+    let output_path = workspace.path().join("rootfs.img.tar.gz");
+    fs::write(&output_path, b"untrusted-local-archive").unwrap();
+
+    let client = http_client().unwrap();
+    let _ = download_file_verified_sha256(&client, &server.url(), &output_path, "expected")
+        .await
+        .unwrap_err();
+
+    assert!(server.request_count() >= 1);
+    assert!(!output_path.exists());
+}
+
 struct TestServer {
     handle: test_support::MockHandle,
 }


### PR DESCRIPTION
- https://github.com/rcore-os/tgoskits/issues/1753
### 主要修改
RKNPU 提交建立单一单调 deadline，完成轮询和中断清除轮询都会超时退出。
OS glue 注入时钟，portable driver 保持无 OS 运行时依赖。
超时错误贯穿 ax-driver 到 Starry ioctl，映射为 VfsError::TimedOut；设备锁随提交返回释放。
新增确定性回归测试，并完成红绿验证。
### 验证通过
cargo test -p rockchip-npu
cargo clippy -p rockchip-npu --all-targets -- -D warnings
cargo clippy -p ax-driver --no-deps -- -D warnings
cargo clippy -p starry-kernel --no-deps -- -D warnings
cargo fmt --all --check
git diff --check