### PR TITLE
fix(rknpu): copy and validate user task arrays before NPU submit

### DIFF
--- a/drivers/ax-driver/src/rknpu.rs
+++ b/drivers/ax-driver/src/rknpu.rs
@@ -11,7 +11,7 @@ use rdrive::{
     register::ProbeFdt,
 };
 pub use rockchip_npu::{
-    GemBufferInfo, GemCachePolicy, RknpuAction,
+    GemBufferInfo, GemCachePolicy, RknpuAction, RknpuTask,
     ioctrl::{RknpuMemCreate, RknpuMemDestroy, RknpuMemMap, RknpuMemSync, RknpuSubmit},
 };
 use rockchip_npu::{Rknpu, RknpuConfig, RknpuType};
@@ -199,14 +199,14 @@ pub fn buffer_retainer(handle: u32) -> Result<Arc<dyn Any + Send + Sync>, Error>
     with_npu(|npu| npu.buffer_retainer(handle).ok_or(Error::NotFound))
 }
 
-pub fn submit(args: &mut RknpuSubmit) -> Result<(), Error> {
+pub fn submit(args: &mut RknpuSubmit, tasks: &mut [RknpuTask]) -> Result<(), Error> {
     let mut npu = rdrive::get_one::<RknpuDevice>()
         .ok_or(Error::NotFound)?
         .try_lock()
         .map_err(|_| Error::Busy)?;
     npu.ensure_available()?;
     let mut clock = axklib::time::monotonic_nanos;
-    match npu.core.submit_ioctrl(args, &mut clock) {
+    match npu.core.submit_ioctrl(args, tasks, &mut clock) {
         Ok(()) => Ok(()),
         Err(rockchip_npu::RknpuError::Timeout) => {
             npu.recover_timeout()?;

--- a/drivers/ax-driver/src/rknpu.rs
+++ b/drivers/ax-driver/src/rknpu.rs
@@ -154,8 +154,11 @@ fn probe(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
     if resets.is_empty() {
         return Err(OnProbeError::other("RKNPU node has no reset line"));
     }
+    let core = Rknpu::new(&base_regs, config, dma).map_err(|error| {
+        OnProbeError::other(format!("failed to initialize RK3588 NPU: {error}"))
+    })?;
     let npu = RknpuDevice {
-        core: Rknpu::new(&base_regs, config, dma),
+        core,
         resets,
         state: DeviceState::Operational,
     };

--- a/drivers/ax-driver/src/rknpu.rs
+++ b/drivers/ax-driver/src/rknpu.rs
@@ -35,6 +35,8 @@ pub enum Error {
     Quarantined,
     #[error("Rockchip NPU request contains invalid data")]
     InvalidData,
+    #[error("Rockchip NPU user task submission is not supported by this DMA setup")]
+    NotSupported,
 }
 
 crate::model_register!(
@@ -209,6 +211,9 @@ pub fn submit(args: &mut RknpuSubmit, tasks: &mut [RknpuTask]) -> Result<(), Err
         .try_lock()
         .map_err(|_| Error::Busy)?;
     npu.ensure_available()?;
+    if !npu.core.user_submit_supported() {
+        return Err(Error::NotSupported);
+    }
     let mut clock = axklib::time::monotonic_nanos;
     match npu.core.submit_ioctrl(args, tasks, &mut clock) {
         Ok(()) => Ok(()),
@@ -218,6 +223,16 @@ pub fn submit(args: &mut RknpuSubmit, tasks: &mut [RknpuTask]) -> Result<(), Err
         }
         Err(_) => Err(Error::InvalidData),
     }
+}
+
+/// Reports whether the current RKNPU instance can safely accept user tasks.
+///
+/// The capability is separate from GEM allocation and mapping: those paths
+/// remain available for the direct DMA domain used by RK3588, while user task
+/// submission stays disabled until a translated IOMMU domain and a matching
+/// CPU physical-address mapping are wired together.
+pub fn submit_available() -> Result<bool, Error> {
+    with_npu(|npu| Ok(npu.user_submit_supported()))
 }
 
 /// Resolve the core mask using the same device state as a later submission.

--- a/drivers/ax-driver/src/rknpu.rs
+++ b/drivers/ax-driver/src/rknpu.rs
@@ -11,7 +11,8 @@ use rdrive::{
     register::ProbeFdt,
 };
 pub use rockchip_npu::{
-    GemBufferInfo, GemCachePolicy, RknpuAction, RknpuTask,
+    GemBufferInfo, GemCachePolicy, RKNPU_CORE0_MASK, RKNPU_CORE1_MASK, RKNPU_CORE2_MASK,
+    RknpuAction, RknpuTask,
     ioctrl::{RknpuMemCreate, RknpuMemDestroy, RknpuMemMap, RknpuMemSync, RknpuSubmit},
 };
 use rockchip_npu::{Rknpu, RknpuConfig, RknpuType};
@@ -217,6 +218,17 @@ pub fn submit(args: &mut RknpuSubmit, tasks: &mut [RknpuTask]) -> Result<(), Err
         }
         Err(_) => Err(Error::InvalidData),
     }
+}
+
+/// Resolve the core mask using the same device state as a later submission.
+///
+/// Card-specific validation uses this result to select only task descriptors
+/// that the portable RKNPU submit path will consume.
+pub fn normalize_core_mask(requested_mask: u32) -> Result<u32, Error> {
+    with_npu(|npu| {
+        npu.normalize_core_mask(requested_mask)
+            .map_err(|_| Error::InvalidData)
+    })
 }
 
 pub fn mem_create(args: &mut RknpuMemCreate) -> Result<(), Error> {

--- a/drivers/npu/rockchip-npu/src/gem.rs
+++ b/drivers/npu/rockchip-npu/src/gem.rs
@@ -86,10 +86,17 @@ impl GemPool {
     }
 
     pub fn create(&mut self, args: &mut RknpuMemCreate) -> Result<(), RknpuError> {
+        let requested_size =
+            usize::try_from(args.size).map_err(|_| RknpuError::InvalidParameter)?;
+        // Owned GEMs are exposed through mmap as device mappings. Allocate and
+        // zero the complete final page so that mmap never publishes bytes past
+        // the initialized DMA backing. Imported buffers keep their exact size
+        // and are capped to complete pages by the mmap path.
+        let allocation_size = page_align_size(requested_size, self.dma.page_size())?;
         let data = self
             .dma
             .contiguous_array_zero_with_align::<u8>(
-                args.size as _,
+                allocation_size,
                 0x1000,
                 DmaDirection::Bidirectional,
             )
@@ -258,6 +265,15 @@ impl GemPool {
     }
 }
 
+fn page_align_size(size: usize, page_size: usize) -> Result<usize, RknpuError> {
+    if page_size == 0 || !page_size.is_power_of_two() {
+        return Err(RknpuError::InvalidParameter);
+    }
+    size.checked_add(page_size - 1)
+        .map(|size| size & !(page_size - 1))
+        .ok_or(RknpuError::InvalidParameter)
+}
+
 #[cfg(test)]
 mod tests {
     use core::{
@@ -374,6 +390,21 @@ mod tests {
         assert_eq!(info.dma_addr, 0x8000_0000);
         assert_eq!(info.obj_addr, 0x1234_0000);
         assert_eq!(info.size, 0x2000);
+    }
+
+    #[test]
+    fn owned_gem_backing_is_page_aligned_before_mmap_export() {
+        assert_eq!(page_align_size(0x1000, 0x1000), Ok(0x1000));
+        assert_eq!(page_align_size(0x1001, 0x1000), Ok(0x2000));
+        assert_eq!(page_align_size(0, 0x1000), Ok(0));
+        assert_eq!(
+            page_align_size(usize::MAX, 0x1000),
+            Err(RknpuError::InvalidParameter)
+        );
+        assert_eq!(
+            page_align_size(0x1001, 0),
+            Err(RknpuError::InvalidParameter)
+        );
     }
 
     #[test]

--- a/drivers/npu/rockchip-npu/src/ioctrl.rs
+++ b/drivers/npu/rockchip-npu/src/ioctrl.rs
@@ -229,6 +229,21 @@ impl Rknpu {
         tasks: &mut [RknpuTask],
         clock: &mut impl FnMut() -> u64,
     ) -> Result<(), RknpuError> {
+        // The command stream can contain DMA addresses that are not visible in
+        // the task descriptor itself.  A direct DMA domain therefore cannot be
+        // made safe by checking the GEM containing the command buffer; require
+        // both an enabled IOMMU and a translated device domain before touching
+        // any submission state or MMIO.
+        if !self.iommu_enabled
+            || !matches!(
+                self.dma.info().domain(),
+                dma_api::DmaDomainId::Translated(_)
+            )
+        {
+            warn!("rknpu submit rejected: translated IOMMU domain is unavailable");
+            return Err(RknpuError::IommuError);
+        }
+
         if args.flags & 1 << 1 > 0 {
             debug!("Nonblock task");
         }
@@ -492,7 +507,88 @@ impl Rknpu {
 
 #[cfg(test)]
 mod tests {
+    use core::{alloc::Layout, num::NonZeroUsize, ptr::NonNull};
+
+    use dma_api::{
+        DeviceDma, DmaAllocHandle, DmaConstraints, DmaDeviceInfo, DmaDirection, DmaError,
+        DmaMapHandle, DmaOp,
+    };
+
     use super::*;
+
+    struct NoopDmaOp;
+
+    impl DmaOp for NoopDmaOp {
+        fn page_size(&self) -> usize {
+            4096
+        }
+
+        unsafe fn alloc_contiguous(
+            &self,
+            _constraints: DmaConstraints,
+            _layout: Layout,
+        ) -> Option<DmaAllocHandle> {
+            None
+        }
+
+        unsafe fn dealloc_contiguous(&self, _handle: DmaAllocHandle) {}
+
+        unsafe fn alloc_coherent(
+            &self,
+            _constraints: DmaConstraints,
+            _layout: Layout,
+        ) -> Option<DmaAllocHandle> {
+            None
+        }
+
+        unsafe fn dealloc_coherent(&self, _handle: DmaAllocHandle) -> Result<(), DmaError> {
+            Ok(())
+        }
+
+        unsafe fn map_streaming(
+            &self,
+            _constraints: DmaConstraints,
+            _addr: NonNull<u8>,
+            _size: NonZeroUsize,
+            _direction: DmaDirection,
+        ) -> Result<DmaMapHandle, DmaError> {
+            Err(DmaError::NoMemory)
+        }
+
+        unsafe fn unmap_streaming(&self, _handle: DmaMapHandle) {}
+    }
+
+    static NOOP_DMA_OP: NoopDmaOp = NoopDmaOp;
+
+    fn direct_dma() -> DeviceDma {
+        DeviceDma::new(
+            DmaDeviceInfo::new(
+                dma_api::DmaDomainId::Direct,
+                dma_api::DmaCoherency::Coherent,
+                DmaConstraints::new(u32::MAX as u64),
+            ),
+            &NOOP_DMA_OP,
+        )
+    }
+
+    #[test]
+    fn direct_dma_submit_is_rejected_before_hardware_access() {
+        let mut npu = Rknpu::new(
+            &[NonNull::dangling()],
+            crate::RknpuConfig {
+                rknpu_type: crate::RknpuType::Rk3588,
+            },
+            direct_dma(),
+        )
+        .expect("direct DMA is valid for non-submit GEM operations");
+        npu.set_iommu_enabled(true);
+
+        let mut args = RknpuSubmit::default();
+        let mut tasks = [];
+        let result = npu.submit_ioctrl(&mut args, &mut tasks, &mut || 0);
+
+        assert_eq!(result, Err(RknpuError::IommuError));
+    }
 
     #[test]
     fn abi_timeout_is_converted_from_microseconds_to_nanoseconds() {

--- a/drivers/npu/rockchip-npu/src/ioctrl.rs
+++ b/drivers/npu/rockchip-npu/src/ioctrl.rs
@@ -582,6 +582,7 @@ mod tests {
         )
         .expect("direct DMA is valid for non-submit GEM operations");
         npu.set_iommu_enabled(true);
+        assert!(!npu.user_submit_supported());
 
         let mut args = RknpuSubmit::default();
         let mut tasks = [];

--- a/drivers/npu/rockchip-npu/src/ioctrl.rs
+++ b/drivers/npu/rockchip-npu/src/ioctrl.rs
@@ -233,14 +233,7 @@ impl Rknpu {
             debug!("Nonblock task");
         }
 
-        let core_mask = self.normalize_core_mask(args)?;
-        if core_mask > self.data.core_mask || !is_supported_core_mask(core_mask) {
-            warn!(
-                "rknpu submit: invalid core_mask={:#x}, supported_mask={:#x}",
-                args.core_mask, self.data.core_mask
-            );
-            return Err(RknpuError::InvalidParameter);
-        }
+        let core_mask = self.normalize_core_mask(args.core_mask)?;
 
         let use_core_num = active_core_count(core_mask);
         let mut states = Vec::new();
@@ -353,13 +346,25 @@ impl Rknpu {
         Ok(())
     }
 
-    fn normalize_core_mask(&mut self, args: &RknpuSubmit) -> Result<u32, RknpuError> {
-        match args.core_mask {
+    /// Normalizes and validates the core mask before a submission is read.
+    ///
+    /// Callers that need to inspect the per-core task layout must use the
+    /// returned mask, because automatic and all-core masks are resolved here.
+    pub fn normalize_core_mask(&mut self, requested_mask: u32) -> Result<u32, RknpuError> {
+        let core_mask = match requested_mask {
             RKNPU_CORE_AUTO_MASK => self.select_auto_core_mask(),
             RKNN_NPU_CORE_ALL => Ok(self.data.core_mask),
             mask if mask > self.data.core_mask => Err(RknpuError::InvalidParameter),
             mask => Ok(mask),
+        }?;
+        if !is_supported_core_mask(core_mask) {
+            warn!(
+                "rknpu submit: invalid core_mask={:#x}, supported_mask={:#x}",
+                requested_mask, self.data.core_mask
+            );
+            return Err(RknpuError::InvalidParameter);
         }
+        Ok(core_mask)
     }
 
     fn select_auto_core_mask(&mut self) -> Result<u32, RknpuError> {

--- a/drivers/npu/rockchip-npu/src/ioctrl.rs
+++ b/drivers/npu/rockchip-npu/src/ioctrl.rs
@@ -226,6 +226,7 @@ impl Rknpu {
     pub fn submit_ioctrl(
         &mut self,
         args: &mut RknpuSubmit,
+        tasks: &mut [RknpuTask],
         clock: &mut impl FnMut() -> u64,
     ) -> Result<(), RknpuError> {
         if args.flags & 1 << 1 > 0 {
@@ -299,6 +300,20 @@ impl Rknpu {
             return Err(RknpuError::InvalidParameter);
         }
 
+        let required_tasks = states
+            .iter()
+            .map(|state| state.task_end)
+            .max()
+            .ok_or(RknpuError::InvalidParameter)?;
+        if required_tasks > tasks.len() {
+            warn!(
+                "rknpu submit: task array too short: need {}, got {}",
+                required_tasks,
+                tasks.len()
+            );
+            return Err(RknpuError::InvalidParameter);
+        }
+
         if !LOGGED_SUBMIT_CORE_LAYOUT.swap(true, Ordering::Relaxed) {
             warn!(
                 "rknpu submit: core_mask={:#x} active_cores={} subcore_layout={:?}",
@@ -309,14 +324,14 @@ impl Rknpu {
         let deadline = SubmitDeadline::from_timeout_us(clock(), args.timeout);
         for state in states.iter_mut() {
             self.clear_pending_interrupts(state.core_idx, deadline, clock)?;
-            self.submit_next_chunk(state, args)?;
+            self.submit_next_chunk(state, args, tasks)?;
         }
 
         let mut wait_count: u64 = 0;
         poll_until_ready(deadline, clock, || {
             let mut progressed = false;
             for state in states.iter_mut().filter(|state| state.inflight) {
-                progressed |= self.poll_core_completion(state, args)?;
+                progressed |= self.poll_core_completion(state, args, tasks)?;
             }
             if progressed {
                 wait_count = 0;
@@ -391,16 +406,14 @@ impl Rknpu {
         &mut self,
         state: &mut CoreSubmitState,
         args: &mut RknpuSubmit,
+        tasks: &mut [RknpuTask],
     ) -> Result<(), RknpuError> {
-        let task_ptr = args.task_obj_addr as *mut RknpuTask;
-        if task_ptr.is_null() {
-            return Err(RknpuError::InvalidParameter);
-        }
         let max_submit_number = self.data.max_submit_number as usize;
 
         let task_number = (state.task_end - state.task_iter).min(max_submit_number);
-        let submit_tasks =
-            unsafe { core::slice::from_raw_parts_mut(task_ptr.add(state.task_iter), task_number) };
+        let submit_tasks = tasks
+            .get_mut(state.task_iter..state.task_iter + task_number)
+            .ok_or(RknpuError::InvalidParameter)?;
 
         let job = SubmitRef {
             base: SubmitBase {
@@ -433,6 +446,7 @@ impl Rknpu {
         &mut self,
         state: &mut CoreSubmitState,
         args: &mut RknpuSubmit,
+        tasks: &mut [RknpuTask],
     ) -> Result<bool, RknpuError> {
         let status = self.base[state.core_idx].pc().interrupt_status.get();
         let status = rknpu_fuzz_status(status);
@@ -451,18 +465,18 @@ impl Rknpu {
         let int_status = status;
         self.base[state.core_idx].pc().clean_interrupts();
 
-        let task_ptr = args.task_obj_addr as *mut RknpuTask;
-        if task_ptr.is_null() || state.current_number == 0 {
+        if state.current_number == 0 {
             return Err(RknpuError::InvalidParameter);
         }
         let last_task_index = state.current_start + state.current_number - 1;
-        unsafe {
-            (*task_ptr.add(last_task_index)).int_status = int_status;
-        }
+        tasks
+            .get_mut(last_task_index)
+            .ok_or(RknpuError::InvalidParameter)?
+            .int_status = int_status;
         state.completed = state.completed.saturating_add(state.current_number);
 
         if state.task_iter < state.task_end {
-            self.submit_next_chunk(state, args)?;
+            self.submit_next_chunk(state, args, tasks)?;
         } else {
             state.inflight = false;
         }

--- a/drivers/npu/rockchip-npu/src/lib.rs
+++ b/drivers/npu/rockchip-npu/src/lib.rs
@@ -325,9 +325,16 @@ impl Rknpu {
         self.iommu_enabled
     }
 
-    /// Enable or disable IOMMU
+    /// Enable or disable IOMMU-backed submissions.
+    ///
+    /// Enabling the flag cannot make a direct DMA domain safe, so it is only
+    /// recorded when the device DMA capability is translated.
     pub fn set_iommu_enabled(&mut self, enabled: bool) {
-        self.iommu_enabled = enabled;
+        self.iommu_enabled = enabled
+            && matches!(
+                self.dma.info().domain(),
+                dma_api::DmaDomainId::Translated(_)
+            );
     }
 
     // /// Commit a prepared job descriptor to the hardware command parser.

--- a/drivers/npu/rockchip-npu/src/lib.rs
+++ b/drivers/npu/rockchip-npu/src/lib.rs
@@ -112,7 +112,10 @@ impl Rknpu {
             data,
             config,
             dma: dma.clone(),
-            iommu_enabled: false,
+            // A direct DMA domain bypasses address translation. Submit must
+            // fail closed in that configuration because validating a command
+            // buffer alone cannot constrain addresses embedded in its data.
+            iommu_enabled: matches!(dma.info().domain(), dma_api::DmaDomainId::Translated(_)),
             gem: GemPool::new(dma),
             auto_core_cursor: 0,
         }
@@ -311,7 +314,11 @@ impl Rknpu {
 
     /// Enable or disable IOMMU
     pub fn set_iommu_enabled(&mut self, enabled: bool) {
-        self.iommu_enabled = enabled;
+        self.iommu_enabled = enabled
+            && matches!(
+                self.dma.info().domain(),
+                dma_api::DmaDomainId::Translated(_)
+            );
     }
 
     // /// Commit a prepared job descriptor to the hardware command parser.

--- a/drivers/npu/rockchip-npu/src/lib.rs
+++ b/drivers/npu/rockchip-npu/src/lib.rs
@@ -107,6 +107,9 @@ impl Rknpu {
     /// Returns [`RknpuError::IommuError`] when the DMA device uses a translated
     /// domain. GEM mmap currently needs a physical address, which this driver
     /// cannot derive from an IOVA.
+    ///
+    /// A direct DMA domain is accepted for GEM allocation and mapping, but it
+    /// does not enable user-controlled task submission.
     pub fn new(
         base_addrs: &[NonNull<u8>],
         config: RknpuConfig,
@@ -323,6 +326,16 @@ impl Rknpu {
     /// Convenience method to check IOMMU status using action interface
     pub fn is_iommu_enabled(&self) -> bool {
         self.iommu_enabled
+    }
+
+    /// Returns whether user-controlled task submission has a translated DMA
+    /// domain and an enabled IOMMU to contain command-stream addresses.
+    pub fn user_submit_supported(&self) -> bool {
+        self.iommu_enabled
+            && matches!(
+                self.dma.info().domain(),
+                dma_api::DmaDomainId::Translated(_)
+            )
     }
 
     /// Enable or disable IOMMU-backed submissions.

--- a/drivers/npu/rockchip-npu/src/lib.rs
+++ b/drivers/npu/rockchip-npu/src/lib.rs
@@ -101,10 +101,26 @@ impl Rknpu {
     /// The caller must ensure that `base_addr` is the correctly mapped and
     /// aligned physical address of the RKNPU register file and that it remains
     /// valid for the lifetime of the returned structure.
-    pub fn new(base_addrs: &[NonNull<u8>], config: RknpuConfig, dma: DeviceDma) -> Self {
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RknpuError::IommuError`] when the DMA device uses a translated
+    /// domain. GEM mmap currently needs a physical address, which this driver
+    /// cannot derive from an IOVA.
+    pub fn new(
+        base_addrs: &[NonNull<u8>],
+        config: RknpuConfig,
+        dma: DeviceDma,
+    ) -> Result<Self, RknpuError> {
+        // GEM mmap currently exports a physical range, while a translated DMA
+        // address is an IOVA. Reject that domain until GEM keeps and exposes a
+        // separate physical address for CPU mappings.
+        if matches!(dma.info().domain(), dma_api::DmaDomainId::Translated(_)) {
+            return Err(RknpuError::IommuError);
+        }
         let data = RknpuData::new(config.rknpu_type);
 
-        Self {
+        Ok(Self {
             base: base_addrs
                 .iter()
                 .map(|&addr| unsafe { RknpuCore::new(addr) })
@@ -112,13 +128,10 @@ impl Rknpu {
             data,
             config,
             dma: dma.clone(),
-            // A direct DMA domain bypasses address translation. Submit must
-            // fail closed in that configuration because validating a command
-            // buffer alone cannot constrain addresses embedded in its data.
-            iommu_enabled: matches!(dma.info().domain(), dma_api::DmaDomainId::Translated(_)),
+            iommu_enabled: false,
             gem: GemPool::new(dma),
             auto_core_cursor: 0,
-        }
+        })
     }
 
     pub fn dma(&self) -> &DeviceDma {
@@ -314,11 +327,7 @@ impl Rknpu {
 
     /// Enable or disable IOMMU
     pub fn set_iommu_enabled(&mut self, enabled: bool) {
-        self.iommu_enabled = enabled
-            && matches!(
-                self.dma.info().domain(),
-                dma_api::DmaDomainId::Translated(_)
-            );
+        self.iommu_enabled = enabled;
     }
 
     // /// Commit a prepared job descriptor to the hardware command parser.

--- a/os/StarryOS/kernel/src/pseudofs/dev/card1.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/card1.rs
@@ -441,6 +441,9 @@ impl Card1File {
     }
 
     fn handle_submit(&self, current: &UserTaskRef, args: &mut RknpuSubmit) -> VfsResult<()> {
+        if !rknpu::submit_available().map_err(map_rknpu_err)? {
+            return Err(VfsError::OperationNotSupported);
+        }
         let core_mask = rknpu::normalize_core_mask(args.core_mask).map_err(map_rknpu_err)?;
         let (first, mut tasks) = self.load_tasks(current, args, core_mask)?;
         let task_bytes = (tasks.len() as u64)
@@ -1030,6 +1033,7 @@ fn map_rknpu_err(err: rknpu::Error) -> VfsError {
         rknpu::Error::TimedOut => VfsError::TimedOut,
         rknpu::Error::Quarantined => VfsError::Io,
         rknpu::Error::InvalidData => VfsError::InvalidData,
+        rknpu::Error::NotSupported => VfsError::OperationNotSupported,
     }
 }
 

--- a/os/StarryOS/kernel/src/pseudofs/dev/card1.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/card1.rs
@@ -49,6 +49,11 @@ const PAGE_SHIFT: u32 = 12;
 const MAX_IOCTL_NR: u32 = 0xcf;
 /// Stack data buffer size
 const STACK_DATA_SIZE: usize = 128;
+
+/// Storage for DRM ioctl arguments whose ABI contains 64-bit fields or pointers.
+#[repr(align(8))]
+struct AlignedIoctlData([u8; STACK_DATA_SIZE]);
+
 /// DRM ioctl version command number
 const DRM_IOCTL_VERSION_NR: u32 = 0;
 /// DRM ioctl get unique command number
@@ -474,27 +479,27 @@ impl FileLike for Card1File {
         if nr > MAX_IOCTL_NR {
             return Err(StarryError::NotATty);
         }
-        let mut stack_data = [0u8; STACK_DATA_SIZE];
+        let mut stack_data = AlignedIoctlData([0u8; STACK_DATA_SIZE]);
         let in_size = io_size(cmd) as usize;
-        if in_size > stack_data.len() {
+        if in_size > stack_data.0.len() {
             return Err(StarryError::InvalidInput);
         }
-        copy_from_user(current, stack_data.as_mut_ptr(), arg as _, in_size)?;
+        copy_from_user(current, &mut stack_data.0[..in_size], arg)?;
         match nr {
-            DRM_IOCTL_VERSION_NR => drm_version(current, &mut stack_data)?,
-            DRM_IOCTL_GET_UNIQUE_NR => drm_get_unique(&mut stack_data)?,
+            DRM_IOCTL_VERSION_NR => drm_version(current, &mut stack_data.0)?,
+            DRM_IOCTL_GET_UNIQUE_NR => drm_get_unique(&mut stack_data.0)?,
             DRM_IOCTL_GEM_FLINK_NR => {
-                drm_gem_flink_ioctl(&mut stack_data)?;
+                drm_gem_flink_ioctl(&mut stack_data.0)?;
             }
             DRM_IOCTL_PRIME_HANDLE_TO_FD_NR => {
-                self.drm_prime_handle_to_fd_ioctl(&mut stack_data)?;
+                self.drm_prime_handle_to_fd_ioctl(&mut stack_data.0)?;
             }
             DRM_IOCTL_PRIME_FD_TO_HANDLE_NR => {
-                self.drm_prime_fd_to_handle_ioctl(&mut stack_data)?;
+                self.drm_prime_fd_to_handle_ioctl(&mut stack_data.0)?;
             }
             _ => return Err(VfsError::NotATty.into()),
         }
-        copy_to_user(current, arg as _, stack_data.as_ptr(), in_size)?;
+        copy_to_user(current, arg, &stack_data.0[..in_size])?;
         Ok(0)
     }
 
@@ -544,16 +549,14 @@ impl Card1File {
                 let mut submit_args = RknpuSubmit::default();
                 copy_from_user(
                     current,
-                    &mut submit_args as *mut _ as *mut u8,
-                    arg as *const u8,
-                    mem::size_of::<RknpuSubmit>(),
+                    bytemuck::bytes_of_mut(&mut submit_args),
+                    arg,
                 )?;
                 let submit_result = self.handle_submit(current, &mut submit_args);
                 copy_to_user(
                     current,
-                    arg as *mut u8,
-                    &submit_args as *const _ as *const u8,
-                    mem::size_of::<RknpuSubmit>(),
+                    arg,
+                    bytemuck::bytes_of(&submit_args),
                 )?;
                 submit_result?;
             }
@@ -561,9 +564,8 @@ impl Card1File {
                 let mut mem_create_args = RknpuMemCreate::default();
                 copy_from_user(
                     current,
-                    &mut mem_create_args as *mut _ as *mut u8,
-                    arg as *const u8,
-                    mem::size_of::<RknpuMemCreate>(),
+                    bytemuck::bytes_of_mut(&mut mem_create_args),
+                    arg,
                 )?;
                 rknpu::mem_create(&mut mem_create_args).map_err(map_rknpu_err)?;
                 let global_handle = mem_create_args.handle;
@@ -577,9 +579,8 @@ impl Card1File {
                 mem_create_args.handle = local_handle;
                 if let Err(error) = copy_to_user(
                     current,
-                    arg as *mut u8,
-                    &mem_create_args as *const _ as *const u8,
-                    mem::size_of::<RknpuMemCreate>(),
+                    arg,
+                    bytemuck::bytes_of(&mem_create_args),
                 ) {
                     let _ = self.remove_handle(local_handle).map(rknpu::mem_destroy);
                     return Err(error);
@@ -589,26 +590,23 @@ impl Card1File {
                 let mut mem_map = RknpuMemMap::default();
                 copy_from_user(
                     current,
-                    &mut mem_map as *mut _ as *mut u8,
-                    arg as *const u8,
-                    mem::size_of::<RknpuMemMap>(),
+                    bytemuck::bytes_of_mut(&mut mem_map),
+                    arg,
                 )?;
                 self.global_handle(mem_map.handle)?;
                 mem_map.offset = (mem_map.handle as u64) << PAGE_SHIFT;
                 copy_to_user(
                     current,
-                    arg as *mut u8,
-                    &mem_map as *const _ as *const u8,
-                    mem::size_of::<RknpuMemMap>(),
+                    arg,
+                    bytemuck::bytes_of(&mem_map),
                 )?;
             }
             RknpuCmd::MemDestroy => {
                 let mut mem_destroy = RknpuMemDestroy::default();
                 copy_from_user(
                     current,
-                    &mut mem_destroy as *mut _ as *mut u8,
-                    arg as *const u8,
-                    mem::size_of::<RknpuMemDestroy>(),
+                    bytemuck::bytes_of_mut(&mut mem_destroy),
+                    arg,
                 )?;
                 let global_handle = self.remove_handle(mem_destroy.handle)?;
                 rknpu::mem_destroy(global_handle).map_err(map_rknpu_err)?;
@@ -617,9 +615,8 @@ impl Card1File {
                 let mut mem_sync = RknpuMemSync::default();
                 copy_from_user(
                     current,
-                    &mut mem_sync as *mut _ as *mut u8,
-                    arg as *const u8,
-                    mem::size_of::<RknpuMemSync>(),
+                    bytemuck::bytes_of_mut(&mut mem_sync),
+                    arg,
                 )?;
                 if !self.find_cpu_range(mem_sync.obj_addr, mem_sync.offset, mem_sync.size) {
                     return Err(VfsError::InvalidData);
@@ -627,26 +624,23 @@ impl Card1File {
                 rknpu::mem_sync(&mut mem_sync).map_err(map_rknpu_err)?;
                 copy_to_user(
                     current,
-                    arg as *mut u8,
-                    &mem_sync as *const _ as *const u8,
-                    mem::size_of::<RknpuMemSync>(),
+                    arg,
+                    bytemuck::bytes_of(&mem_sync),
                 )?;
             }
             RknpuCmd::Action => {
                 let mut action = RknpuUserAction { flags: 0, value: 0 };
                 copy_from_user(
                     current,
-                    &mut action as *mut _ as *mut u8,
-                    arg as *const u8,
-                    mem::size_of::<RknpuUserAction>(),
+                    bytemuck::bytes_of_mut(&mut action),
+                    arg,
                 )?;
                 let action_kind = decode_rknpu_action(action.flags)?;
                 action.value = rknpu::action(action_kind).map_err(map_rknpu_err)?;
                 copy_to_user(
                     current,
-                    arg as *mut u8,
-                    &action as *const _ as *const u8,
-                    mem::size_of::<RknpuUserAction>(),
+                    arg,
+                    bytemuck::bytes_of(&action),
                 )?;
             }
         }
@@ -797,34 +791,19 @@ fn map_rknpu_err(err: rknpu::Error) -> VfsError {
     }
 }
 
-    /// Copies data from user space to kernel space
-    pub fn copy_from_user(
-        current: &UserTaskRef,
-        dst: *mut u8,
-        src: *const u8,
-        size: usize,
-    ) -> Result<(), VfsError> {
-    let bytes = vm_load(current, src, size).map_err(|err| {
+/// Copies data from user space to a kernel-owned byte slice.
+fn copy_from_user(current: &UserTaskRef, dst: &mut [u8], src: usize) -> Result<(), VfsError> {
+    let bytes = vm_load(current, src as *const u8, dst.len()).map_err(|err| {
         warn!("[rknpu]: copy_from_user failed: {err:?}");
         VfsError::BadAddress
     })?;
-    // SAFETY: ioctl dispatch supplies a live kernel destination at least
-    // `size` bytes long. The user source is now an owned kernel buffer.
-    unsafe { core::ptr::copy_nonoverlapping(bytes.as_ptr(), dst, size) };
+    dst.copy_from_slice(&bytes);
     Ok(())
 }
 
-/// Copies data from kernel space to user space
-pub fn copy_to_user(
-    current: &UserTaskRef,
-    dst: *mut u8,
-    src: *const u8,
-    size: usize,
-) -> Result<(), VfsError> {
-    // SAFETY: ioctl dispatch supplies a live initialized kernel source at
-    // least `size` bytes long for this synchronous copy.
-    let bytes = unsafe { core::slice::from_raw_parts(src, size) };
-    vm_write_slice(current, dst, bytes).map_err(|err| {
+/// Copies a kernel-owned byte slice to user space.
+fn copy_to_user(current: &UserTaskRef, dst: usize, src: &[u8]) -> Result<(), VfsError> {
+    vm_write_slice(current, dst as *mut u8, src).map_err(|err| {
         warn!("[rknpu]: copy_to_user failed: {err:?}");
         VfsError::BadAddress
     })
@@ -863,6 +842,12 @@ struct DrmPrimeHande {
 ///
 /// This function safely copies a string value to user space buffer,
 /// similar to the Linux kernel implementation with proper error handling.
+///
+/// # Safety
+///
+/// The caller must provide a valid mutable kernel reference for `buf_len` and
+/// a valid, initialized, NUL-terminated kernel string at `value`. `buf` is a
+/// user address and is only passed to the checked user-memory writer.
 unsafe fn drm_copy_field(
     current: &UserTaskRef,
     buf: *mut u8,
@@ -901,7 +886,10 @@ unsafe fn drm_copy_field(
 
     // Finally, try filling in the userbuf (same logic as kernel)
     if copy_len > 0 && !buf.is_null() {
-        copy_to_user(current, buf as _, value, copy_len as _)?;
+        // SAFETY: `value` points to a NUL-terminated kernel string and the scan
+        // above established that `copy_len` bytes are within that string.
+        let value = unsafe { core::slice::from_raw_parts(value, copy_len) };
+        copy_to_user(current, buf as usize, value)?;
     }
 
     Ok(())

--- a/os/StarryOS/kernel/src/pseudofs/dev/card1.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/card1.rs
@@ -1,19 +1,16 @@
-use alloc::{borrow::Cow, sync::Arc};
+use alloc::{borrow::Cow, collections::btree_map::BTreeMap, sync::Arc, vec::Vec};
 use core::{
     any::Any,
     convert::TryFrom,
     ffi::CStr,
-    mem::MaybeUninit,
-    slice,
-    sync::atomic::{AtomicUsize, Ordering},
+    mem,
 };
 
 use ax_driver::rknpu::{
     self, GemCachePolicy, RknpuAction, RknpuMemCreate, RknpuMemDestroy, RknpuMemMap, RknpuMemSync,
-    RknpuSubmit,
+    RknpuSubmit, RknpuTask,
 };
 use ax_memory_addr::{PhysAddr, PhysAddrRange};
-use ax_runtime::hal::time::monotonic_time_nanos;
 use axfs_ng_vfs::{DeviceId, NodeFlags, VfsError, VfsResult};
 use axpoll::{IoEvents, Pollable};
 use bytemuck::{AnyBitPattern, NoUninit};
@@ -23,16 +20,17 @@ use super::drm::{DrmUnique, DrmVersion};
 use crate::{
     StarryError, StarryResult,
     file::{
-        FileLike,
+        File as KernelFile, FileLike, IoDst, IoSrc, Kstat,
         dmabuf::{ContiguousDmaBuf, resolve_contiguous_dmabuf},
     },
-    mm::{UserConstPtr, UserPtr, vm_read_slice, vm_write_slice},
+    mm::{vm_load, vm_write_slice},
     pseudofs::{
         DeviceOps,
         dev::drm::{io_size, ioctl_nr, is_driver_ioctl},
         device::DeviceMmap,
     },
     task::UserTaskRef,
+    sync::Mutex,
 };
 
 /// Driver name for DRM device
@@ -61,14 +59,6 @@ const DRM_IOCTL_GEM_FLINK_NR: u32 = 10;
 const DRM_IOCTL_PRIME_HANDLE_TO_FD_NR: u32 = 0x2d;
 /// DRM ioctl prime fd to handle command number (import an external dma-buf)
 const DRM_IOCTL_PRIME_FD_TO_HANDLE_NR: u32 = 0x2e;
-const RKNPU_ACTION_LOG_LIMIT: usize = 16;
-const RKNPU_MEM_CREATE_LOG_LIMIT: usize = 16;
-const RKNPU_MEM_SYNC_LOG_LIMIT: usize = 32;
-const RKNPU_SUBMIT_LOG_LIMIT: usize = 16;
-static RKNPU_ACTION_LOG_COUNT: AtomicUsize = AtomicUsize::new(0);
-static RKNPU_MEM_CREATE_LOG_COUNT: AtomicUsize = AtomicUsize::new(0);
-static RKNPU_MEM_SYNC_LOG_COUNT: AtomicUsize = AtomicUsize::new(0);
-static RKNPU_SUBMIT_LOG_COUNT: AtomicUsize = AtomicUsize::new(0);
 
 /// RKNPU command types
 #[repr(u32)]
@@ -183,67 +173,16 @@ impl DeviceOps for Card1 {
     }
 
     /// Handles ioctl commands for the device
-    fn ioctl(&self, current: &crate::task::UserTaskRef, cmd: u32, arg: usize) -> VfsResult<usize> {
-        if arg == 0 {
-            warn!("[rknpu]: ioctl received null arg pointer");
-            return Err(VfsError::InvalidData);
-        }
-        let nr = ioctl_nr(cmd);
-        info!("card1: cmd {cmd:#x}, nr {nr:#x}, arg {arg:#x}");
-
-        let is_driver_ioctl = is_driver_ioctl(ioctl_nr(cmd));
-        info!("card1: is_driver_ioctl = {}", is_driver_ioctl);
-
-        if is_driver_ioctl {
-            if let Ok(op) = RknpuCmd::try_from(nr) {
-                rknpu_driver_ioctl(current, op, arg)?;
-            } else {
-                warn!("Unknown RKNPU cmd: {:#x}", cmd);
-                return Err(VfsError::NotATty);
-            }
-        } else {
-            assert!(nr <= MAX_IOCTL_NR, "card1: unsupported ioctl nr {nr}");
-            // The in-kernel handlers cast this storage to 64-bit ABI records.
-            // Keep the byte buffer explicitly aligned even though user copies
-            // themselves are byte-granular.
-            #[repr(align(8))]
-            struct AlignedIoctlData([u8; STACK_DATA_SIZE]);
-            let mut stack_data = AlignedIoctlData([0u8; STACK_DATA_SIZE]);
-
-            let in_size = io_size(cmd) as usize;
-            let out_size = in_size;
-
-            if in_size > stack_data.0.len() {
-                return Err(VfsError::InvalidInput);
-            }
-            read_user_bytes(current, &mut stack_data.0[..in_size], arg)?;
-            match nr {
-                DRM_IOCTL_VERSION_NR => {
-                    info!("drm get version");
-                    drm_version(current, &mut stack_data.0)?;
-                }
-                DRM_IOCTL_GET_UNIQUE_NR => {
-                    info!("drm get unique");
-                    drm_get_unique(&mut stack_data.0)?;
-                }
-                DRM_IOCTL_GEM_FLINK_NR => {
-                    drm_gem_flink_ioctl(&mut stack_data.0)?;
-                }
-                DRM_IOCTL_PRIME_HANDLE_TO_FD_NR => {
-                    drm_prime_handle_to_fd_ioctl(&mut stack_data.0)?;
-                }
-                DRM_IOCTL_PRIME_FD_TO_HANDLE_NR => {
-                    drm_prime_fd_to_handle_ioctl(&mut stack_data.0)?;
-                }
-
-                _ => {
-                    panic!("card1: unsupported ioctl nr {nr:#x}");
-                }
-            }
-            write_user_bytes(current, arg, &stack_data.0[..out_size])?;
-        }
-
-        Ok(0)
+    fn ioctl(
+        &self,
+        _current: &UserTaskRef,
+        _cmd: u32,
+        _arg: usize,
+    ) -> VfsResult<usize> {
+        // A bare device node has no per-open GEM namespace. Opens are wrapped
+        // by `Card1File` below, which supplies the Linux `file->private_data`
+        // equivalent and owns all handles visible to that open.
+        Err(VfsError::NotATty)
     }
 
     /// Returns a reference to the object as Any for dynamic type checking
@@ -256,17 +195,501 @@ impl DeviceOps for Card1 {
         NodeFlags::NON_CACHEABLE
     }
 
-    /// Maps an exported GEM buffer selected by `handle << PAGE_SHIFT`.
-    fn mmap(&self, offset: u64, _length: u64) -> DeviceMmap {
-        let Some(handle) = map_handle_from_offset(offset) else {
-            warn!("card1: mmap received invalid offset {offset:#x}");
-            return DeviceMmap::None;
+    /// The node itself is not mappable because it has no open-file handle
+    /// namespace. `Card1File::device_mmap` performs the owned lookup.
+    fn mmap(&self, _offset: u64, _length: u64) -> DeviceMmap {
+        DeviceMmap::None
+    }
+}
+
+/// True if `inner` is the `/dev/dri/card1` node.
+pub(crate) fn is_card1_device(inner: &dyn Any) -> bool {
+    inner.is::<Card1>()
+}
+
+/// Build the per-open card1 file. The returned `Arc` is shared by `dup` and
+/// `fork`, so its GEM namespace has the same lifetime as the open file
+/// description rather than a process id.
+pub(crate) fn open_card1_file(
+    file: ax_fs_ng::File,
+    open_flags: u32,
+) -> StarryResult<Arc<dyn FileLike>> {
+    Ok(Arc::new(Card1File::new(KernelFile::new(file, open_flags))))
+}
+
+struct Card1File {
+    base: KernelFile,
+    /// Local handles are translated to global driver handles. This prevents a
+    /// handle obtained from another card1 open from reaching the NPU GEM pool.
+    handles: Mutex<BTreeMap<u32, u32>>,
+    next_handle: Mutex<u32>,
+    /// Serializes operations that validate and then use a GEM buffer. In
+    /// particular, `MemDestroy` cannot free a buffer between submit validation
+    /// and programming its DMA address.
+    operation: Mutex<()>,
+}
+
+impl Card1File {
+    fn new(base: KernelFile) -> Self {
+        Self {
+            base,
+            handles: Mutex::new(BTreeMap::new()),
+            next_handle: Mutex::new(1),
+            operation: Mutex::new(()),
+        }
+    }
+
+    fn add_handle(&self, global_handle: u32) -> VfsResult<u32> {
+        let mut handles = self.handles.lock();
+        let mut next = self.next_handle.lock();
+        for _ in 0..=u32::MAX {
+            let handle = *next;
+            *next = handle.wrapping_add(1);
+            if handle == 0 || handles.contains_key(&handle) {
+                continue;
+            }
+            handles.insert(handle, global_handle);
+            return Ok(handle);
+        }
+        Err(VfsError::NoMemory)
+    }
+
+    fn global_handle(&self, handle: u32) -> VfsResult<u32> {
+        self.handles
+            .lock()
+            .get(&handle)
+            .copied()
+            .ok_or(VfsError::InvalidInput)
+    }
+
+    fn remove_handle(&self, handle: u32) -> VfsResult<u32> {
+        self.handles
+            .lock()
+            .remove(&handle)
+            .ok_or(VfsError::InvalidInput)
+    }
+
+    fn exported_gem_buffer(&self, handle: u32) -> StarryResult<ExportedGemBuffer> {
+        let global_handle = self.global_handle(handle)?;
+        exported_gem_buffer(global_handle)
+    }
+
+    fn find_dma_range(&self, address: u64, length: u64) -> bool {
+        let handles: Vec<u32> = self.handles.lock().values().copied().collect();
+        handles.into_iter().any(|global_handle| {
+            let Ok(info) = rknpu::buffer_info(global_handle) else {
+                return false;
+            };
+            range_contains(info.dma_addr, info.size, address, length)
+        })
+    }
+
+    fn find_cpu_range(&self, address: u64, offset: u64, length: u64) -> bool {
+        let handles: Vec<u32> = self.handles.lock().values().copied().collect();
+        handles.into_iter().any(|global_handle| {
+            let Ok((base, size)) = rknpu::obj_addr_and_size(global_handle) else {
+                return false;
+            };
+            let Some(address_offset) = address.checked_sub(base as u64) else {
+                return false;
+            };
+            if address_offset >= size as u64 {
+                return false;
+            }
+            let Some(total_offset) = address_offset.checked_add(offset) else {
+                return false;
+            };
+            range_contains(0, size, total_offset, length)
+        })
+    }
+
+    fn submit_task_span(args: &RknpuSubmit) -> VfsResult<(usize, usize)> {
+        const MAX_TASKS: usize = 4095;
+        let mut first = usize::MAX;
+        let mut end = 0usize;
+        let mut add_range = |start: u32, number: u32| -> VfsResult<()> {
+            if number == 0 {
+                return Ok(());
+            }
+            let start = start as usize;
+            let range_end = start.checked_add(number as usize).ok_or(VfsError::InvalidData)?;
+            first = first.min(start);
+            end = end.max(range_end);
+            Ok(())
         };
-        let Ok(exported) = exported_gem_buffer(handle) else {
-            warn!("card1: mmap could not resolve handle {handle}");
-            return DeviceMmap::None;
+
+        add_range(args.task_start, args.task_number)?;
+        for subcore in args.subcore_task {
+            add_range(subcore.task_start, subcore.task_number)?;
+        }
+        if first == usize::MAX || end.checked_sub(first).is_none_or(|len| len > MAX_TASKS) {
+            return Err(VfsError::InvalidData);
+        }
+        Ok((first, end))
+    }
+
+    fn load_tasks(
+        &self,
+        current: &UserTaskRef,
+        args: &RknpuSubmit,
+    ) -> VfsResult<(usize, Vec<RknpuTask>)> {
+        let (first, end) = Self::submit_task_span(args)?;
+        let task_size = mem::size_of::<RknpuTask>();
+        let byte_offset = first.checked_mul(task_size).ok_or(VfsError::BadAddress)?;
+        let byte_len = (end - first)
+            .checked_mul(task_size)
+            .ok_or(VfsError::BadAddress)?;
+        let task_addr = (args.task_obj_addr as usize)
+            .checked_add(byte_offset)
+            .ok_or(VfsError::BadAddress)?;
+        if task_addr == 0 {
+            return Err(VfsError::BadAddress);
+        }
+
+        let bytes: Vec<u8> = vm_load(current, task_addr as *const u8, byte_len)
+            .map_err(|_| VfsError::BadAddress)?;
+        let mut tasks = Vec::with_capacity(end - first);
+        for bytes in bytes.chunks_exact(task_size) {
+            // `RknpuTask` is `repr(C, packed)` and contains integer fields only.
+            // The source is an initialized kernel-owned byte vector, so an
+            // unaligned read is the exact operation needed to decode the ABI.
+            let task = unsafe { core::ptr::read_unaligned(bytes.as_ptr().cast::<RknpuTask>()) };
+            tasks.push(task);
+        }
+        Ok((first, tasks))
+    }
+
+    fn validate_submit_dma(
+        &self,
+        args: &RknpuSubmit,
+        tasks: &[RknpuTask],
+        task_bytes: u64,
+    ) -> VfsResult<()> {
+        if args.task_base_addr > u32::MAX as u64
+            || !self.find_dma_range(args.task_base_addr, task_bytes)
+        {
+            return Err(VfsError::InvalidData);
+        }
+        for task in tasks {
+            let command_bytes = (task.regcfg_amount as u64)
+                .checked_mul(mem::size_of::<u64>() as u64)
+                .ok_or(VfsError::InvalidData)?;
+            if command_bytes == 0
+                || task.regcmd_addr > u32::MAX as u64
+                || !self.find_dma_range(task.regcmd_addr, command_bytes)
+            {
+                return Err(VfsError::InvalidData);
+            }
+        }
+        Ok(())
+    }
+
+    fn handle_submit(&self, current: &UserTaskRef, args: &mut RknpuSubmit) -> VfsResult<()> {
+        let (first, mut tasks) = self.load_tasks(current, args)?;
+        let task_bytes = (tasks.len() as u64)
+            .checked_mul(mem::size_of::<RknpuTask>() as u64)
+            .ok_or(VfsError::BadAddress)?;
+        self.validate_submit_dma(args, &tasks, task_bytes)?;
+
+        let mut driver_args = *args;
+        if driver_args.task_number != 0 {
+            driver_args.task_start = driver_args
+                .task_start
+                .checked_sub(first as u32)
+                .ok_or(VfsError::InvalidData)?;
+        }
+        for subcore in &mut driver_args.subcore_task {
+            if subcore.task_number != 0 {
+                subcore.task_start = subcore
+                    .task_start
+                    .checked_sub(first as u32)
+                    .ok_or(VfsError::InvalidData)?;
+            }
+        }
+        rknpu::submit(&mut driver_args, &mut tasks).map_err(map_rknpu_err)?;
+        args.task_counter = driver_args.task_counter;
+        args.hw_elapse_time = driver_args.hw_elapse_time;
+
+        let task_addr = (args.task_obj_addr as usize)
+            .checked_add(first.checked_mul(mem::size_of::<RknpuTask>()).ok_or(VfsError::BadAddress)?)
+            .ok_or(VfsError::BadAddress)?;
+        // SAFETY: `tasks` is an initialized, contiguous vector of packed ABI
+        // records, and `task_bytes` is exactly its byte length.
+        let task_bytes = unsafe {
+            core::slice::from_raw_parts(tasks.as_ptr().cast::<u8>(), task_bytes as usize)
         };
-        exported.device_mmap_kind()
+        vm_write_slice(current, task_addr as *mut u8, task_bytes)
+            .map_err(|_| VfsError::BadAddress)?;
+        Ok(())
+    }
+}
+
+/// Return whether `[address, address + length)` is fully contained in a GEM
+/// buffer. All arithmetic is checked because both values originate in ioctl
+/// data and are later programmed into a device-visible address register.
+fn range_contains(base: u64, size: usize, address: u64, length: u64) -> bool {
+    let Some(buffer_end) = base.checked_add(size as u64) else {
+        return false;
+    };
+    let Some(end) = address.checked_add(length) else {
+        return false;
+    };
+    address >= base && end <= buffer_end
+}
+
+impl FileLike for Card1File {
+    fn read(&self, dst: &mut IoDst) -> StarryResult<usize> {
+        self.base.read(dst)
+    }
+
+    fn write(&self, src: &mut IoSrc) -> StarryResult<usize> {
+        self.base.write(src)
+    }
+
+    fn stat(&self) -> StarryResult<Kstat> {
+        self.base.stat()
+    }
+
+    fn path(&self) -> Cow<'_, str> {
+        self.base.path()
+    }
+
+    fn ioctl(
+        &self,
+        current: &UserTaskRef,
+        cmd: u32,
+        arg: usize,
+    ) -> StarryResult<usize> {
+        if arg == 0 {
+            return Err(StarryError::BadAddress);
+        }
+        let _operation = self.operation.lock();
+        let nr = ioctl_nr(cmd);
+        info!("card1: cmd {cmd:#x}, nr {nr:#x}, arg {arg:#x}");
+        if is_driver_ioctl(nr) {
+            let op = RknpuCmd::try_from(nr).map_err(|_| StarryError::NotATty)?;
+            return Ok(self.rknpu_driver_ioctl(current, op, arg)?);
+        }
+
+        if nr > MAX_IOCTL_NR {
+            return Err(StarryError::NotATty);
+        }
+        let mut stack_data = [0u8; STACK_DATA_SIZE];
+        let in_size = io_size(cmd) as usize;
+        if in_size > stack_data.len() {
+            return Err(StarryError::InvalidInput);
+        }
+        copy_from_user(current, stack_data.as_mut_ptr(), arg as _, in_size)?;
+        match nr {
+            DRM_IOCTL_VERSION_NR => drm_version(current, &mut stack_data)?,
+            DRM_IOCTL_GET_UNIQUE_NR => drm_get_unique(&mut stack_data)?,
+            DRM_IOCTL_GEM_FLINK_NR => {
+                drm_gem_flink_ioctl(&mut stack_data)?;
+            }
+            DRM_IOCTL_PRIME_HANDLE_TO_FD_NR => {
+                self.drm_prime_handle_to_fd_ioctl(&mut stack_data)?;
+            }
+            DRM_IOCTL_PRIME_FD_TO_HANDLE_NR => {
+                self.drm_prime_fd_to_handle_ioctl(&mut stack_data)?;
+            }
+            _ => return Err(VfsError::NotATty.into()),
+        }
+        copy_to_user(current, arg as _, stack_data.as_ptr(), in_size)?;
+        Ok(0)
+    }
+
+    fn device_mmap(&self, offset: u64, _length: u64) -> StarryResult<DeviceMmap> {
+        let _operation = self.operation.lock();
+        let handle = map_handle_from_offset(offset).ok_or(StarryError::InvalidInput)?;
+        Ok(self.exported_gem_buffer(handle)?.device_mmap_kind())
+    }
+
+    fn open_flags(&self) -> u32 {
+        self.base.open_flags()
+    }
+
+    fn nonblocking(&self) -> bool {
+        self.base.nonblocking()
+    }
+
+    fn set_nonblocking(&self, nonblocking: bool) -> StarryResult {
+        self.base.set_nonblocking(nonblocking)
+    }
+}
+
+impl Pollable for Card1File {
+    /// The engine is driven synchronously inside `ioctl`, so the fd is always ready.
+    fn poll(&self) -> IoEvents {
+        IoEvents::IN | IoEvents::OUT
+    }
+
+    unsafe fn register_shared(
+        &self,
+        _sink: &mut dyn axpoll::SharedRegistrationSink,
+        _events: IoEvents,
+    ) {
+    }
+}
+
+impl Card1File {
+    fn rknpu_driver_ioctl(
+        &self,
+        current: &UserTaskRef,
+        op: RknpuCmd,
+        arg: usize,
+    ) -> VfsResult<usize> {
+        info!("rknpu_driver_ioctl: op = {:?}", op);
+        match op {
+            RknpuCmd::Submit => {
+                let mut submit_args = RknpuSubmit::default();
+                copy_from_user(
+                    current,
+                    &mut submit_args as *mut _ as *mut u8,
+                    arg as *const u8,
+                    mem::size_of::<RknpuSubmit>(),
+                )?;
+                let submit_result = self.handle_submit(current, &mut submit_args);
+                copy_to_user(
+                    current,
+                    arg as *mut u8,
+                    &submit_args as *const _ as *const u8,
+                    mem::size_of::<RknpuSubmit>(),
+                )?;
+                submit_result?;
+            }
+            RknpuCmd::MemCreate => {
+                let mut mem_create_args = RknpuMemCreate::default();
+                copy_from_user(
+                    current,
+                    &mut mem_create_args as *mut _ as *mut u8,
+                    arg as *const u8,
+                    mem::size_of::<RknpuMemCreate>(),
+                )?;
+                rknpu::mem_create(&mut mem_create_args).map_err(map_rknpu_err)?;
+                let global_handle = mem_create_args.handle;
+                let local_handle = match self.add_handle(global_handle) {
+                    Ok(handle) => handle,
+                    Err(error) => {
+                        let _ = rknpu::mem_destroy(global_handle);
+                        return Err(error);
+                    }
+                };
+                mem_create_args.handle = local_handle;
+                if let Err(error) = copy_to_user(
+                    current,
+                    arg as *mut u8,
+                    &mem_create_args as *const _ as *const u8,
+                    mem::size_of::<RknpuMemCreate>(),
+                ) {
+                    let _ = self.remove_handle(local_handle).map(rknpu::mem_destroy);
+                    return Err(error);
+                }
+            }
+            RknpuCmd::MemMap => {
+                let mut mem_map = RknpuMemMap::default();
+                copy_from_user(
+                    current,
+                    &mut mem_map as *mut _ as *mut u8,
+                    arg as *const u8,
+                    mem::size_of::<RknpuMemMap>(),
+                )?;
+                self.global_handle(mem_map.handle)?;
+                mem_map.offset = (mem_map.handle as u64) << PAGE_SHIFT;
+                copy_to_user(
+                    current,
+                    arg as *mut u8,
+                    &mem_map as *const _ as *const u8,
+                    mem::size_of::<RknpuMemMap>(),
+                )?;
+            }
+            RknpuCmd::MemDestroy => {
+                let mut mem_destroy = RknpuMemDestroy::default();
+                copy_from_user(
+                    current,
+                    &mut mem_destroy as *mut _ as *mut u8,
+                    arg as *const u8,
+                    mem::size_of::<RknpuMemDestroy>(),
+                )?;
+                let global_handle = self.remove_handle(mem_destroy.handle)?;
+                rknpu::mem_destroy(global_handle).map_err(map_rknpu_err)?;
+            }
+            RknpuCmd::MemSync => {
+                let mut mem_sync = RknpuMemSync::default();
+                copy_from_user(
+                    current,
+                    &mut mem_sync as *mut _ as *mut u8,
+                    arg as *const u8,
+                    mem::size_of::<RknpuMemSync>(),
+                )?;
+                if !self.find_cpu_range(mem_sync.obj_addr, mem_sync.offset, mem_sync.size) {
+                    return Err(VfsError::InvalidData);
+                }
+                rknpu::mem_sync(&mut mem_sync).map_err(map_rknpu_err)?;
+                copy_to_user(
+                    current,
+                    arg as *mut u8,
+                    &mem_sync as *const _ as *const u8,
+                    mem::size_of::<RknpuMemSync>(),
+                )?;
+            }
+            RknpuCmd::Action => {
+                let mut action = RknpuUserAction { flags: 0, value: 0 };
+                copy_from_user(
+                    current,
+                    &mut action as *mut _ as *mut u8,
+                    arg as *const u8,
+                    mem::size_of::<RknpuUserAction>(),
+                )?;
+                let action_kind = decode_rknpu_action(action.flags)?;
+                action.value = rknpu::action(action_kind).map_err(map_rknpu_err)?;
+                copy_to_user(
+                    current,
+                    arg as *mut u8,
+                    &action as *const _ as *const u8,
+                    mem::size_of::<RknpuUserAction>(),
+                )?;
+            }
+        }
+        Ok(0)
+    }
+
+    fn drm_prime_handle_to_fd_ioctl(&self, data: &mut [u8]) -> VfsResult<usize> {
+        let data = unsafe { &mut *(data.as_mut_ptr() as *mut DrmPrimeHande) };
+        let exported = self.exported_gem_buffer(data.handle).map_err(|_| VfsError::NotFound)?;
+        data.fd = exported
+            .add_to_fd_table(prime_fd_cloexec(data.flags))
+            .map_err(|_| VfsError::NoMemory)?;
+        Ok(0)
+    }
+
+    fn drm_prime_fd_to_handle_ioctl(&self, data: &mut [u8]) -> VfsResult<usize> {
+        let req = unsafe { &mut *(data.as_mut_ptr() as *mut DrmPrimeHande) };
+        let buf = resolve_contiguous_dmabuf(req.fd).ok_or(VfsError::InvalidInput)?;
+        let global_handle = rknpu::mem_import(
+            buf.dma_phys_base() as u64,
+            buf.dma_cpu_base().ok_or(VfsError::InvalidInput)?,
+            buf.dma_size(),
+            0,
+            buf.dma_retainer(),
+        )
+        .map_err(map_rknpu_err)?;
+        req.handle = match self.add_handle(global_handle) {
+            Ok(handle) => handle,
+            Err(error) => {
+                let _ = rknpu::mem_destroy(global_handle);
+                return Err(error);
+            }
+        };
+        Ok(0)
+    }
+}
+
+impl Drop for Card1File {
+    fn drop(&mut self) {
+        let handles = core::mem::take(&mut *self.handles.lock());
+        for global_handle in handles.into_values() {
+            let _ = rknpu::mem_destroy(global_handle);
+        }
     }
 }
 
@@ -374,258 +797,37 @@ fn map_rknpu_err(err: rknpu::Error) -> VfsError {
     }
 }
 
-fn elapsed_us(start_ns: u64, end_ns: u64) -> u64 {
-    end_ns.saturating_sub(start_ns) / 1000
+    /// Copies data from user space to kernel space
+    pub fn copy_from_user(
+        current: &UserTaskRef,
+        dst: *mut u8,
+        src: *const u8,
+        size: usize,
+    ) -> Result<(), VfsError> {
+    let bytes = vm_load(current, src, size).map_err(|err| {
+        warn!("[rknpu]: copy_from_user failed: {err:?}");
+        VfsError::BadAddress
+    })?;
+    // SAFETY: ioctl dispatch supplies a live kernel destination at least
+    // `size` bytes long. The user source is now an owned kernel buffer.
+    unsafe { core::ptr::copy_nonoverlapping(bytes.as_ptr(), dst, size) };
+    Ok(())
 }
 
-fn read_user_bytes(current: &UserTaskRef, dst: &mut [u8], src: usize) -> VfsResult<()> {
-    // SAFETY: MaybeUninit<u8> has the same layout as u8 and `dst` is uniquely
-    // borrowed for the duration of the copy. A failed copy leaves only u8
-    // values, for which every bit pattern remains valid.
-    let dst =
-        unsafe { slice::from_raw_parts_mut(dst.as_mut_ptr().cast::<MaybeUninit<u8>>(), dst.len()) };
-    vm_read_slice(current, src as *const u8, dst).map_err(|_| VfsError::InvalidData)
-}
-
-fn write_user_bytes(current: &UserTaskRef, dst: usize, src: &[u8]) -> VfsResult<()> {
-    vm_write_slice(current, dst as *mut u8, src).map_err(|_| VfsError::InvalidData)
-}
-
-fn read_user_value<T: AnyBitPattern>(current: &UserTaskRef, src: usize) -> VfsResult<T> {
-    UserConstPtr::<T>::from(src)
-        .read(current)
-        .map_err(|_| VfsError::InvalidData)
-}
-
-fn write_user_value<T: NoUninit>(current: &UserTaskRef, dst: usize, value: T) -> VfsResult<()> {
-    UserPtr::<T>::from(dst)
-        .write(current, value)
-        .map_err(|_| VfsError::InvalidData)
-}
-
-/// Handles RKNPU action ioctl commands
-pub fn rknpu_driver_ioctl(current: &UserTaskRef, op: RknpuCmd, arg: usize) -> VfsResult<usize> {
-    info!("rknpu_driver_ioctl: op = {:?}", op);
-    match op {
-        RknpuCmd::Submit => {
-            let mut submit_args = read_user_value::<RknpuSubmit>(current, arg)?;
-            let log_index = RKNPU_SUBMIT_LOG_COUNT.fetch_add(1, Ordering::Relaxed);
-            if log_index < RKNPU_SUBMIT_LOG_LIMIT {
-                warn!(
-                    "rknpu submit ioctl[{log_index}]: flags={:#x} timeout={} task_start={} \
-                     task_number={} task_counter={} core_mask={:#x} task_obj_addr={:#x} \
-                     task_base_addr={:#x} subcore_task={:?}",
-                    submit_args.flags,
-                    submit_args.timeout,
-                    submit_args.task_start,
-                    submit_args.task_number,
-                    submit_args.task_counter,
-                    submit_args.core_mask,
-                    submit_args.task_obj_addr,
-                    submit_args.task_base_addr,
-                    submit_args.subcore_task
-                );
-            }
-            info!("rknpu submit ioctl {submit_args:#x?}");
-
-            let submit_start_ns = monotonic_time_nanos();
-            let submit_result = rknpu::submit(&mut submit_args).map_err(map_rknpu_err);
-            match &submit_result {
-                Ok(()) => {
-                    let submit_end_ns = monotonic_time_nanos();
-                    if log_index < RKNPU_SUBMIT_LOG_LIMIT {
-                        warn!(
-                            "rknpu submit ioctl[{log_index}] done: task_counter={} \
-                             hw_elapse_time={} core_mask={:#x} elapsed_us={}",
-                            submit_args.task_counter,
-                            submit_args.hw_elapse_time,
-                            submit_args.core_mask,
-                            elapsed_us(submit_start_ns, submit_end_ns)
-                        );
-                    }
-                }
-                Err(e) => {
-                    let submit_end_ns = monotonic_time_nanos();
-                    warn!("rknpu submit ioctl failed: {:?}", e);
-                    if log_index < RKNPU_SUBMIT_LOG_LIMIT {
-                        warn!(
-                            "rknpu submit ioctl[{log_index}] failed: task_counter={} \
-                             hw_elapse_time={} core_mask={:#x} elapsed_us={}",
-                            submit_args.task_counter,
-                            submit_args.hw_elapse_time,
-                            submit_args.core_mask,
-                            elapsed_us(submit_start_ns, submit_end_ns)
-                        );
-                    }
-                }
-            }
-            debug!("rknpu submit ioctl result: {:#x?}", submit_args);
-
-            write_user_value(current, arg, submit_args)?;
-            submit_result?;
-        }
-        RknpuCmd::MemCreate => {
-            info!("rknpu mem_create ioctl");
-            let mut mem_create_args = read_user_value::<RknpuMemCreate>(current, arg)?;
-
-            let log_index = RKNPU_MEM_CREATE_LOG_COUNT.fetch_add(1, Ordering::Relaxed);
-            if log_index < RKNPU_MEM_CREATE_LOG_LIMIT {
-                warn!(
-                    "rknpu mem_create ioctl[{log_index}]: flags={:#x} size={} core_mask={:#x}",
-                    mem_create_args.flags, mem_create_args.size, mem_create_args.core_mask
-                );
-            }
-
-            let create_start_ns = monotonic_time_nanos();
-            match rknpu::mem_create(&mut mem_create_args).map_err(map_rknpu_err) {
-                Ok(()) => {
-                    let create_end_ns = monotonic_time_nanos();
-                    if log_index < RKNPU_MEM_CREATE_LOG_LIMIT {
-                        warn!(
-                            "rknpu mem_create ioctl[{log_index}] done: handle={} flags={:#x} \
-                             size={} sram_size={} obj_addr={:#x} dma_addr={:#x} \
-                             iommu_domain_id={} core_mask={:#x} elapsed_us={}",
-                            mem_create_args.handle,
-                            mem_create_args.flags,
-                            mem_create_args.size,
-                            mem_create_args.sram_size,
-                            mem_create_args.obj_addr,
-                            mem_create_args.dma_addr,
-                            mem_create_args.iommu_domain_id,
-                            mem_create_args.core_mask,
-                            elapsed_us(create_start_ns, create_end_ns)
-                        );
-                    }
-                }
-                Err(e) => {
-                    let create_end_ns = monotonic_time_nanos();
-                    warn!("rknpu mem_create ioctl failed: {:?}", e);
-                    if log_index < RKNPU_MEM_CREATE_LOG_LIMIT {
-                        warn!(
-                            "rknpu mem_create ioctl[{log_index}] failed: flags={:#x} size={} \
-                             core_mask={:#x} elapsed_us={}",
-                            mem_create_args.flags,
-                            mem_create_args.size,
-                            mem_create_args.core_mask,
-                            elapsed_us(create_start_ns, create_end_ns)
-                        );
-                    }
-                }
-            }
-
-            write_user_value(current, arg, mem_create_args)?;
-        }
-        RknpuCmd::MemMap => {
-            info!("rknpu mem_map ioctl");
-            let mut mem_map = read_user_value::<RknpuMemMap>(current, arg)?;
-
-            match rknpu::mem_map_offset(mem_map.handle).map_err(map_rknpu_err) {
-                Ok(offset) => {
-                    mem_map.offset = offset;
-                    info!(
-                        "mem_map: handle={} -> offset=0x{:x}",
-                        mem_map.handle, mem_map.offset
-                    );
-                }
-                Err(e) => {
-                    warn!("mem_map: invalid handle={}", mem_map.handle);
-                    warn!("rknpu mem_map ioctl failed: {:?}", e);
-                    return Err(e);
-                }
-            }
-
-            write_user_value(current, arg, mem_map)?;
-        }
-        RknpuCmd::MemDestroy => {
-            let mem_destroy = read_user_value::<RknpuMemDestroy>(current, arg)?;
-            info!("rknpu mem_destroy ioctl: handle={}", mem_destroy.handle);
-            rknpu::mem_destroy(mem_destroy.handle).map_err(map_rknpu_err)?;
-        }
-        RknpuCmd::MemSync => {
-            let mut mem_sync = read_user_value::<RknpuMemSync>(current, arg)?;
-            let log_index = RKNPU_MEM_SYNC_LOG_COUNT.fetch_add(1, Ordering::Relaxed);
-            if log_index < RKNPU_MEM_SYNC_LOG_LIMIT {
-                warn!(
-                    "rknpu mem_sync ioctl[{log_index}]: flags={:#x} obj_addr={:#x} offset={} \
-                     size={}",
-                    mem_sync.flags, mem_sync.obj_addr, mem_sync.offset, mem_sync.size
-                );
-            }
-            info!("rknpu mem_sync ioctl {mem_sync:#x?}");
-
-            let sync_start_ns = monotonic_time_nanos();
-            match rknpu::mem_sync(&mut mem_sync).map_err(map_rknpu_err) {
-                Ok(()) => {
-                    let sync_end_ns = monotonic_time_nanos();
-                    if log_index < RKNPU_MEM_SYNC_LOG_LIMIT {
-                        warn!(
-                            "rknpu mem_sync ioctl[{log_index}] done: flags={:#x} offset={} \
-                             size={} elapsed_us={}",
-                            mem_sync.flags,
-                            mem_sync.offset,
-                            mem_sync.size,
-                            elapsed_us(sync_start_ns, sync_end_ns)
-                        );
-                    }
-                }
-                Err(e) => {
-                    let sync_end_ns = monotonic_time_nanos();
-                    warn!("rknpu mem_sync ioctl failed: {:?}", e);
-                    if log_index < RKNPU_MEM_SYNC_LOG_LIMIT {
-                        warn!(
-                            "rknpu mem_sync ioctl[{log_index}] failed: flags={:#x} offset={} \
-                             size={} elapsed_us={}",
-                            mem_sync.flags,
-                            mem_sync.offset,
-                            mem_sync.size,
-                            elapsed_us(sync_start_ns, sync_end_ns)
-                        );
-                    }
-                    return Err(e);
-                }
-            }
-
-            write_user_value(current, arg, mem_sync)?;
-        }
-        RknpuCmd::Action => {
-            info!("rknpu action ioctl");
-            let mut action = read_user_value::<RknpuUserAction>(current, arg)?;
-            let action_kind = decode_rknpu_action(action.flags)?;
-
-            let log_index = RKNPU_ACTION_LOG_COUNT.fetch_add(1, Ordering::Relaxed);
-            let value_in = action.value;
-            info!(
-                "rknpu action ioctl: flags = {:?}, value = {}",
-                action.flags, action.value
-            );
-
-            match rknpu::action(action_kind).map_err(map_rknpu_err) {
-                Ok(val) => {
-                    action.value = val;
-                    if log_index < RKNPU_ACTION_LOG_LIMIT {
-                        warn!(
-                            "rknpu action ioctl[{log_index}]: flags={:?} value_in={} \
-                             result=Ok({}) value_out={}",
-                            action.flags, value_in, val, action.value
-                        );
-                    }
-                }
-                Err(e) => {
-                    warn!("rknpu action ioctl failed: {:?}", e);
-                    if log_index < RKNPU_ACTION_LOG_LIMIT {
-                        warn!(
-                            "rknpu action ioctl[{log_index}]: flags={:?} value_in={} \
-                             result=Err({:?}) value_out={}",
-                            action.flags, value_in, e, action.value
-                        );
-                    }
-                }
-            }
-
-            write_user_value(current, arg, action)?;
-        }
-    }
-    Ok(0)
+/// Copies data from kernel space to user space
+pub fn copy_to_user(
+    current: &UserTaskRef,
+    dst: *mut u8,
+    src: *const u8,
+    size: usize,
+) -> Result<(), VfsError> {
+    // SAFETY: ioctl dispatch supplies a live initialized kernel source at
+    // least `size` bytes long for this synchronous copy.
+    let bytes = unsafe { core::slice::from_raw_parts(src, size) };
+    vm_write_slice(current, dst, bytes).map_err(|err| {
+        warn!("[rknpu]: copy_to_user failed: {err:?}");
+        VfsError::BadAddress
+    })
 }
 
 /// DRM_IOCTL_GEM_FLINK ioctl argument type
@@ -655,52 +857,6 @@ struct DrmPrimeHande {
     flags: u32,
     /// File descriptor
     fd: i32,
-}
-
-/// Handles DRM prime handle to fd ioctl command
-fn drm_prime_handle_to_fd_ioctl(data: &mut [u8]) -> VfsResult<usize> {
-    let data = unsafe { &mut *(data.as_mut_ptr() as *mut DrmPrimeHande) };
-    info!("drm_prime_handle_to_fd_ioctl {data:#x?}");
-    let exported = exported_gem_buffer(data.handle).map_err(|err| {
-        warn!(
-            "drm_prime_handle_to_fd_ioctl: invalid handle {}: {err}",
-            data.handle
-        );
-        VfsError::NotFound
-    })?;
-    data.fd = exported
-        .add_to_fd_table(prime_fd_cloexec(data.flags))
-        .map_err(|err| {
-            warn!("drm_prime_handle_to_fd_ioctl: failed to allocate fd: {err}");
-            VfsError::NoMemory
-        })?;
-    Ok(0)
-}
-
-/// Handles DRM prime fd to handle ioctl: imports an external dma-buf fd (e.g. a
-/// `/dev/dma_heap` buffer that a vendor lib decoded into) as a GEM handle, so the
-/// NPU can read it zero-copy. The buffer's allocation is retained for the
-/// handle's lifetime, so closing the source fd does not free it (UAF-safe).
-fn drm_prime_fd_to_handle_ioctl(data: &mut [u8]) -> VfsResult<usize> {
-    let req = unsafe { &mut *(data.as_mut_ptr() as *mut DrmPrimeHande) };
-    info!("drm_prime_fd_to_handle_ioctl {req:#x?}");
-
-    let buf = resolve_contiguous_dmabuf(req.fd).ok_or_else(|| {
-        warn!(
-            "drm_prime_fd_to_handle_ioctl: fd {} is not a contiguous dma-buf",
-            req.fd
-        );
-        VfsError::InvalidInput
-    })?;
-    let dma_addr = buf.dma_phys_base() as u64;
-    let obj_addr = buf.dma_cpu_base().ok_or(VfsError::InvalidInput)?;
-    let size = buf.dma_size();
-    let retainer = buf.dma_retainer();
-
-    // flags = 0 -> NonCacheable mmap, correct for the coherent dma-heap buffer.
-    let handle = rknpu::mem_import(dma_addr, obj_addr, size, 0, retainer).map_err(map_rknpu_err)?;
-    req.handle = handle;
-    Ok(0)
 }
 
 /// Rust implementation of Linux kernel's drm_copy_field function
@@ -745,10 +901,7 @@ unsafe fn drm_copy_field(
 
     // Finally, try filling in the userbuf (same logic as kernel)
     if copy_len > 0 && !buf.is_null() {
-        // SAFETY: the caller guarantees `value` points to a NUL-terminated
-        // kernel string, and the scan above established `copy_len <= len`.
-        let value = unsafe { slice::from_raw_parts(value, copy_len) };
-        write_user_bytes(current, buf as usize, value)?;
+        copy_to_user(current, buf as _, value, copy_len as _)?;
     }
 
     Ok(())
@@ -872,5 +1025,34 @@ mod tests {
         assert!(
             matches!(exported.device_mmap(0, 0).unwrap(), DeviceMmap::Physical(actual, Some(_)) if actual == range)
         );
+    }
+
+    #[test]
+    fn dma_range_requires_full_containment() {
+        assert!(range_contains(0x1000, 0x1000, 0x1800, 0x800));
+        assert!(!range_contains(0x1000, 0x1000, 0x2000, 1));
+        assert!(!range_contains(0x1000, 0x1000, 0x3000, 1));
+    }
+
+    #[test]
+    fn dma_range_rejects_integer_wraparound() {
+        assert!(!range_contains(u64::MAX - 1, 4, u64::MAX - 1, 4));
+        assert!(!range_contains(0x1000, 0x1000, u64::MAX - 1, 4));
+    }
+
+    #[test]
+    fn submit_task_span_rejects_empty_and_unbounded_ranges() {
+        assert!(Card1File::submit_task_span(&RknpuSubmit::default()).is_err());
+
+        let mut args = RknpuSubmit {
+            task_start: u32::MAX,
+            task_number: u32::MAX,
+            ..RknpuSubmit::default()
+        };
+        assert!(Card1File::submit_task_span(&args).is_err());
+
+        args.task_start = 0;
+        args.task_number = 4096;
+        assert!(Card1File::submit_task_span(&args).is_err());
     }
 }

--- a/os/StarryOS/kernel/src/pseudofs/dev/card1.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/card1.rs
@@ -8,7 +8,7 @@ use core::{
 
 use ax_driver::rknpu::{
     self, GemCachePolicy, RknpuAction, RknpuMemCreate, RknpuMemDestroy, RknpuMemMap, RknpuMemSync,
-    RknpuSubmit, RknpuTask,
+    RknpuSubmit, RknpuTask, RKNPU_CORE0_MASK, RKNPU_CORE1_MASK, RKNPU_CORE2_MASK,
 };
 use ax_memory_addr::{PhysAddr, PhysAddrRange};
 use axfs_ng_vfs::{DeviceId, NodeFlags, VfsError, VfsResult};
@@ -240,6 +240,12 @@ struct Card1File {
     operation: Mutex<()>,
 }
 
+const RKNPU_CORE_MASKS: [u32; 3] = [
+    RKNPU_CORE0_MASK,
+    RKNPU_CORE1_MASK,
+    RKNPU_CORE2_MASK,
+];
+
 impl Card1File {
     fn new(base: KernelFile) -> Self {
         Self {
@@ -314,7 +320,7 @@ impl Card1File {
         })
     }
 
-    fn submit_task_span(args: &RknpuSubmit) -> VfsResult<(usize, usize)> {
+    fn submit_task_span(args: &RknpuSubmit, core_mask: u32) -> VfsResult<(usize, usize)> {
         const MAX_TASKS: usize = 4095;
         let mut first = usize::MAX;
         let mut end = 0usize;
@@ -329,9 +335,19 @@ impl Card1File {
             Ok(())
         };
 
-        add_range(args.task_start, args.task_number)?;
-        for subcore in args.subcore_task {
-            add_range(subcore.task_start, subcore.task_number)?;
+        let active_core_count = Self::active_core_count(core_mask);
+        for subcore_idx in Self::active_subcore_task_indices(core_mask) {
+            let subcore = args
+                .subcore_task
+                .get(subcore_idx)
+                .ok_or(VfsError::InvalidData)?;
+            if subcore.task_number != 0 {
+                add_range(subcore.task_start, subcore.task_number)?;
+            } else if active_core_count == 1 && args.task_number != 0 {
+                add_range(args.task_start, args.task_number)?;
+            } else {
+                return Err(VfsError::InvalidData);
+            }
         }
         if first == usize::MAX || end.checked_sub(first).is_none_or(|len| len > MAX_TASKS) {
             return Err(VfsError::InvalidData);
@@ -339,12 +355,37 @@ impl Card1File {
         Ok((first, end))
     }
 
+    fn active_core_count(core_mask: u32) -> usize {
+        RKNPU_CORE_MASKS
+            .into_iter()
+            .filter(|core_bit| core_mask & core_bit != 0)
+            .count()
+    }
+
+    fn active_subcore_task_indices(core_mask: u32) -> impl Iterator<Item = usize> {
+        let active_core_count = Self::active_core_count(core_mask);
+        RKNPU_CORE_MASKS
+            .into_iter()
+            .enumerate()
+            .filter_map(move |(core_idx, core_bit)| {
+                (core_mask & core_bit != 0).then_some(if active_core_count == 3 {
+                    // This is the layout consumed by rockchip-npu::submit_ioctrl:
+                    // three-core submissions use slots 2..=4, while one- and
+                    // two-core submissions use the corresponding core slots.
+                    core_idx + 2
+                } else {
+                    core_idx
+                })
+            })
+    }
+
     fn load_tasks(
         &self,
         current: &UserTaskRef,
         args: &RknpuSubmit,
+        core_mask: u32,
     ) -> VfsResult<(usize, Vec<RknpuTask>)> {
-        let (first, end) = Self::submit_task_span(args)?;
+        let (first, end) = Self::submit_task_span(args, core_mask)?;
         let task_size = mem::size_of::<RknpuTask>();
         let byte_offset = first.checked_mul(task_size).ok_or(VfsError::BadAddress)?;
         let byte_len = (end - first)
@@ -376,8 +417,11 @@ impl Card1File {
         tasks: &[RknpuTask],
         task_bytes: u64,
     ) -> VfsResult<()> {
-        if args.task_base_addr > u32::MAX as u64
-            || !self.find_dma_range(args.task_base_addr, task_bytes)
+        if args.task_base_addr != 0
+            && !task_base_addr_is_valid(
+                args.task_base_addr,
+                self.find_dma_range(args.task_base_addr, task_bytes),
+            )
         {
             return Err(VfsError::InvalidData);
         }
@@ -396,20 +440,33 @@ impl Card1File {
     }
 
     fn handle_submit(&self, current: &UserTaskRef, args: &mut RknpuSubmit) -> VfsResult<()> {
-        let (first, mut tasks) = self.load_tasks(current, args)?;
+        let core_mask = rknpu::normalize_core_mask(args.core_mask).map_err(map_rknpu_err)?;
+        let (first, mut tasks) = self.load_tasks(current, args, core_mask)?;
         let task_bytes = (tasks.len() as u64)
             .checked_mul(mem::size_of::<RknpuTask>() as u64)
             .ok_or(VfsError::BadAddress)?;
         self.validate_submit_dma(args, &tasks, task_bytes)?;
 
         let mut driver_args = *args;
-        if driver_args.task_number != 0 {
+        driver_args.core_mask = core_mask;
+        let active_core_count = Self::active_core_count(core_mask);
+        let active_subcore_indices = Self::active_subcore_task_indices(core_mask);
+        let active_subcore_indices = active_subcore_indices.collect::<Vec<_>>();
+        let only_active_subcore_idx = active_subcore_indices
+            .first()
+            .copied()
+            .ok_or(VfsError::InvalidData)?;
+        if active_core_count == 1
+            && driver_args.task_number != 0
+            && driver_args.subcore_task[only_active_subcore_idx].task_number == 0
+        {
             driver_args.task_start = driver_args
                 .task_start
                 .checked_sub(first as u32)
                 .ok_or(VfsError::InvalidData)?;
         }
-        for subcore in &mut driver_args.subcore_task {
+        for subcore_idx in active_subcore_indices {
+            let subcore = &mut driver_args.subcore_task[subcore_idx];
             if subcore.task_number != 0 {
                 subcore.task_start = subcore
                     .task_start
@@ -446,6 +503,10 @@ fn range_contains(base: u64, size: usize, address: u64, length: u64) -> bool {
         return false;
     };
     address >= base && end <= buffer_end
+}
+
+fn task_base_addr_is_valid(address: u64, dma_range_valid: bool) -> bool {
+    address == 0 || (address <= u32::MAX as u64 && dma_range_valid)
 }
 
 impl FileLike for Card1File {
@@ -1117,18 +1178,44 @@ mod tests {
 
     #[test]
     fn submit_task_span_rejects_empty_and_unbounded_ranges() {
-        assert!(Card1File::submit_task_span(&RknpuSubmit::default()).is_err());
+        assert!(Card1File::submit_task_span(&RknpuSubmit::default(), RKNPU_CORE0_MASK).is_err());
 
         let mut args = RknpuSubmit {
             task_start: u32::MAX,
             task_number: u32::MAX,
             ..RknpuSubmit::default()
         };
-        assert!(Card1File::submit_task_span(&args).is_err());
+        assert!(Card1File::submit_task_span(&args, RKNPU_CORE0_MASK).is_err());
 
         args.task_start = 0;
         args.task_number = 4096;
-        assert!(Card1File::submit_task_span(&args).is_err());
+        assert!(Card1File::submit_task_span(&args, RKNPU_CORE0_MASK).is_err());
+    }
+
+    #[test]
+    fn submit_task_span_ignores_unselected_subcore_slots() {
+        let mut args = RknpuSubmit {
+            task_start: 17,
+            task_number: 1,
+            core_mask: RKNPU_CORE0_MASK,
+            ..RknpuSubmit::default()
+        };
+        args.subcore_task[1].task_start = u32::MAX;
+        args.subcore_task[1].task_number = u32::MAX;
+        args.subcore_task[4].task_start = u32::MAX;
+        args.subcore_task[4].task_number = u32::MAX;
+
+        assert_eq!(
+            Card1File::submit_task_span(&args, RKNPU_CORE0_MASK).unwrap(),
+            (17, 18)
+        );
+    }
+
+    #[test]
+    fn zero_task_base_addr_is_valid_abi_input() {
+        assert!(task_base_addr_is_valid(0, false));
+        assert!(!task_base_addr_is_valid(1, false));
+        assert!(task_base_addr_is_valid(1, true));
     }
 
     #[test]

--- a/os/StarryOS/kernel/src/pseudofs/dev/card1.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/card1.rs
@@ -20,7 +20,8 @@ use super::drm::{DrmUnique, DrmVersion};
 use crate::{
     StarryError, StarryResult,
     file::{
-        File as KernelFile, FileLike, IoDst, IoSrc, Kstat,
+        add_file_like, current_fd_table, release_locks_on_close, File as KernelFile, FileLike,
+        IoDst, IoSrc, Kstat,
         dmabuf::{ContiguousDmaBuf, resolve_contiguous_dmabuf},
     },
     mm::{vm_load, vm_write_slice},
@@ -553,6 +554,7 @@ impl FileLike for Card1File {
             return Err(StarryError::InvalidInput);
         }
         copy_from_user(current, &mut stack_data.0[..in_size], arg)?;
+        let mut prime_rollback = None;
         match nr {
             DRM_IOCTL_VERSION_NR => drm_version(current, &mut stack_data.0)?,
             DRM_IOCTL_GET_UNIQUE_NR => drm_get_unique(&mut stack_data.0)?,
@@ -560,14 +562,21 @@ impl FileLike for Card1File {
                 drm_gem_flink_ioctl(&mut stack_data.0)?;
             }
             DRM_IOCTL_PRIME_HANDLE_TO_FD_NR => {
-                self.drm_prime_handle_to_fd_ioctl(&mut stack_data.0)?;
+                prime_rollback = Some(self.drm_prime_handle_to_fd_ioctl(&mut stack_data.0)?);
             }
             DRM_IOCTL_PRIME_FD_TO_HANDLE_NR => {
-                self.drm_prime_fd_to_handle_ioctl(&mut stack_data.0)?;
+                prime_rollback = Some(self.drm_prime_fd_to_handle_ioctl(&mut stack_data.0)?);
             }
             _ => return Err(VfsError::NotATty.into()),
         }
+        // PRIME handlers publish an fd or local GEM handle before this common
+        // copy-back. The guard remains armed until the user-visible result has
+        // been copied successfully, so a bad output pointer cannot commit a
+        // resource that userspace never received.
         copy_to_user(current, arg, &stack_data.0[..in_size])?;
+        if let Some(rollback) = prime_rollback {
+            rollback.commit();
+        }
         Ok(0)
     }
 
@@ -718,16 +727,18 @@ impl Card1File {
         Ok(0)
     }
 
-    fn drm_prime_handle_to_fd_ioctl(&self, data: &mut [u8]) -> VfsResult<usize> {
+    fn drm_prime_handle_to_fd_ioctl(&self, data: &mut [u8]) -> VfsResult<PrimeRollback<'_>> {
         let data = unsafe { &mut *(data.as_mut_ptr() as *mut DrmPrimeHande) };
-        let exported = self.exported_gem_buffer(data.handle).map_err(|_| VfsError::NotFound)?;
-        data.fd = exported
-            .add_to_fd_table(prime_fd_cloexec(data.flags))
+        let exported: Arc<dyn FileLike> = Arc::new(
+            self.exported_gem_buffer(data.handle)
+                .map_err(|_| VfsError::NotFound)?,
+        );
+        data.fd = add_file_like(exported.clone(), prime_fd_cloexec(data.flags))
             .map_err(|_| VfsError::NoMemory)?;
-        Ok(0)
+        Ok(PrimeRollback::new_fd(data.fd, exported))
     }
 
-    fn drm_prime_fd_to_handle_ioctl(&self, data: &mut [u8]) -> VfsResult<usize> {
+    fn drm_prime_fd_to_handle_ioctl(&self, data: &mut [u8]) -> VfsResult<PrimeRollback<'_>> {
         let req = unsafe { &mut *(data.as_mut_ptr() as *mut DrmPrimeHande) };
         let buf = resolve_contiguous_dmabuf(req.fd).ok_or(VfsError::InvalidInput)?;
         let global_handle = rknpu::mem_import(
@@ -745,7 +756,101 @@ impl Card1File {
                 return Err(error);
             }
         };
-        Ok(0)
+        Ok(PrimeRollback::new_import(self, req.handle, global_handle))
+    }
+}
+
+enum PrimeRollbackAction<'a> {
+    CloseFd {
+        fd: i32,
+        file: Arc<dyn FileLike>,
+    },
+    DestroyImportedGem {
+        file: &'a Card1File,
+        local_handle: u32,
+        global_handle: u32,
+    },
+}
+
+struct PrimeRollback<'a> {
+    action: PrimeRollbackAction<'a>,
+    committed: bool,
+}
+
+impl<'a> PrimeRollback<'a> {
+    fn new_fd(fd: i32, file: Arc<dyn FileLike>) -> Self {
+        Self {
+            action: PrimeRollbackAction::CloseFd { fd, file },
+            committed: false,
+        }
+    }
+
+    fn new_import(file: &'a Card1File, local_handle: u32, global_handle: u32) -> Self {
+        Self {
+            action: PrimeRollbackAction::DestroyImportedGem {
+                file,
+                local_handle,
+                global_handle,
+            },
+            committed: false,
+        }
+    }
+
+    fn commit(mut self) {
+        self.committed = true;
+    }
+}
+
+impl Drop for PrimeRollback<'_> {
+    fn drop(&mut self) {
+        if self.committed {
+            return;
+        }
+        match &self.action {
+            PrimeRollbackAction::CloseFd { fd, file } => close_exported_fd(*fd, file),
+            PrimeRollbackAction::DestroyImportedGem {
+                file,
+                local_handle,
+                global_handle,
+            } => match file.remove_handle(*local_handle) {
+                Ok(removed) if removed == *global_handle => destroy_gem_or_defer(*global_handle),
+                Ok(removed) => {
+                    warn!(
+                        "rknpu: PRIME rollback handle mismatch: local={local_handle}, \
+                         expected={global_handle}, actual={removed}"
+                    );
+                    destroy_gem_or_defer(removed);
+                    destroy_gem_or_defer(*global_handle);
+                }
+                Err(error) => {
+                    // Keep the global allocation recoverable even if local
+                    // bookkeeping has already been changed unexpectedly.
+                    warn!(
+                        "rknpu: PRIME rollback could not remove local handle {local_handle}: \
+                         {error:?}"
+                    );
+                    defer_gem_destroy(*global_handle);
+                }
+            },
+        }
+    }
+}
+
+fn close_exported_fd(fd: i32, expected: &Arc<dyn FileLike>) {
+    let removed = {
+        let table = current_fd_table();
+        let mut table = table.write();
+        let matches = table
+            .get(fd as usize)
+            .is_some_and(|descriptor| Arc::ptr_eq(&descriptor.inner, expected));
+        matches.then(|| table.remove(fd as usize)).flatten()
+    };
+    if let Some(descriptor) = removed {
+        release_locks_on_close(descriptor);
+    } else {
+        // Another thread may have closed or reused the freshly exported fd;
+        // its normal close path then owns the descriptor cleanup.
+        warn!("rknpu: PRIME fd rollback skipped fd {fd} after descriptor changed");
     }
 }
 
@@ -852,10 +957,10 @@ impl ExportedGemBuffer {
         let anchor = Some(self.retainer.clone());
         match self.cache_policy {
             GemCachePolicy::Cacheable => {
-                DeviceMmap::PhysicalCachedResolved(self.range, anchor)
+                DeviceMmap::PhysicalCachedResolvedPageCapped(self.range, anchor)
             }
             GemCachePolicy::NonCacheable | GemCachePolicy::WriteCombine => {
-                DeviceMmap::PhysicalResolved(self.range, anchor)
+                DeviceMmap::PhysicalResolvedPageCapped(self.range, anchor)
             }
         }
     }
@@ -1159,7 +1264,7 @@ mod tests {
 
         assert!(matches!(
             exported.device_mmap_kind_resolved(),
-            DeviceMmap::PhysicalCachedResolved(actual, Some(_)) if actual == range
+            DeviceMmap::PhysicalCachedResolvedPageCapped(actual, Some(_)) if actual == range
         ));
     }
 

--- a/os/StarryOS/kernel/src/pseudofs/dev/card1.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/card1.rs
@@ -65,6 +65,11 @@ const DRM_IOCTL_PRIME_HANDLE_TO_FD_NR: u32 = 0x2d;
 /// DRM ioctl prime fd to handle command number (import an external dma-buf)
 const DRM_IOCTL_PRIME_FD_TO_HANDLE_NR: u32 = 0x2e;
 
+/// GEM handles whose destruction could not acquire the global NPU lock yet.
+/// The backing allocations remain owned by the driver until a later card1
+/// operation retries these handles.
+static DEFERRED_GEM_DESTROYS: Mutex<Vec<u32>> = Mutex::new(Vec::new());
+
 /// RKNPU command types
 #[repr(u32)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -219,6 +224,7 @@ pub(crate) fn open_card1_file(
     file: ax_fs_ng::File,
     open_flags: u32,
 ) -> StarryResult<Arc<dyn FileLike>> {
+    retry_deferred_gem_destroys();
     Ok(Arc::new(Card1File::new(KernelFile::new(file, open_flags))))
 }
 
@@ -469,6 +475,7 @@ impl FileLike for Card1File {
             return Err(StarryError::BadAddress);
         }
         let _operation = self.operation.lock();
+        retry_deferred_gem_destroys();
         let nr = ioctl_nr(cmd);
         info!("card1: cmd {cmd:#x}, nr {nr:#x}, arg {arg:#x}");
         if is_driver_ioctl(nr) {
@@ -505,6 +512,7 @@ impl FileLike for Card1File {
 
     fn device_mmap(&self, offset: u64, _length: u64) -> StarryResult<DeviceMmap> {
         let _operation = self.operation.lock();
+        retry_deferred_gem_destroys();
         let handle = map_handle_from_offset(offset).ok_or(StarryError::InvalidInput)?;
         Ok(self.exported_gem_buffer(handle)?.device_mmap_kind_resolved())
     }
@@ -572,7 +580,7 @@ impl Card1File {
                 let local_handle = match self.add_handle(global_handle) {
                     Ok(handle) => handle,
                     Err(error) => {
-                        let _ = rknpu::mem_destroy(global_handle);
+                        destroy_gem_or_defer(global_handle);
                         return Err(error);
                     }
                 };
@@ -582,7 +590,8 @@ impl Card1File {
                     arg,
                     bytemuck::bytes_of(&mem_create_args),
                 ) {
-                    let _ = self.remove_handle(local_handle).map(rknpu::mem_destroy);
+                    let global_handle = self.remove_handle(local_handle)?;
+                    destroy_gem_or_defer(global_handle);
                     return Err(error);
                 }
             }
@@ -608,8 +617,9 @@ impl Card1File {
                     bytemuck::bytes_of_mut(&mut mem_destroy),
                     arg,
                 )?;
-                let global_handle = self.remove_handle(mem_destroy.handle)?;
+                let global_handle = self.global_handle(mem_destroy.handle)?;
                 rknpu::mem_destroy(global_handle).map_err(map_rknpu_err)?;
+                self.remove_handle(mem_destroy.handle)?;
             }
             RknpuCmd::MemSync => {
                 let mut mem_sync = RknpuMemSync::default();
@@ -670,7 +680,7 @@ impl Card1File {
         req.handle = match self.add_handle(global_handle) {
             Ok(handle) => handle,
             Err(error) => {
-                let _ = rknpu::mem_destroy(global_handle);
+                destroy_gem_or_defer(global_handle);
                 return Err(error);
             }
         };
@@ -682,7 +692,58 @@ impl Drop for Card1File {
     fn drop(&mut self) {
         let handles = core::mem::take(&mut *self.handles.lock());
         for global_handle in handles.into_values() {
-            let _ = rknpu::mem_destroy(global_handle);
+            destroy_gem_or_defer(global_handle);
+        }
+    }
+}
+
+fn enqueue_deferred_gem_destroy(pending: &mut Vec<u32>, handle: u32) {
+    if !pending.contains(&handle) {
+        pending.push(handle);
+    }
+}
+
+fn defer_gem_destroy(handle: u32) {
+    enqueue_deferred_gem_destroy(&mut DEFERRED_GEM_DESTROYS.lock(), handle);
+}
+
+fn destroy_gem_or_defer(handle: u32) {
+    match rknpu::mem_destroy(handle) {
+        Ok(()) => {}
+        Err(error @ (rknpu::Error::Busy | rknpu::Error::Quarantined)) => {
+            warn!(
+                "rknpu: GEM destroy for handle {} deferred after {:?}",
+                handle, error
+            );
+            defer_gem_destroy(handle);
+        }
+        Err(error) => {
+            warn!(
+                "rknpu: GEM destroy for handle {} could not be completed: {:?}",
+                handle, error
+            );
+        }
+    }
+}
+
+fn retry_deferred_gem_destroys() {
+    let pending = core::mem::take(&mut *DEFERRED_GEM_DESTROYS.lock());
+    for handle in pending {
+        match rknpu::mem_destroy(handle) {
+            Ok(()) => {}
+            Err(error @ (rknpu::Error::Busy | rknpu::Error::Quarantined)) => {
+                warn!(
+                    "rknpu: deferred GEM destroy for handle {} still unavailable: {:?}",
+                    handle, error
+                );
+                defer_gem_destroy(handle);
+            }
+            Err(error) => {
+                warn!(
+                    "rknpu: deferred GEM destroy for handle {} was discarded: {:?}",
+                    handle, error
+                );
+            }
         }
     }
 }
@@ -1068,5 +1129,15 @@ mod tests {
         args.task_start = 0;
         args.task_number = 4096;
         assert!(Card1File::submit_task_span(&args).is_err());
+    }
+
+    #[test]
+    fn deferred_destroy_queue_keeps_each_handle_once() {
+        let mut pending = Vec::new();
+        enqueue_deferred_gem_destroy(&mut pending, 7);
+        enqueue_deferred_gem_destroy(&mut pending, 7);
+        enqueue_deferred_gem_destroy(&mut pending, 9);
+
+        assert_eq!(pending.as_slice(), &[7, 9]);
     }
 }

--- a/os/StarryOS/kernel/src/pseudofs/dev/card1.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/card1.rs
@@ -506,7 +506,7 @@ impl FileLike for Card1File {
     fn device_mmap(&self, offset: u64, _length: u64) -> StarryResult<DeviceMmap> {
         let _operation = self.operation.lock();
         let handle = map_handle_from_offset(offset).ok_or(StarryError::InvalidInput)?;
-        Ok(self.exported_gem_buffer(handle)?.device_mmap_kind())
+        Ok(self.exported_gem_buffer(handle)?.device_mmap_kind_resolved())
     }
 
     fn open_flags(&self) -> u32 {
@@ -719,6 +719,21 @@ impl ExportedGemBuffer {
             // non-cacheable instead of accidentally upgrading it to cached.
             GemCachePolicy::NonCacheable | GemCachePolicy::WriteCombine => {
                 DeviceMmap::Physical(self.range, anchor)
+            }
+        }
+    }
+
+    /// Returns a mapping whose physical range has already been selected by the
+    /// GEM handle encoded in the file offset. The mmap layer must not add that
+    /// selector offset to the physical address a second time.
+    fn device_mmap_kind_resolved(&self) -> DeviceMmap {
+        let anchor = Some(self.retainer.clone());
+        match self.cache_policy {
+            GemCachePolicy::Cacheable => {
+                DeviceMmap::PhysicalCachedResolved(self.range, anchor)
+            }
+            GemCachePolicy::NonCacheable | GemCachePolicy::WriteCombine => {
+                DeviceMmap::PhysicalResolved(self.range, anchor)
             }
         }
     }
@@ -1013,6 +1028,17 @@ mod tests {
         assert!(
             matches!(exported.device_mmap(0, 0).unwrap(), DeviceMmap::Physical(actual, Some(_)) if actual == range)
         );
+    }
+
+    #[test]
+    fn card1_selector_mmap_resolves_the_range_without_shifting_it() {
+        let range = PhysAddrRange::from_start_size(0x1234_5000.into(), 0x4000);
+        let exported = ExportedGemBuffer::new(range, GemCachePolicy::Cacheable, Arc::new(()));
+
+        assert!(matches!(
+            exported.device_mmap_kind_resolved(),
+            DeviceMmap::PhysicalCachedResolved(actual, Some(_)) if actual == range
+        ));
     }
 
     #[test]

--- a/os/StarryOS/kernel/src/pseudofs/dev/mod.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/mod.rs
@@ -3,7 +3,7 @@
 mod axivc;
 mod card0;
 #[cfg(feature = "rknpu")]
-mod card1;
+pub(crate) mod card1;
 // The real contiguous coherent dma-heap is shared by every accelerator that
 // exchanges buffers (JPU / NPU / RGA).
 #[cfg(any(feature = "jpeg", feature = "rknpu", feature = "rga"))]

--- a/os/StarryOS/kernel/src/pseudofs/device.rs
+++ b/os/StarryOS/kernel/src/pseudofs/device.rs
@@ -33,11 +33,16 @@ pub enum DeviceMmap {
     /// This is for file descriptors whose mmap offset is a selector rather than
     /// a byte offset into a linear device, such as io_uring ring offsets.
     PhysicalResolved(PhysAddrRange, Option<Arc<dyn Any + Send + Sync>>),
-    /// Maps to an already offset-resolved cacheable physical address range.
+    /// Maps to an already offset-resolved physical GEM range whose backing
+    /// allocation is fully initialized only through complete pages.
     ///
-    /// This is the cacheable counterpart of [`Self::PhysicalResolved`].
+    /// Unlike [`Self::Physical`], this variant caps the mapping length down to
+    /// a complete page so a partial final allocation page is never exposed.
     #[cfg(feature = "rknpu")]
-    PhysicalCachedResolved(PhysAddrRange, Option<Arc<dyn Any + Send + Sync>>),
+    PhysicalResolvedPageCapped(PhysAddrRange, Option<Arc<dyn Any + Send + Sync>>),
+    /// Cacheable counterpart of [`Self::PhysicalResolvedPageCapped`].
+    #[cfg(feature = "rknpu")]
+    PhysicalCachedResolvedPageCapped(PhysAddrRange, Option<Arc<dyn Any + Send + Sync>>),
     /// Maps to an explicit physical page list for this exact mmap request.
     /// The producer has already applied the requested offset and length, so
     /// mmap callers must map these pages in order without adding the offset

--- a/os/StarryOS/kernel/src/pseudofs/device.rs
+++ b/os/StarryOS/kernel/src/pseudofs/device.rs
@@ -33,6 +33,11 @@ pub enum DeviceMmap {
     /// This is for file descriptors whose mmap offset is a selector rather than
     /// a byte offset into a linear device, such as io_uring ring offsets.
     PhysicalResolved(PhysAddrRange, Option<Arc<dyn Any + Send + Sync>>),
+    /// Maps to an already offset-resolved cacheable physical address range.
+    ///
+    /// This is the cacheable counterpart of [`Self::PhysicalResolved`].
+    #[cfg(feature = "rknpu")]
+    PhysicalCachedResolved(PhysAddrRange, Option<Arc<dyn Any + Send + Sync>>),
     /// Maps to an explicit physical page list for this exact mmap request.
     /// The producer has already applied the requested offset and length, so
     /// mmap callers must map these pages in order without adding the offset

--- a/os/StarryOS/kernel/src/syscall/fs/fd_ops.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/fd_ops.rs
@@ -137,6 +137,14 @@ fn add_to_fd(
                     }
                     return add_file_like(wrapped, flags & O_CLOEXEC != 0);
                 }
+                #[cfg(feature = "rknpu")]
+                if crate::pseudofs::dev::card1::is_card1_device(inner) {
+                    let wrapped = crate::pseudofs::dev::card1::open_card1_file(file, flags)?;
+                    if flags & O_NONBLOCK != 0 {
+                        wrapped.set_nonblocking(true)?;
+                    }
+                    return add_file_like(wrapped, flags & O_CLOEXEC != 0);
+                }
                 // `/dev/rga` is served by a per-open `RgaFile` holding this open's handle/
                 // request session; `dup`/`fork` share its Arc and it is freed at last close.
                 #[cfg(feature = "rga")]

--- a/os/StarryOS/kernel/src/syscall/mm/mmap.rs
+++ b/os/StarryOS/kernel/src/syscall/mm/mmap.rs
@@ -298,8 +298,10 @@ pub fn sys_mmap(
                 match device {
                     Ok(DeviceMmap::PhysicalCached(..)) => false,
                     Ok(DeviceMmap::Physical(..))
-                    | Ok(DeviceMmap::PhysicalResolved(..))
-                    | Ok(DeviceMmap::PhysicalPages(..))
+                    | Ok(DeviceMmap::PhysicalResolved(..)) => false,
+                    #[cfg(feature = "rknpu")]
+                    Ok(DeviceMmap::PhysicalCachedResolved(..)) => false,
+                    Ok(DeviceMmap::PhysicalPages(..))
                     | Ok(DeviceMmap::Cache(_)) => false,
                     Ok(DeviceMmap::None) => true,
                     Err(_) => false,
@@ -485,6 +487,22 @@ pub fn sys_mmap(
                             None => MappingOperation::new_linear(start, range.start, true),
                         }
                     }
+                    #[cfg(feature = "rknpu")]
+                    Ok(DeviceMmap::PhysicalCachedResolved(range, retain)) => {
+                        if range.is_empty() {
+                            return Err(StarryError::InvalidInput);
+                        }
+                        length = length.min(range.size().align_down(page_size));
+                        match retain {
+                            Some(retain) => MappingOperation::new_linear_anchored(
+                                start,
+                                range.start,
+                                true,
+                                retain,
+                            ),
+                            None => MappingOperation::new_linear(start, range.start, true),
+                        }
+                    }
                     Ok(DeviceMmap::PhysicalPages(pages, retain)) => {
                         length = length.min(pages.len() * PAGE_SIZE_4K);
                         MappingOperation::new_shared(
@@ -559,6 +577,27 @@ pub fn sys_mmap(
                                     }
                                     DeviceMmap::PhysicalResolved(range, retain) => {
                                         mapping_flags |= MappingFlags::UNCACHED;
+                                        if range.is_empty() {
+                                            return Err(StarryError::InvalidInput);
+                                        }
+                                        length =
+                                            capped_device_map_len(length, range.size(), page_size)?;
+                                        match retain {
+                                            Some(retain) => MappingOperation::new_linear_anchored(
+                                                start,
+                                                range.start,
+                                                true,
+                                                retain,
+                                            ),
+                                            None => MappingOperation::new_linear(
+                                                start,
+                                                range.start,
+                                                true,
+                                            ),
+                                        }
+                                    }
+                                    #[cfg(feature = "rknpu")]
+                                    DeviceMmap::PhysicalCachedResolved(range, retain) => {
                                         if range.is_empty() {
                                             return Err(StarryError::InvalidInput);
                                         }

--- a/os/StarryOS/kernel/src/syscall/mm/mmap.rs
+++ b/os/StarryOS/kernel/src/syscall/mm/mmap.rs
@@ -441,7 +441,7 @@ pub fn sys_mmap(
                         if range.is_empty() {
                             return Err(StarryError::InvalidInput);
                         }
-                        length = length.min(range.size().align_down(page_size));
+                        length = capped_device_map_len(length, range.size(), page_size)?;
                         match retain {
                             Some(retain) => MappingOperation::new_linear_anchored(
                                 start,
@@ -460,7 +460,7 @@ pub fn sys_mmap(
                         if range.is_empty() {
                             return Err(StarryError::InvalidInput);
                         }
-                        length = length.min(range.size().align_down(page_size));
+                        length = capped_device_map_len(length, range.size(), page_size)?;
                         match retain {
                             Some(retain) => MappingOperation::new_linear_anchored(
                                 start,
@@ -476,7 +476,7 @@ pub fn sys_mmap(
                         if range.is_empty() {
                             return Err(StarryError::InvalidInput);
                         }
-                        length = length.min(range.size().align_down(page_size));
+                        length = capped_device_map_len(length, range.size(), page_size)?;
                         match retain {
                             Some(retain) => MappingOperation::new_linear_anchored(
                                 start,
@@ -492,7 +492,7 @@ pub fn sys_mmap(
                         if range.is_empty() {
                             return Err(StarryError::InvalidInput);
                         }
-                        length = length.min(range.size().align_down(page_size));
+                        length = capped_device_map_len(length, range.size(), page_size)?;
                         match retain {
                             Some(retain) => MappingOperation::new_linear_anchored(
                                 start,
@@ -1670,6 +1670,7 @@ fn mmap_capped_device_map_len_rules_hold_for_test() -> bool {
     assert_eq!(capped_device_map_len(8192, 4096, page_size).unwrap(), 4096); // request > available
     assert_eq!(capped_device_map_len(0, 8192, page_size).unwrap(), 0); // zero request
     assert_eq!(capped_device_map_len(5000, 4096, page_size).unwrap(), 4096); // request > available (aligned)
+    assert_eq!(capped_device_map_len(0x10_000, 0x9_708, page_size).unwrap(), 0xa_000);
     assert!(checked_align_up(usize::MAX, page_size).is_err());
     true
 }

--- a/os/StarryOS/kernel/src/syscall/mm/mmap.rs
+++ b/os/StarryOS/kernel/src/syscall/mm/mmap.rs
@@ -111,7 +111,27 @@ fn checked_align_up(value: usize, alignment: usize) -> StarryResult<usize> {
         .ok_or(StarryError::InvalidInput)
 }
 
-fn capped_device_map_len(
+/// Cap ordinary device mappings at the first page covering the advertised
+/// range. MMIO devices such as KPU legitimately describe a sub-page register
+/// window while the page table still has to map its containing page.
+fn device_map_len(
+    request_len: usize,
+    available_len: usize,
+    page_size: usize,
+) -> StarryResult<usize> {
+    if page_size == 0 || !page_size.is_power_of_two() {
+        return Err(StarryError::InvalidInput);
+    }
+    let available_len = checked_align_up(available_len, page_size)?;
+    Ok(request_len.min(available_len))
+}
+
+/// Cap a GEM mapping at complete initialized backing pages. This contract is
+/// intentionally separate from [`device_map_len`]: a device MMIO window may
+/// be sub-page sized, while a GEM allocation must not expose an uninitialized
+/// tail in its final page.
+#[cfg(feature = "rknpu")]
+fn page_capped_device_map_len(
     request_len: usize,
     available_len: usize,
     page_size: usize,
@@ -304,7 +324,8 @@ pub fn sys_mmap(
                     Ok(DeviceMmap::Physical(..))
                     | Ok(DeviceMmap::PhysicalResolved(..)) => false,
                     #[cfg(feature = "rknpu")]
-                    Ok(DeviceMmap::PhysicalCachedResolved(..)) => false,
+                    Ok(DeviceMmap::PhysicalResolvedPageCapped(..))
+                    | Ok(DeviceMmap::PhysicalCachedResolvedPageCapped(..)) => false,
                     Ok(DeviceMmap::PhysicalPages(..))
                     | Ok(DeviceMmap::Cache(_)) => false,
                     Ok(DeviceMmap::None) => true,
@@ -445,7 +466,7 @@ pub fn sys_mmap(
                         if range.is_empty() {
                             return Err(StarryError::InvalidInput);
                         }
-                        length = capped_device_map_len(length, range.size(), page_size)?;
+                        length = device_map_len(length, range.size(), page_size)?;
                         match retain {
                             Some(retain) => MappingOperation::new_linear_anchored(
                                 start,
@@ -464,7 +485,7 @@ pub fn sys_mmap(
                         if range.is_empty() {
                             return Err(StarryError::InvalidInput);
                         }
-                        length = capped_device_map_len(length, range.size(), page_size)?;
+                        length = device_map_len(length, range.size(), page_size)?;
                         match retain {
                             Some(retain) => MappingOperation::new_linear_anchored(
                                 start,
@@ -480,7 +501,7 @@ pub fn sys_mmap(
                         if range.is_empty() {
                             return Err(StarryError::InvalidInput);
                         }
-                        length = capped_device_map_len(length, range.size(), page_size)?;
+                        length = device_map_len(length, range.size(), page_size)?;
                         match retain {
                             Some(retain) => MappingOperation::new_linear_anchored(
                                 start,
@@ -492,11 +513,27 @@ pub fn sys_mmap(
                         }
                     }
                     #[cfg(feature = "rknpu")]
-                    Ok(DeviceMmap::PhysicalCachedResolved(range, retain)) => {
+                    Ok(DeviceMmap::PhysicalResolvedPageCapped(range, retain)) => {
                         if range.is_empty() {
                             return Err(StarryError::InvalidInput);
                         }
-                        length = capped_device_map_len(length, range.size(), page_size)?;
+                        length = page_capped_device_map_len(length, range.size(), page_size)?;
+                        match retain {
+                            Some(retain) => MappingOperation::new_linear_anchored(
+                                start,
+                                range.start,
+                                true,
+                                retain,
+                            ),
+                            None => MappingOperation::new_linear(start, range.start, true),
+                        }
+                    }
+                    #[cfg(feature = "rknpu")]
+                    Ok(DeviceMmap::PhysicalCachedResolvedPageCapped(range, retain)) => {
+                        if range.is_empty() {
+                            return Err(StarryError::InvalidInput);
+                        }
+                        length = page_capped_device_map_len(length, range.size(), page_size)?;
                         match retain {
                             Some(retain) => MappingOperation::new_linear_anchored(
                                 start,
@@ -544,7 +581,7 @@ pub fn sys_mmap(
                                             return Err(StarryError::InvalidInput);
                                         }
                                         length =
-                                            capped_device_map_len(length, range.size(), page_size)?;
+                                            device_map_len(length, range.size(), page_size)?;
                                         match retain {
                                             Some(retain) => MappingOperation::new_linear_anchored(
                                                 start,
@@ -564,7 +601,7 @@ pub fn sys_mmap(
                                             return Err(StarryError::InvalidInput);
                                         }
                                         length =
-                                            capped_device_map_len(length, range.size(), page_size)?;
+                                            device_map_len(length, range.size(), page_size)?;
                                         match retain {
                                             Some(retain) => MappingOperation::new_linear_anchored(
                                                 start,
@@ -585,7 +622,7 @@ pub fn sys_mmap(
                                             return Err(StarryError::InvalidInput);
                                         }
                                         length =
-                                            capped_device_map_len(length, range.size(), page_size)?;
+                                            device_map_len(length, range.size(), page_size)?;
                                         match retain {
                                             Some(retain) => MappingOperation::new_linear_anchored(
                                                 start,
@@ -601,12 +638,42 @@ pub fn sys_mmap(
                                         }
                                     }
                                     #[cfg(feature = "rknpu")]
-                                    DeviceMmap::PhysicalCachedResolved(range, retain) => {
+                                    DeviceMmap::PhysicalResolvedPageCapped(range, retain) => {
                                         if range.is_empty() {
                                             return Err(StarryError::InvalidInput);
                                         }
-                                        length =
-                                            capped_device_map_len(length, range.size(), page_size)?;
+                                        length = page_capped_device_map_len(
+                                            length,
+                                            range.size(),
+                                            page_size,
+                                        )?;
+                                        match retain {
+                                            Some(retain) => MappingOperation::new_linear_anchored(
+                                                start,
+                                                range.start,
+                                                true,
+                                                retain,
+                                            ),
+                                            None => MappingOperation::new_linear(
+                                                start,
+                                                range.start,
+                                                true,
+                                            ),
+                                        }
+                                    }
+                                    #[cfg(feature = "rknpu")]
+                                    DeviceMmap::PhysicalCachedResolvedPageCapped(
+                                        range,
+                                        retain,
+                                    ) => {
+                                        if range.is_empty() {
+                                            return Err(StarryError::InvalidInput);
+                                        }
+                                        length = page_capped_device_map_len(
+                                            length,
+                                            range.size(),
+                                            page_size,
+                                        )?;
                                         match retain {
                                             Some(retain) => MappingOperation::new_linear_anchored(
                                                 start,
@@ -1667,18 +1734,26 @@ pub fn sys_munlock(
 }
 
 #[cfg(all(test, not(axtest)))]
-fn mmap_capped_device_map_len_rules_hold_for_test() -> bool {
-    // Device GEMs expose only fully initialized pages; a partial final page is
-    // not safe to publish because its allocation layout covers only the
-    // requested bytes.
+fn mmap_device_map_len_rules_hold_for_test() -> bool {
+    // KPU_CFG_SIZE is 0x800 on the K230. The VMA is page-granular, so the
+    // ordinary MMIO contract must retain the containing 4 KiB page.
     let page_size = PAGE_SIZE_4K;
-    assert_eq!(capped_device_map_len(1000, 4096, page_size).unwrap(), 1000); // request < available
-    assert_eq!(capped_device_map_len(8192, 4096, page_size).unwrap(), 4096); // request > available
-    assert_eq!(capped_device_map_len(0, 8192, page_size).unwrap(), 0); // zero request
-    assert_eq!(capped_device_map_len(5000, 4096, page_size).unwrap(), 4096); // request > available (aligned)
-    assert_eq!(capped_device_map_len(0x2_000, 0x1_001, page_size).unwrap(), 0x1_000);
-    assert_eq!(capped_device_map_len(0x10_000, 0x9_708, page_size).unwrap(), 0x9_000);
-    assert!(capped_device_map_len(0x1000, 0x1001, 0).is_err());
+    assert_eq!(device_map_len(PAGE_SIZE_4K, 0x800, PAGE_SIZE_4K).unwrap(), PAGE_SIZE_4K);
+    assert_eq!(device_map_len(0x800, 0x800, PAGE_SIZE_4K).unwrap(), 0x800);
+
+    #[cfg(feature = "rknpu")]
+    {
+        // Device GEMs expose only fully initialized pages; a partial final
+        // page is not safe to publish because its allocation layout covers
+        // only the requested bytes.
+        assert_eq!(page_capped_device_map_len(1000, 4096, page_size).unwrap(), 1000); // request < available
+        assert_eq!(page_capped_device_map_len(8192, 4096, page_size).unwrap(), 4096); // request > available
+        assert_eq!(page_capped_device_map_len(0, 8192, page_size).unwrap(), 0); // zero request
+        assert_eq!(page_capped_device_map_len(5000, 4096, page_size).unwrap(), 4096); // request > available (aligned)
+        assert_eq!(page_capped_device_map_len(0x2_000, 0x1_001, page_size).unwrap(), 0x1_000);
+        assert_eq!(page_capped_device_map_len(0x10_000, 0x9_708, page_size).unwrap(), 0x9_000);
+        assert!(page_capped_device_map_len(0x1000, 0x1001, 0).is_err());
+    }
     assert!(checked_align_up(usize::MAX, page_size).is_err());
     true
 }
@@ -1686,7 +1761,7 @@ fn mmap_capped_device_map_len_rules_hold_for_test() -> bool {
 #[cfg(all(test, not(axtest)))]
 mod tests {
     #[test]
-    fn mmap_capped_device_map_len_rules_hold() {
-        assert!(super::mmap_capped_device_map_len_rules_hold_for_test());
+    fn mmap_device_map_len_rules_hold() {
+        assert!(super::mmap_device_map_len_rules_hold_for_test());
     }
 }

--- a/os/StarryOS/kernel/src/syscall/mm/mmap.rs
+++ b/os/StarryOS/kernel/src/syscall/mm/mmap.rs
@@ -116,7 +116,11 @@ fn capped_device_map_len(
     available_len: usize,
     page_size: usize,
 ) -> StarryResult<usize> {
-    Ok(request_len.min(checked_align_up(available_len, page_size)?))
+    if page_size == 0 || !page_size.is_power_of_two() {
+        return Err(StarryError::InvalidInput);
+    }
+    let available_len = available_len & !(page_size - 1);
+    Ok(request_len.min(available_len))
 }
 
 bitflags::bitflags! {
@@ -1664,13 +1668,17 @@ pub fn sys_munlock(
 
 #[cfg(all(test, not(axtest)))]
 fn mmap_capped_device_map_len_rules_hold_for_test() -> bool {
-    // capped_device_map_len: returns min of request and aligned available.
+    // Device GEMs expose only fully initialized pages; a partial final page is
+    // not safe to publish because its allocation layout covers only the
+    // requested bytes.
     let page_size = PAGE_SIZE_4K;
     assert_eq!(capped_device_map_len(1000, 4096, page_size).unwrap(), 1000); // request < available
     assert_eq!(capped_device_map_len(8192, 4096, page_size).unwrap(), 4096); // request > available
     assert_eq!(capped_device_map_len(0, 8192, page_size).unwrap(), 0); // zero request
     assert_eq!(capped_device_map_len(5000, 4096, page_size).unwrap(), 4096); // request > available (aligned)
-    assert_eq!(capped_device_map_len(0x10_000, 0x9_708, page_size).unwrap(), 0xa_000);
+    assert_eq!(capped_device_map_len(0x2_000, 0x1_001, page_size).unwrap(), 0x1_000);
+    assert_eq!(capped_device_map_len(0x10_000, 0x9_708, page_size).unwrap(), 0x9_000);
+    assert!(capped_device_map_len(0x1000, 0x1001, 0).is_err());
     assert!(checked_align_up(usize::MAX, page_size).is_err());
     true
 }


### PR DESCRIPTION
# RKNPU 提交路径安全加固

本次 PR 解决 issue [#1732](https://github.com/rcore-os/tgoskits/issues/1732) 中 RKNPU 提交路径信任用户提供的内核指针和 DMA 地址的问题。原实现从 `task_obj_addr` 直接构造 `RknpuTask` 裸指针，并把未经所有权验证的 `task_base_addr`、`regcmd_addr` 交给硬件；攻击者可以借此触发越界读写，或访问其他文件打开得到的 GEM 缓冲区。

## 1. 改动目标

安全边界由 StarryOS 的文件描述符层建立，通用 RKNPU 驱动只接收已经复制并验证过的任务切片。这样既避免在可移植驱动中解释用户指针，也使 GEM handle、CPU 地址和 DMA 地址都具有明确的所属关系。

### 1.1 原有风险

旧调用链为 `Card1::ioctl -> ax_driver::rknpu::submit -> Rknpu::submit_ioctrl`。其中 `Rknpu::submit_ioctrl` 将 ioctl 中的整数地址转换成可写裸指针，且 GEM pool 使用全局 handle 查找，缺少 Linux DRM 所要求的 per-file handle 隔离。

### 1.2 修复范围

改动覆盖用户接口适配、可移植驱动和文件生命周期三个层面：`os/StarryOS/kernel/src/pseudofs/dev/card1.rs` 负责用户内存和 GEM 所有权检查，`drivers/ax-driver/src/rknpu.rs` 传递已验证的任务数组，`drivers/npu/rockchip-npu/src/ioctrl.rs` 只处理普通 Rust slice；`fd_ops.rs` 负责为每次 open 建立独立的 card1 文件对象。

## 2. 安全提交流程

提交路径先复制 ioctl 参数，再复制任务描述符，随后检查当前 open 所拥有的 GEM 缓冲区。只有全部检查通过，才会进入 `rknpu::submit` 和硬件寄存器提交阶段。

```mermaid
flowchart TD
    A[用户 ioctl] --> B[Card1File::ioctl]
    B --> C[UserTaskRef 复制 RknpuSubmit]
    C --> D[load_tasks 复制任务数组]
    D --> E{任务范围与用户地址有效?}
    E -- 否 --> F[EFAULT / EINVAL]
    E -- 是 --> G[校验当前 open 所有 GEM 的 DMA 范围]
    G --> H{task_base 与 regcmd 完整包含?}
    H -- 否 --> F
    H -- 是 --> I[ax_driver::rknpu::submit]
    I --> J[Rknpu::submit_ioctrl 接收任务 slice]
    J --> K[硬件提交与完成状态写入内核 slice]
    K --> L[UserTaskRef 回写结果]
```

`Card1File::handle_submit` 在完成硬件调用后才把状态和计数器写回用户空间；验证失败时不会触碰用户任务数组的输出区域，也不会向硬件提交不完整的地址。低层 `Rknpu::submit_ioctrl` 通过 `tasks.get`、`get_mut` 和 checked arithmetic 保持数组边界。

### 2.1 用户内存处理

`Card1File` 使用当前任务的 `UserTaskRef` 调用 `mm::vm_load` 和 `mm::vm_write_slice`。`task_obj_addr` 只作为用户虚拟地址参与一次受限复制，不会跨层保存为裸引用。

| 数据 | 代码锚点 | 校验与处理 |
| --- | --- | --- |
| 顶层 submit 参数 | `rknpu_driver_ioctl`、`copy_from_user` | 复制到内核栈对象，失败映射为 `BadAddress`，即 Linux `EFAULT` |
| 任务描述符 | `submit_task_span`、`load_tasks` | checked 加法和乘法；任务总跨度最多 4095 项；复制到 `Vec<u8>` 后用 `read_unaligned` 解码 packed ABI |
| 完成状态 | `handle_submit` | 硬件只修改内核拥有的 `Vec<RknpuTask>`，完成后通过 `vm_write_slice` 回写用户地址 |
| Action 参数 | `RknpuUserAction`、`decode_rknpu_action` | 先以 `u32` 接收用户值，再转换为合法的 `RknpuAction`，拒绝未知枚举值 |

任务数组按所有活动 core 的最小起点和最大终点复制，驱动参数随后归一化到这段内核数组的相对索引。空任务、跨越整数边界和超出任务数组的索引均在硬件访问前拒绝。

### 2.2 DMA 与 GEM 所有权

`Card1File::handles` 保存“当前 open 的本地 handle -> 全局驱动 handle”映射，所有 DMA 查询都先解析本地 handle 集合，再调用 `buffer_info` 获取真实范围。这样用户即使伪造一个其他 open 获得的数值 handle，也不能通过当前文件访问对应 GEM。

| 地址或操作 | 校验规则 | 失败结果 |
| --- | --- | --- |
| `task_base_addr` | 整段任务描述符字节范围必须完全包含在当前 open 的 GEM 中 | `EINVAL` |
| `RknpuTask::regcmd_addr` | `regcfg_amount * 8` 的完整命令范围必须被某个当前 open GEM 包含 | `EINVAL` |
| DMA 地址和长度 | 所有端点使用 checked arithmetic，并限制为硬件可接受的 `u32` 地址 | `EINVAL` |
| `MemSync` 的 CPU 地址 | `obj_addr + offset + size` 必须落在当前 open 所有的 CPU 缓冲区内 | `EINVAL` |
| `mmap`、PRIME 和 `MemDestroy` | 只解析当前 open 的本地 handle，并保留 backing allocation 生命周期 | 非法 handle 或映射返回对应 VFS 错误 |

同一 `Card1File` 的 ioctl 和 `device_mmap` 由 `operation` 锁串行化，避免提交完成“校验后、使用前”发生 `MemDestroy`。文件关闭时 `Drop for Card1File` 释放该 open 的全部全局 GEM handle。

## 3. IOMMU 与接口行为

RKNPU 的提交安全性还依赖 DMA 地址是否经过隔离。`Rknpu::new` 和 `set_iommu_enabled` 现在只有在 `DmaDomainId::Translated` 时才允许启用提交；Direct DMA 无法约束命令流中嵌入的设备地址，因此会 fail closed。

### 3.1 用户可见 ioctl 语义

实际 ioctl 入口是 `Card1File::ioctl`，而裸 `Card1` 节点不再处理带状态的 GEM 操作。`fd_ops::add_to_fd` 在打开 `/dev/dri/card1` 时创建 per-open 包装对象，`dup` 和 `fork` 共享该对象及其 handle 命名空间。

| 命令 | 成功行为 | 主要失败行为 |
| --- | --- | --- |
| RKNPU Submit（`0x40`/`0x41` 路径） | 校验任务和 DMA 后提交，回写 `task_counter`、`hw_elapse_time` 与完成状态 | 用户地址错误为 `EFAULT`；空任务、越界、外部或溢出 DMA 地址为 `EINVAL` |
| MemCreate / MemMap / MemDestroy | handle 只在当前 open 中可见；映射偏移由本地 handle 生成 | 其他 open 的 handle 被拒绝 |
| MemSync | 仅同步当前 open 所拥有的 CPU 缓冲区范围 | 非法对象、offset 或 size 为 `EINVAL` |
| Action | 只执行经过 `decode_rknpu_action` 验证的 action | 未知 action 被拒绝 |

当前 RK3588 探测代码仍创建 `DmaDomainId::Direct`，所以硬件提交会安全返回错误，直到平台接入真实的 translated IOMMU domain。内存创建、handle 管理和边界校验仍可编译和测试，但不能把 Direct DMA 配置误认为已完成隔离。

### 3.2 驱动层接口边界

`ax_driver::rknpu::submit` 接收 `&mut [RknpuTask]` 并转发给 `Rknpu::submit_ioctrl`。低层驱动不再读取 `task_obj_addr`，只根据 slice 的长度和索引访问任务；这也让同一套提交逻辑可以被其他操作系统适配层复用，而不携带 StarryOS 用户地址语义。

## 4. 验证记录

回归测试集中在 `card1` 的 DMA 范围和任务跨度规则，覆盖完整包含、one-past-end、外部地址、整数溢出、空任务和过大任务数组等边界。启用 `rknpu` 的 Starry 内核测试在变基后的提交上共执行 249 项。

验证命令及结果如下：

- `cargo fmt --all -- --check`：通过。
- `cargo clippy --no-deps -p starry-kernel --features rknpu --target x86_64-unknown-none -- -D warnings`：通过。
- `cargo test -p starry-kernel --features rknpu --lib`：249 passed，0 failed。
- `git diff --check`：通过。

