### PR TITLE
fix(release): restore release-plz dependency updates

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -11,7 +11,6 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  RUSTUP_TOOLCHAIN: stable
 
 concurrency:
   group: release-plz-${{ github.ref }}
@@ -20,6 +19,8 @@ concurrency:
 jobs:
   release-plz-release:
     name: Release-plz release
+    env:
+      RUSTUP_TOOLCHAIN: stable
     if: >-
       github.repository == 'rcore-os/tgoskits' &&
       (github.event_name == 'workflow_dispatch' || github.ref_name == 'dev')
@@ -35,8 +36,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - &install-rust
-        name: Install Rust toolchain
+      - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
       - name: Preflight workspace packages
@@ -62,7 +62,11 @@ jobs:
       pull-requests: write
     steps:
       - *checkout
-      - *install-rust
+      - name: Install workspace Rust toolchain
+        run: |
+          toolchain="$(rustup show active-toolchain)"
+          # Apply the repository toolchain to temporary registry baseline builds too.
+          echo "RUSTUP_TOOLCHAIN=${toolchain%% *}" >> "$GITHUB_ENV"
 
       - name: Run release-plz
         uses: release-plz/action@v0.5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,22 +112,11 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aes"
-version = "0.8.4"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+checksum = "35f0f96ce78e38c3dc6d8948aa8163d06385be74000f3c7a95bf1eef35d3ea32"
 dependencies = [
- "cfg-if",
- "cipher 0.4.4",
- "cpufeatures 0.2.17",
-]
-
-[[package]]
-name = "aes"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8eb277bec05f56a0e0591f155a484cbd0f4f07ff2905051a48c72f004f7ed58"
-dependencies = [
- "cipher 0.5.2",
+ "cipher",
  "cpubits",
  "cpufeatures 0.3.1",
  "zeroize",
@@ -139,19 +128,8 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41ac571010bd60765c56085a4f1d412012a9be2663b1a2f2b19b49318653fd0d"
 dependencies = [
- "aes 0.9.2",
+ "aes",
  "zeroize",
-]
-
-[[package]]
-name = "ahash"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
-dependencies = [
- "getrandom 0.2.17",
- "once_cell",
- "version_check",
 ]
 
 [[package]]
@@ -194,7 +172,7 @@ version = "0.2.9"
 dependencies = [
  "aes-kw",
  "dma-api",
- "hmac 0.13.0",
+ "hmac",
  "log",
  "rdif-eth",
  "ringbuf",
@@ -475,7 +453,7 @@ dependencies = [
 
 [[package]]
 name = "arm-gic-driver"
-version = "0.17.13"
+version = "0.18.0"
 dependencies = [
  "aarch64-cpu 11.2.0",
  "bitflags 2.13.1",
@@ -674,7 +652,7 @@ checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -700,9 +678,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.18.0"
+version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
+checksum = "b281d307588d634de920874890732659e2e7672f72b5e10e81badc1a8a83621e"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -710,9 +688,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.44.0"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
+checksum = "9bff6c3b54fad79a2e60b8102caf565819711497c1f5f092f49508e2f5c31b27"
 dependencies = [
  "cc",
  "cmake",
@@ -780,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "ax-cpu"
-version = "0.8.8"
+version = "0.9.0"
 dependencies = [
  "aarch64-cpu 11.2.0",
  "ax-lazyinit",
@@ -813,7 +791,7 @@ version = "0.5.8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -829,7 +807,7 @@ version = "0.4.9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -951,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "ax-hal"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "ax-alloc",
  "ax-cpu",
@@ -1109,7 +1087,7 @@ version = "0.4.12"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -1136,7 +1114,7 @@ version = "0.3.10"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -1170,7 +1148,7 @@ dependencies = [
 
 [[package]]
 name = "ax-runtime"
-version = "0.11.3"
+version = "0.12.0"
 dependencies = [
  "ax-alloc",
  "ax-crate-interface",
@@ -1220,7 +1198,7 @@ dependencies = [
 
 [[package]]
 name = "ax-std"
-version = "0.5.33"
+version = "0.6.0"
 dependencies = [
  "ax-alloc",
  "ax-api",
@@ -1247,7 +1225,7 @@ dependencies = [
 
 [[package]]
 name = "ax-task"
-version = "0.6.11"
+version = "0.7.0"
 dependencies = [
  "axpanic",
  "cfg-if",
@@ -1268,7 +1246,7 @@ version = "0.6.0"
 dependencies = [
  "env_logger",
  "log",
- "lru 0.18.3",
+ "lru 0.18.4",
  "paste",
  "thiserror 2.0.20",
  "tp-lexer",
@@ -1304,7 +1282,7 @@ dependencies = [
 
 [[package]]
 name = "axbuild"
-version = "0.5.3"
+version = "0.6.0"
 dependencies = [
  "addr2line 0.26.1",
  "anyhow",
@@ -1336,11 +1314,11 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "syn 3.0.4",
+ "syn 3.0.5",
  "tar",
  "tempfile",
  "tokio",
- "toml 1.1.4+spec-1.1.0",
+ "toml 1.1.5+spec-1.1.0",
  "tracing",
  "tracing-log",
  "tracing-subscriber",
@@ -1444,7 +1422,7 @@ version = "0.1.1"
 
 [[package]]
 name = "axplat-dyn"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "ax-cpu",
@@ -1465,7 +1443,7 @@ dependencies = [
 
 [[package]]
 name = "axpoll"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "bitflags 2.13.1",
  "linux-raw-sys 0.12.1",
@@ -1473,7 +1451,7 @@ dependencies = [
 
 [[package]]
 name = "axpoll-set"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "ax-lazyinit",
  "ax-sync",
@@ -1496,7 +1474,7 @@ version = "0.5.15"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -1618,14 +1596,14 @@ dependencies = [
  "quote",
  "serde_json",
  "shlex 2.0.1",
- "syn 3.0.4",
+ "syn 3.0.5",
  "tokio",
- "toml 1.1.4+spec-1.1.0",
+ "toml 1.1.5+spec-1.1.0",
 ]
 
 [[package]]
 name = "axvm"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "aarch64-cpu-ext",
  "acpi_tables",
@@ -1671,7 +1649,7 @@ dependencies = [
  "rsext4",
  "serde",
  "thiserror 2.0.20",
- "toml 1.1.4+spec-1.1.0",
+ "toml 1.1.5+spec-1.1.0",
  "x86",
  "x86_vcpu",
  "x86_vlapic",
@@ -1699,7 +1677,7 @@ dependencies = [
  "serde",
  "serde_repr",
  "thiserror 2.0.20",
- "toml 1.1.4+spec-1.1.0",
+ "toml 1.1.5+spec-1.1.0",
 ]
 
 [[package]]
@@ -1894,11 +1872,11 @@ dependencies = [
 
 [[package]]
 name = "block-padding"
-version = "0.3.3"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+checksum = "710f1dd022ef4e93f8a438b4ba958de7f64308434fa6a87104481645cc30068b"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1935,7 +1913,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -1982,28 +1960,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bytecheck"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
-dependencies = [
- "bytecheck_derive",
- "ptr_meta 0.1.4",
- "simdutf8",
-]
-
-[[package]]
-name = "bytecheck_derive"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "bytemuck"
 version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2020,7 +1976,7 @@ checksum = "fc0e56a716f1e132ff6bf4bdac1c944a3fcdc1cae65f70a4a2a1ac3b401d2d1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -2079,18 +2035,18 @@ dependencies = [
 
 [[package]]
 name = "cbc"
-version = "0.1.2"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+checksum = "ce2dc9ee5f88d11e0beb842c88b33c8a5cf0d1329c4b19494af42b07dbfe8896"
 dependencies = [
- "cipher 0.4.4",
+ "cipher",
 ]
 
 [[package]]
 name = "cc"
-version = "1.4.4"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
+checksum = "005ec2760ca554fae18df7a11195552ec576cd665632a881bc011d5bb2fd4d80"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -2146,22 +2102,12 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
-dependencies = [
- "crypto-common 0.1.7",
- "inout 0.1.4",
-]
-
-[[package]]
-name = "cipher"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
 dependencies = [
  "crypto-common 0.2.2",
- "inout 0.2.2",
+ "inout",
 ]
 
 [[package]]
@@ -2207,7 +2153,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -2382,6 +2328,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "core_detect"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f8f80099a98041a3d1622845c271458a2d73e688351bf3cb999266764b81d48"
+
+[[package]]
 name = "cpp_demangle"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2500,9 +2452,9 @@ checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
+checksum = "e71406cd8807725f7ac2f999a4cdd32e98f829fdf65f528343cebf945e41df1e"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-queue",
@@ -2511,18 +2463,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.16"
+version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
+checksum = "98b0cc327b5bc766e7fda9c9260cc0fa81b43a8e240440422dff70788e3f9ef1"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+checksum = "622f3fc73690be383c7214310406f28a90e6edeadc3cea882f9d71e495b9711a"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -2530,18 +2482,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.20"
+version = "0.9.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+checksum = "dc74980687109a3b14c72fd458107bf0baa1da1a1a805e178d15501ba9b86d9d"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "803d13fb3b09d88be9f4dbc29062c66b19bf7170867ceb746d2a8689bf6c7a26"
+checksum = "03e8bd762f7479489c70ed6c768ddca99d7296857de437a68dcb2a94365b3fae"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -2558,9 +2510,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.22"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+checksum = "a31eee39dddec8330830986fcd7625edb5a24ec90ea038215273bbc3adb08ac6"
 
 [[package]]
 name = "crossterm"
@@ -2672,7 +2624,7 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "386d5a36020bb856e9a34ecb8a4e6c9bd6b0262d1857bae4db7bc7e2fdaa532e"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "cfg-if",
  "crossbeam-channel",
  "crossterm 0.28.1",
@@ -2700,7 +2652,7 @@ version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d40c54bcff5c30d198d0c089b3f1674e2b3b7b438147b798fe247c955e171c4f"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "compact_str",
  "crossbeam-channel",
  "cursive-macros",
@@ -2826,7 +2778,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -2870,7 +2822,7 @@ checksum = "2ac7135c3ef02b2f7833bbeb1be5ba7f966dcde8a87c6b87f65a778d71a02785"
 dependencies = [
  "darling_core 0.24.1",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -3000,7 +2952,6 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "crypto-common 0.1.7",
- "subtle",
 ]
 
 [[package]]
@@ -3024,7 +2975,7 @@ checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -3184,11 +3135,17 @@ checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.35"
+version = "0.8.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+checksum = "2a7a45518d2863d18aa47f4a0cf9faec2aa4304cc09df5e41299f276b3ad135e"
 dependencies = [
  "cfg-if",
+ "core_detect",
+ "multiversion",
+ "multiversion_no_op",
+ "rustversion",
+ "scopeguard",
+ "simdutf8",
 ]
 
 [[package]]
@@ -3516,9 +3473,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
+checksum = "3e0f1c7c3a72c66fd80abe965175f7523475c0489a87d3ff9d6e8c87d87a9d2d"
 
 [[package]]
 name = "finl_unicode"
@@ -3708,7 +3665,7 @@ checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -3908,15 +3865,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-dependencies = [
- "ahash 0.7.8",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
@@ -3974,9 +3922,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+checksum = "e17592d60ebacc7d5e169f4663c5f84f9161cc90328abcfe8456f41e4dfcb284"
 
 [[package]]
 name = "hex"
@@ -3986,20 +3934,11 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hkdf"
-version = "0.12.4"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
 dependencies = [
- "hmac 0.12.1",
-]
-
-[[package]]
-name = "hmac"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest 0.10.7",
+ "hmac",
 ]
 
 [[package]]
@@ -4074,18 +4013,18 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+checksum = "27f864f10dfb56725ce5ce5472bc52252c8f93a4ab86327122cebf62c5f59a17"
 dependencies = [
  "typenum",
 ]
 
 [[package]]
 name = "hyper"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
+checksum = "27b501faa50e7a26c3d3560ca625132f4078a17771f4810baf70475ae48cbe43"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -4321,9 +4260,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.14.0"
+version = "2.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+checksum = "cc4e190f5d26ca7051642629da2c52fc03bde85a03197c99408dcd291734c855"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
@@ -4357,7 +4296,7 @@ version = "0.12.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c460d4fa06223667240720ab69a8045133755ae6dfbe100cf481b95e3a014f1"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "itoa",
  "log",
  "num-format",
@@ -4381,20 +4320,11 @@ dependencies = [
 
 [[package]]
 name = "inout"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
-dependencies = [
- "block-padding",
- "generic-array",
-]
-
-[[package]]
-name = "inout"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
 dependencies = [
+ "block-padding",
  "hybrid-array",
 ]
 
@@ -4408,7 +4338,7 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -4444,9 +4374,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.12.1"
+version = "2.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
+checksum = "791930b43c0d5973160d90a8f3894509f2b273430f5c5c73b668636d0287c5c0"
 
 [[package]]
 name = "irq-framework"
@@ -4577,7 +4507,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.20",
  "tokio",
- "toml 1.1.4+spec-1.1.0",
+ "toml 1.1.5+spec-1.1.0",
  "unicode-width 0.2.2",
 ]
 
@@ -4651,9 +4581,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.104"
+version = "0.3.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
+checksum = "ce57d20d1ea864ce2ac172ab472d409214f4fd359f0b2a2775abdf522e2af99e"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -4685,7 +4615,7 @@ dependencies = [
  "darling 0.23.0",
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -4716,7 +4646,7 @@ dependencies = [
  "int-enum",
  "lock_api",
  "log",
- "lru 0.18.3",
+ "lru 0.18.4",
  "printf-compat",
 ]
 
@@ -4751,9 +4681,9 @@ dependencies = [
 
 [[package]]
 name = "keyring"
-version = "4.1.6"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72585bb6cc9bc370d1d545b7e23fcce71dfd4461c5e15275e3cf51bdfd9a980a"
+checksum = "2270074a3d26bcac93c1dc5d2845eb4c089e8d761ccf6e0ea266a16004640627"
 dependencies = [
  "apple-native-keyring-store",
  "keyring-core",
@@ -5037,9 +4967,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.18.3"
+version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d317b4b9eb398e6acce275758ec6125535505e7a146fb1a9b8bda2451b0ff4c"
+checksum = "ff9840bcc50b71349309900da0ce7279aa336ae71d73250b07998932c7d97c25"
 dependencies = [
  "hashbrown 0.17.1",
 ]
@@ -5236,9 +5166,9 @@ checksum = "05015102dad0f7d61691ca347e9d9d9006685a64aefb3d79eecf62665de2153d"
 
 [[package]]
 name = "mio"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+checksum = "4b18443e9c262bfe8fa82f51666e2642c53393f7e5c27b3e1aeab922cff5b9d8"
 dependencies = [
  "libc",
  "log",
@@ -5266,6 +5196,34 @@ dependencies = [
  "derive_more",
  "thiserror 2.0.20",
 ]
+
+[[package]]
+name = "multiversion"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edb7f0ff51249dfda9ab96b5823695e15a052dc15074c9dbf3d118afaf2c201"
+dependencies = [
+ "multiversion-macros",
+ "target-features",
+]
+
+[[package]]
+name = "multiversion-macros"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b093064383341eb3271f42e381cb8f10a01459478446953953c75d24bd339fc0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "target-features",
+]
+
+[[package]]
+name = "multiversion_no_op"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743fb55ba31b18fb1ecef6bdc9aa2743314978ac084044301a7eee33fb99a20d"
 
 [[package]]
 name = "nb"
@@ -5656,7 +5614,7 @@ dependencies = [
  "tokio-serial",
  "tokio-tungstenite 0.28.0",
  "tokio-util",
- "toml 1.1.4+spec-1.1.0",
+ "toml 1.1.5+spec-1.1.0",
  "uboot-shell",
  "url",
 ]
@@ -5780,7 +5738,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112d82ceb8c5bf524d9af484d4e4970c9fd5a0cc15ba14ad93dccd28873b0629"
 dependencies = [
  "digest 0.11.3",
- "hmac 0.13.0",
+ "hmac",
 ]
 
 [[package]]
@@ -5817,9 +5775,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a07a60cc7a4d00c91f95c685609d1d2f79050e6804b70ebedd7650f0b839bcf"
+checksum = "6d45aeb61b4bf818e12d4205f2466f8c4748f85f4fce0146d1c03d69d753f0ad"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -5827,9 +5785,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3a83744a5c8455b8b3e0dc5031362780a347c878bdd11584d1a8984228cc88d"
+checksum = "89cc5a242e25ed4e7704d0be240f2cfbe20a8c27e7e252d94835be93d92dc39f"
 dependencies = [
  "pest",
  "pest_generator",
@@ -5837,9 +5795,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0cd3451aa3de60d4b9a1e736885e4dea6b31617598026f12256ad566d63304a"
+checksum = "7abf21475cc3820fe4b2ca2dc2142902f67a02189f3b5b3a229f4febc01a43e5"
 dependencies = [
  "pest",
  "pest_meta",
@@ -5850,9 +5808,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e04d3a0849e241d7dfce834c83b1c5edc8622009e8dd51a12ba1927c32f05496"
+checksum = "adba4db388f687393c18c51348d44a41d870ca9df71a2c98172ea3035dc6936e"
 dependencies = [
  "pest",
 ]
@@ -5987,9 +5945,9 @@ checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+checksum = "10ab3eb7f3becc3a1cbc4f2c6f20267996cfc1a6467a873763411b136a122715"
 dependencies = [
  "portable-atomic",
 ]
@@ -6035,7 +5993,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bfe0f4c752e450fc2faf62654f1c134747922825d5b04ca717b8874f41a40c0"
 dependencies = [
  "proc-macro2",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -6081,31 +6039,11 @@ dependencies = [
 
 [[package]]
 name = "ptr_meta"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
-dependencies = [
- "ptr_meta_derive 0.1.4",
-]
-
-[[package]]
-name = "ptr_meta"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "743da816b98c921cdbe8628ef7381b76f25ecf4da599fc80aca90eae7ef70cc0"
 dependencies = [
- "ptr_meta_derive 0.3.2",
-]
-
-[[package]]
-name = "ptr_meta_derive"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
+ "ptr_meta_derive",
 ]
 
 [[package]]
@@ -6116,7 +6054,7 @@ checksum = "1c8d9ca532f185d5d4db7a7c9d51420b452168ea1c2b913953281bd6fe1fcbd0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -6393,7 +6331,7 @@ dependencies = [
  "hashbrown 0.17.1",
  "itertools 0.14.0",
  "kasuari",
- "lru 0.18.3",
+ "lru 0.18.4",
  "palette",
  "serde",
  "strum 0.28.0",
@@ -6708,7 +6646,7 @@ version = "0.4.3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -6757,7 +6695,7 @@ checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -6796,21 +6734,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
-name = "rend"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
-dependencies = [
- "bytecheck",
-]
-
-[[package]]
 name = "reqwest"
-version = "0.13.4"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+checksum = "16a1cfa75cc186dd73d5818e510e042e40927bccc9c236b061cea97e1eb08029"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.23.1",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -6961,35 +6890,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rkyv"
-version = "0.7.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2297bf9c81a3f0dc96bc9521370b88f054168c29826a75e89c55ff196e7ed6a1"
-dependencies = [
- "bitvec",
- "bytecheck",
- "bytes",
- "hashbrown 0.12.3",
- "ptr_meta 0.1.4",
- "rend",
- "rkyv_derive",
- "seahash",
- "tinyvec",
- "uuid",
-]
-
-[[package]]
-name = "rkyv_derive"
-version = "0.7.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84d7b42d4b8d06048d3ac8db0eb31bcb942cbeb709f0b5f2b2ebde398d3038f5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "rlsf"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7082,16 +6982,16 @@ version = "0.1.0"
 
 [[package]]
 name = "rust_decimal"
-version = "1.42.1"
+version = "1.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be2a24f50780bc85f09cc6ac299bdf1424302742d77221106859c9d8b102126a"
+checksum = "7653272e75dcac41dc199fbea6f5797633994fafd339943c06c9af16bf29cd3a"
 dependencies = [
  "arrayvec",
  "borsh",
  "bytes",
  "num-traits",
  "rand 0.8.8",
- "rkyv",
+ "rand 0.9.5",
  "serde",
  "serde_json",
  "wasm-bindgen",
@@ -7152,9 +7052,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.43"
+version = "0.23.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
+checksum = "6725596c3f2c3a0aef021139e145d4eafe314a6623e4680ca83852b2c67ab2ba"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -7337,7 +7237,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -7374,13 +7274,13 @@ dependencies = [
 
 [[package]]
 name = "scroll_derive"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed76efe62313ab6610570951494bdaa81568026e0318eaa55f167de70eeea67d"
+checksum = "e1a36a382ed65dbcc0ab47fd5e9a94112417ccd34560a392ef3b7b0f0ec39148"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -7417,27 +7317,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "seahash"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
-
-[[package]]
 name = "secret-service"
-version = "5.1.0"
+version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a62d7f86047af0077255a29494136b9aaaf697c76ff70b8e49cded4e2623c14"
+checksum = "5107b24b91445dd2aa449a258a1807b63240942157292354dc5bfdbeb8bc6db8"
 dependencies = [
- "aes 0.8.4",
+ "aes",
  "cbc",
  "futures-util",
- "generic-array",
- "getrandom 0.2.17",
+ "getrandom 0.4.3",
  "hkdf",
+ "hybrid-array",
  "num",
  "once_cell",
  "serde",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "zbus",
 ]
 
@@ -7501,7 +7395,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -7512,7 +7406,7 @@ checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -7547,7 +7441,7 @@ checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -7573,9 +7467,9 @@ dependencies = [
 
 [[package]]
 name = "serialport"
-version = "4.10.0"
+version = "4.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a2f4ac56b5d3af3c40fbbee17be96d532cba02fa5853926aacdb77d926272ab"
+checksum = "6ba5f8f29aa20853c4e3e85a33ec580eb66be1f057142e77a333834a318bacf2"
 dependencies = [
  "bitflags 2.13.1",
  "cfg-if",
@@ -7756,9 +7650,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.2"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+checksum = "b9be42f50aa861c555654aa3a37f52f4b1074bacf4e48fe0ef7fa584e80f1f0f"
 
 [[package]]
 name = "smccc"
@@ -7843,7 +7737,7 @@ dependencies = [
  "smccc",
  "some-serial",
  "somehal-macros",
- "syn 3.0.4",
+ "syn 3.0.5",
  "thiserror 2.0.20",
  "tock-registers 0.10.1",
  "uefi",
@@ -7889,7 +7783,7 @@ dependencies = [
  "darling 0.23.0",
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -8178,9 +8072,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.4"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
+checksum = "12df2e0110f65b775f769bb17ef989067a1d931b2eb822bd4346631eeada89f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8250,6 +8144,12 @@ dependencies = [
  "libc",
  "xattr",
 ]
+
+[[package]]
+name = "target-features"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1bbb9f3c5c463a01705937a24fdabc5047929ac764b2d5b9cf681c1f5041ed5"
 
 [[package]]
 name = "target-tuple"
@@ -8468,7 +8368,7 @@ checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -8535,9 +8435,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+checksum = "4cf0ded5c4e56918d8f8a339e1bb67d038d3bc6d144ac407904015ba2e4cde9b"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -8591,14 +8491,14 @@ checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.4"
+version = "0.26.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+checksum = "b0c85f2c3ef0b1cd58b36682f4b17aaa995f0e5db534d85692b4903abce21f67"
 dependencies = [
  "rustls",
  "tokio",
@@ -8679,9 +8579,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.4+spec-1.1.0"
+version = "1.1.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
+checksum = "12c0ba9680044b4ce98d391a62094047eada0d64860b80166c39f4a6b5640785"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -8879,7 +8779,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "semver",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -8914,7 +8814,7 @@ dependencies = [
  "serde_json",
  "target-tuple",
  "termcolor",
- "toml 1.1.4+spec-1.1.0",
+ "toml 1.1.5+spec-1.1.0",
 ]
 
 [[package]]
@@ -9024,7 +8924,7 @@ dependencies = [
  "bitflags 2.13.1",
  "cfg-if",
  "log",
- "ptr_meta 0.3.2",
+ "ptr_meta",
  "ucs2",
  "uefi-macros",
  "uefi-raw",
@@ -9143,9 +9043,9 @@ checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
 
 [[package]]
 name = "ureq"
-version = "3.4.0"
+version = "3.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "972d7902c8735f2695410b8aed7df6ed12a47394aa1c8d7af49f0497b731a94d"
+checksum = "af5546be8f5378d5414f83733f5c9a2526f4645829edbc1c41790aeef1b38e8b"
 dependencies = [
  "base64 0.23.1",
  "flate2",
@@ -9160,9 +9060,9 @@ dependencies = [
 
 [[package]]
 name = "ureq-proto"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da5f78b09e6941e1a0f2e30e695e4b120377b54d5e0aec11b594bb57b3971613"
+checksum = "fabc3e92916c89c95b20eef7b06b00b066bc217ef9ea3a4ac9bf1a7e35261e10"
 dependencies = [
  "base64 0.23.1",
  "http",
@@ -9278,7 +9178,7 @@ dependencies = [
  "serde",
  "tempfile",
  "tokio",
- "toml 1.1.4+spec-1.1.0",
+ "toml 1.1.5+spec-1.1.0",
 ]
 
 [[package]]
@@ -9325,7 +9225,7 @@ dependencies = [
  "axvmconfig",
  "irq-framework",
  "serde",
- "toml 1.1.4+spec-1.1.0",
+ "toml 1.1.5+spec-1.1.0",
 ]
 
 [[package]]
@@ -9411,9 +9311,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
+checksum = "aecb87a33d3b0c5e3b7aa46336eaf486cffafbd281b195e4c8b80d50df2351bf"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -9424,9 +9324,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.77"
+version = "0.4.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
+checksum = "6ef4c5d3d2cdf5c54f4231181768f5510842e350db025faf1f7163b1030ed928"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -9434,9 +9334,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
+checksum = "a690d511e3c1a8b3a55e33511e3c2c00c78415cd23650f32b808627f5696b9ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -9444,22 +9344,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
+checksum = "411e4887f0071ef2d2164a9d5fdf2d20efbef78fccd3a78b0c10a1dc5295e48a"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.5",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
+checksum = "81941cd78d0c92026c33e5e01312845a4cb1e9af3407f9134b100dd03144103e"
 dependencies = [
  "unicode-ident",
 ]
@@ -9479,9 +9379,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.104"
+version = "0.3.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
+checksum = "9fbddc4a036f00ec4f18c83445bd3115cb306a91da554919a099d9222fe4a7f8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -9935,7 +9835,7 @@ dependencies = [
 
 [[package]]
 name = "x86_vcpu"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "bit_field",
  "bitflags 2.13.1",
@@ -10120,7 +10020,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
  "zbus_names",
  "zvariant",
  "zvariant_utils",
@@ -10154,18 +10054,18 @@ checksum = "2fe21bcc34ca7fe6dd56cc2cb1261ea59d6b93620215aefb5ea6032265527784"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.56"
+version = "0.8.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
+checksum = "d35102a9f36d089ccae9e4c6802bc118be4487b80aaffc0ab4e0cf5ce92d2873"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.56"
+version = "0.8.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
+checksum = "146c01f5ab44258da43cf276c74a2763db2ff3969c9c652c3f2de07041d0b2bc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10229,7 +10129,7 @@ checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -10277,7 +10177,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
  "zvariant_utils",
 ]
 
@@ -10290,6 +10190,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 3.0.4",
+ "syn 3.0.5",
  "winnow 1.0.4",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,7 +135,7 @@ ax-alloc = { version = "0.8", path = "memory/ax-alloc", default-features = false
 ax-api = { version = "0.7", path = "os/arceos/api/arceos_api" }
 ax-arm-pl031 = { version = "0.4", path = "drivers/rtc/arm_pl031" }
 cpu-local = { version = "0.2", path = "components/cpu-local" }
-ax-cpu = { version = "0.8", path = "components/axcpu" }
+ax-cpu = { version = "0.9", path = "components/axcpu" }
 ax-cpumask = { version = "0.4", path = "components/cpumask" }
 ax-crate-interface = { version = "0.5", path = "components/crate_interface" }
 ax-cgroup = { version = "0.2", path = "components/ax-cgroup" }
@@ -145,7 +145,7 @@ ax-display = { version = "0.6", path = "os/arceos/modules/axdisplay" }
 ax-driver = { version = "0.13", path = "drivers/ax-driver" }
 virtio-drivers = { version = "0.13.0", default-features = false }
 ax-fs-ng = { version = "0.9", path = "fs/ax-fs-ng" }
-ax-hal = { version = "0.6", path = "os/arceos/modules/axhal" }
+ax-hal = { version = "0.7", path = "os/arceos/modules/axhal" }
 irq-framework = { version = "0.4", path = "components/irq-framework" }
 ax-input = { version = "0.6", path = "os/arceos/modules/axinput" }
 ax-io = { version = "0.6", path = "components/axio" }
@@ -166,29 +166,29 @@ ax-plat = { version = "0.13", path = "platforms/ax-plat" }
 ax-plat-macros = { version = "0.3", path = "platforms/ax-plat-macros" }
 ax-posix-api = { version = "0.5", path = "os/arceos/api/arceos_posix_api" }
 ax-riscv-plic = { version = "0.4", path = "drivers/intc/riscv_plic" }
-ax-runtime = { version = "0.11", path = "os/arceos/modules/axruntime" }
-ax-std = { version = "0.5", path = "os/arceos/ulib/axstd", default-features = false }
+ax-runtime = { version = "0.12", path = "os/arceos/modules/axruntime" }
+ax-std = { version = "0.6", path = "os/arceos/ulib/axstd", default-features = false }
 ax-sync = { version = "0.5", path = "os/arceos/modules/axsync" }
-ax-task = { version = "0.6", path = "components/ax-task" }
+ax-task = { version = "0.7", path = "components/ax-task" }
 ax-tracepoint = { version = "0.6", path = "components/ax-tracepoint" }
 axtest = { version = "0.5", path = "components/axtest/axtest" }
 axtest-macros = { version = "0.5", path = "components/axtest/axtest_macros" }
 xcover = { version = "0.1.3", default-features = false, features = ["alloc"] }
 axaddrspace = { version = "0.5", path = "virtualization/axaddrspace" }
 axbacktrace = { version = "0.4", path = "components/axbacktrace" }
-axbuild = { version = "0.5", path = "scripts/axbuild" }
+axbuild = { version = "0.6", path = "scripts/axbuild" }
 axdevice = { version = "0.6", path = "virtualization/axdevice" }
 axdevice_base = { version = "0.7", path = "virtualization/axdevice_base" }
 axfs-ng-vfs = { version = "0.6", path = "fs/axfs-ng-vfs" }
 axhvc = { version = "0.5", path = "virtualization/axhvc" }
 axivc = { version = "0.1", path = "virtualization/axivc" }
 axklib = { version = "0.8", path = "components/axklib" }
-axplat-dyn = { version = "0.8", path = "platforms/axplat-dyn", default-features = false }
-axpoll = { version = "0.6", path = "components/axpoll" }
+axplat-dyn = { version = "0.9", path = "platforms/axplat-dyn", default-features = false }
+axpoll = { version = "0.7", path = "components/axpoll" }
 axvirtio-blk = { version = "0.2", path = "virtualization/axvirtio-blk" }
 axvirtio-common = { version = "0.2", path = "virtualization/axvirtio-common" }
 axvirtio-net = { version = "0.2", path = "virtualization/axvirtio-net" }
-axvm = { version = "0.6", path = "virtualization/axvm", default-features = false }
+axvm = { version = "0.7", path = "virtualization/axvm", default-features = false }
 axvm-types = { version = "0.7", path = "virtualization/axvm-types" }
 axvmconfig = { version = "0.8", path = "virtualization/axvmconfig", default-features = false }
 ahci-driver = { version = "0.2", path = "drivers/blk/ahci-driver" }
@@ -199,7 +199,7 @@ fxmac_rs = { version = "0.6", path = "drivers/net/fxmac_rs" }
 impl-simple-traits = { version = "0.3", path = "components/crate_interface/test_crates/impl-simple-traits" }
 impl-weak-partial = { version = "0.3", path = "components/crate_interface/test_crates/impl-weak-partial" }
 impl-weak-traits = { version = "0.3", path = "components/crate_interface/test_crates/impl-weak-traits" }
-arm-gic-driver = { version = "0.17", path = "drivers/intc/arm-gic-driver" }
+arm-gic-driver = { version = "0.18", path = "drivers/intc/arm-gic-driver" }
 loongarch-intc-driver = { version = "0.1", path = "drivers/intc/loongarch-intc-driver" }
 x86-apic-driver = { version = "0.1", path = "drivers/intc/x86-apic-driver" }
 eth-intel = { version = "0.2", path = "drivers/net/eth-intel" }
@@ -256,7 +256,7 @@ starry-kernel = { version = "0.8", path = "os/StarryOS/kernel" }
 starry-signal = { version = "0.8", path = "os/StarryOS/signal" }
 starry-vm = { version = "0.5", path = "os/StarryOS/vm" }
 httpboot-protocol = { version = "0.1.0", default-features = false }
-x86_vcpu = { version = "0.6", path = "virtualization/x86_vcpu", default-features = false }
+x86_vcpu = { version = "0.7", path = "virtualization/x86_vcpu", default-features = false }
 x86_vlapic = { version = "0.5", path = "virtualization/x86_vlapic" }
 page-table-generic = { version = "0.8", path = "memory/page-table-generic" }
 someboot = { version = "0.4", path = "platforms/someboot" }

--- a/components/ax-task/Cargo.toml
+++ b/components/ax-task/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ax-task"
-version = "0.6.11"
+version = "0.7.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/components/axcpu/Cargo.toml
+++ b/components/axcpu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ax-cpu"
-version = "0.8.8"
+version = "0.9.0"
 repository = "https://github.com/rcore-os/tgoskits"
 edition.workspace = true
 authors = [

--- a/components/axpoll-set/Cargo.toml
+++ b/components/axpoll-set/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axpoll-set"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 description = "Shared and exclusive readiness queue implementation."
 documentation = "https://docs.rs/axpoll-set"

--- a/components/axpoll/Cargo.toml
+++ b/components/axpoll/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axpoll"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 description = "A library for polling I/O events and waking up tasks."
 authors = ["Mivik <mivikq@gmail.com>", "朝倉水希 <asakuramizu111@gmail.com>"]

--- a/docs/docs/ci/publishing/releases.md
+++ b/docs/docs/ci/publishing/releases.md
@@ -21,7 +21,7 @@ job 条件允许手动事件，或 ref 名称为 `dev`。手动事件并未进�
 
 concurrency group 为 `release-plz-${{ github.ref }}`，配置 `queue: max`。同 ref 的发布工作流按自己的队列运行，不与主 CI 的 concurrency group 共用队列。
 
-工作流设置 `RUSTUP_TOOLCHAIN=stable`，两个 job 都通过 `dtolnay/rust-toolchain@stable` 准备工具链。这个发布流程是显式的 stable 环境，不能据此更改项目日常构建和格式化使用的固定 nightly 工具链。
+`release-plz-release` 设置 `RUSTUP_TOOLCHAIN=stable`，通过 `dtolnay/rust-toolchain@stable` 准备发布工具链。`release-plz-pr` 使用 `rustup show active-toolchain` 安装并选择 `rust-toolchain.toml` 固定的 nightly，再通过 `GITHUB_ENV` 设置 `RUSTUP_TOOLCHAIN`，使仓库外的临时基线构建也使用同一工具链。API 检查会编译依赖，不能统一强制使用 stable；例如 `x86_64` 的 nightly 功能依赖较新的 `Step` 接口。
 
 ## 2. 发布任务
 
@@ -31,17 +31,17 @@ concurrency group 为 `release-plz-${{ github.ref }}`，配置 `queue: max`。�
 
 `release-plz-release` 以完整 Git 历史 checkout，并设置 `persist-credentials=false`。随后先执行 `cargo publish --workspace --dry-run --no-verify`，再通过 `release-plz/action@v0.5` 运行 `command: release`。
 
-前置命令只做发布预检，不真正上传软件包，也不验证软件包构建。真正的发布由后续 Release-plz 步骤处理；能否发布以及哪些软件包需要发布，仍受软件包配置、版本和 registry 状态影响。
+前置命令只做发布预检，不真正上传软件包，也不验证软件包构建。真正的发布由后续 Release-plz 步骤处理；`release_always=false` 要求当前提交关联发布 PR，普通开发提交不会直接触发上传。这样可以先由发布 PR 协调软件包版本和依赖约束，避免新增软件包先于其依赖所需的新接口发布。
 
 ### 2.2 发布 PR
 
-`release-plz-pr` 复用相同的 checkout 和 stable 安装步骤，直接执行 `command: release-pr`，用于创建或更新版本及发布相关改动的 PR。该 job 没有实际发布 job 中的 `Preflight workspace packages` 步骤。
+`release-plz-pr` 复用 checkout，准备仓库固定的 nightly 后执行 `command: release-pr`，用于创建或更新版本及发布相关改动的 PR。该 job 没有实际发布 job 中的 `Preflight workspace packages` 步骤。
 
 发布 PR 创建成功不等于软件包已经上传；实际发布 job 成功也不等于另一个 job 已创建所需 PR。二者的日志、输出和外部状态分别构成结果证据。
 
 ## 3. 配置与权限
 
-根目录 `release-plz.toml` 只设置 workspace 级选项。未在仓库中显式覆盖的行为由所用 Release-plz 版本解释，不应把工具默认值当作工作流中已经写明的约束。
+根目录 `release-plz.toml` 设置 workspace 级选项，并通过 `[[package]]` 为无法使用默认自动 API 检查的软件包定义例外。未显式覆盖的行为由所用 Release-plz 版本解释。
 
 ### 3.1 workspace 选项
 
@@ -51,11 +51,25 @@ concurrency group 为 `release-plz-${{ github.ref }}`，配置 `queue: max`。�
 | --- | --- | --- |
 | `dependencies_update` | `true` | 在发布准备中启用依赖更新 |
 | `publish_no_verify` | `true` | 发布时不执行 Cargo 的软件包构建验证 |
-| `release_always` | `true` | 发布检查不局限于合并 Release-plz 发布 PR 的场景 |
+| `release_always` | `false` | 仅在当前提交关联发布 PR 时尝试发布 |
 
-`release_always` 不表示每个 push 都一定产生一个新版本。配置和预检也没有执行主 CI 的 Rust 静态检查、std 测试、QEMU 或板卡测试，不能用发布成功代替这些验证。
+Release-plz 通过关联 PR 的分支前缀识别发布 PR，仓库使用默认的 `release-plz-` 前缀。手动触发工作流也不绕过这一条件。配置和预检没有执行主 CI 的 Rust 静态检查、std 测试、QEMU 或板卡测试，不能用发布成功代替这些验证。字段语义见 [Release-plz 官方配置](https://release-plz.dev/docs/config#the-release_always-field)。
 
-### 3.2 外部写入
+### 3.2 API 检查边界
+
+其余软件包继续使用默认的自动 semver 检查。`release-plz.toml` 中的包级 `semver_check=false` 只处理已确认的工具或基线限制，不表示这些软件包已经通过兼容性检查。维护者需要核对公开接口，并在有破坏性变化时使用 `release-plz set-version <package>@<version>` 修正版本及依赖约束。
+
+| 例外软件包 | 默认检查无法运行的原因 |
+| --- | --- |
+| `arm-gic-driver` | 需要 AArch64，Release-plz 未提供包级 `--target` 配置 |
+| `ax-cpu`、`ax-hal`、`axplat-dyn`、`ax-runtime`、`ax-std` | 默认功能并集同时启用互斥的 `tls` 和 `uspace`；应分别检查合法组合 |
+| `x86_vcpu` | 检查器收集私有实现后，VMCB 宏生成的深层 `FieldValueEnumTypes` 超过 `cargo-semver-checks 0.50` 的 JSON 解析能力；这些寄存器类型未通过公开 API 暴露 |
+| `ax-posix-api`、`ax-libc`、`axvm` | 已发布的 `ax-posix-api 0.5.34` 缺少仓库外构建所需的 `src/ctypes_gen.rs` |
+| `axbuild`、`axvisor` | 已发布的 `axbuild 0.5.3` 引用了包外的 review-bench 素材，Axvisor 宿主入口依赖它 |
+
+包级覆盖使用 [Release-plz 官方支持的配置](https://release-plz.dev/docs/config#the-semver_check-field)。历史包缺失文件并未因此得到修复；发布可独立构建的基线后，应重新启用相应检查。目标架构、互斥功能和解析器限制也应在工具支持后重新评估。
+
+### 3.3 外部写入
 
 两个 job 的 GitHub 权限不同。发布使用的 registry token 通过环境传入，不应写入仓库或诊断日志。
 

--- a/drivers/intc/arm-gic-driver/Cargo.toml
+++ b/drivers/intc/arm-gic-driver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arm-gic-driver"
-version = "0.17.13"
+version = "0.18.0"
 edition = "2024"
 license = "MIT"
 description = "A driver for the Arm Generic Interrupt Controller."

--- a/os/arceos/modules/axhal/Cargo.toml
+++ b/os/arceos/modules/axhal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ax-hal"
-version = "0.6.2"
+version = "0.7.0"
 repository = "https://github.com/rcore-os/tgoskits"
 edition.workspace = true
 authors = ["Yuekai Jia <equation618@gmail.com>"]

--- a/os/arceos/modules/axruntime/Cargo.toml
+++ b/os/arceos/modules/axruntime/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 license.workspace = true
 name = "ax-runtime"
 repository = "https://github.com/rcore-os/tgoskits"
-version = "0.11.3"
+version = "0.12.0"
 
 [features]
 default = []

--- a/os/arceos/ulib/axstd/Cargo.toml
+++ b/os/arceos/ulib/axstd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ax-std"
-version = "0.5.33"
+version = "0.6.0"
 repository = "https://github.com/rcore-os/tgoskits"
 edition.workspace = true
 authors = [

--- a/platforms/axplat-dyn/Cargo.toml
+++ b/platforms/axplat-dyn/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axplat-dyn"
-version = "0.8.1"
+version = "0.9.0"
 authors = ["周睿 <zrufo747@outlook.com>"]
 categories.workspace = true
 description = "A dynamic platform module for ArceOS, providing runtime platform detection and configuration"

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,4 +1,71 @@
 [workspace]
 dependencies_update = true
 publish_no_verify = true
-release_always = true
+# Publish the coordinated versions and dependency requirements from the release
+# PR, rather than publishing new crates before their dependencies are released.
+release_always = false
+
+# This driver requires an AArch64 target; release-plz does not expose the
+# cargo-semver-checks --target option. Review its target-specific API manually.
+[[package]]
+name = "arm-gic-driver"
+semver_check = false
+
+# These crates expose mutually exclusive kernel TLS and Linux userspace modes.
+# release-plz does not expose cargo-semver-checks feature selection, so its
+# default feature union is not a supported build. Check valid modes separately
+# and use set-version for breaking releases; keep the compile-time guard intact.
+[[package]]
+name = "ax-cpu"
+semver_check = false
+
+[[package]]
+name = "ax-hal"
+semver_check = false
+
+[[package]]
+name = "axplat-dyn"
+semver_check = false
+
+[[package]]
+name = "ax-runtime"
+semver_check = false
+
+[[package]]
+name = "ax-std"
+semver_check = false
+
+# The published ax-posix-api 0.5.34 omits src/ctypes_gen.rs and cannot build
+# outside the repository's axlibc headers. These baselines depend on it.
+# Re-enable checks after a self-contained baseline is published; review ABI
+# changes manually in the meantime.
+[[package]]
+name = "ax-posix-api"
+semver_check = false
+
+[[package]]
+name = "ax-libc"
+semver_check = false
+
+[[package]]
+name = "axvm"
+semver_check = false
+
+# axbuild 0.5.3 references review-bench assets outside its published package.
+# Axvisor's host entry depends on it. Re-enable after a self-contained baseline
+# is published; review the build-tool API and CLI changes manually meanwhile.
+[[package]]
+name = "axbuild"
+semver_check = false
+
+[[package]]
+name = "axvisor"
+semver_check = false
+
+[[package]]
+name = "x86_vcpu"
+# cargo-semver-checks 0.50 includes private items and cannot parse the deeply
+# nested FieldValueEnumTypes generated for the private VMCB implementation.
+# These register types are not exposed by the public API. Review API changes
+# and set breaking versions manually until its parser supports these types.
+semver_check = false

--- a/scripts/axbuild/Cargo.toml
+++ b/scripts/axbuild/Cargo.toml
@@ -6,7 +6,7 @@ keywords.workspace = true
 license.workspace = true
 name = "axbuild"
 repository.workspace = true
-version = "0.5.3"
+version = "0.6.0"
 description = "An OS build lib toolkit used by arceos"
 
 [lints.rust]

--- a/virtualization/axvm/Cargo.toml
+++ b/virtualization/axvm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axvm"
 authors = ["aarkegz <aarkegz@gmail.com>"]
-version = "0.6.2"
+version = "0.7.0"
 edition.workspace = true
 categories = ["virtualization"]
 description = "Virtual Machine resource management crate for ArceOS's hypervisor variant."

--- a/virtualization/x86_vcpu/Cargo.toml
+++ b/virtualization/x86_vcpu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x86_vcpu"
-version = "0.6.2"
+version = "0.7.0"
 edition.workspace = true
 authors = [
     "Mingxian Su <aarkegz@gmail.com>",


### PR DESCRIPTION
修复 [Release-plz 失败任务](https://github.com/rcore-os/tgoskits/actions/runs/34297541908/job/102297309658)，更新依赖锁文件，并同步修正工作区中尚未体现接口变更的软件包版本。

失败不只来自旧锁文件：stable 无法编译 `x86_64 0.15.5` 的 nightly `Step` 实现；默认功能并集会启用互斥的 `tls` / `uspace`；部分历史发布包缺少构建素材；部分架构和宏生成类型也超出了默认 semver 检查的支持范围。

改动及原因：

- 刷新 `Cargo.lock`，通过官方 `release-plz set-version` 更新版本及工作区依赖约束，保留已发布版本的历史 changelog。
- `release-pr` 使用 `rust-toolchain.toml` 固定的 nightly，并通过 `RUSTUP_TOOLCHAIN` 将工具链传给仓库外的临时基线构建；实际发布 job 继续使用 stable。
- 设置 `release_always=false`，先由发布 PR 协调整组版本与依赖，再发布，避免新增包引用尚未发布的依赖接口。`axpoll-set 0.1.0` 引用发布版 `axpoll 0.6.0` 中不存在的注册接口就是已复现的案例。此行为使用 [官方发布策略](https://release-plz.dev/docs/config#the-release_always-field)。
- 通过 [官方包级配置](https://release-plz.dev/docs/config#the-semver_check-field) 为 12 个已确认无法默认检查的软件包设置 `semver_check=false`，逐项记录互斥功能、目标架构、JSON 解析或不可构建历史基线的原因；其余包继续自动检查。
- 同步更新发布流程文档。

需要人工确认兼容性版本的包已同步调整：

| 软件包 | 原版本 | 新版本 |
| --- | --- | --- |
| `ax-task` | `0.6.11` | `0.7.0` |
| `ax-cpu` | `0.8.8` | `0.9.0` |
| `ax-hal` | `0.6.2` | `0.7.0` |
| `axplat-dyn` | `0.8.1` | `0.9.0` |
| `ax-runtime` | `0.11.3` | `0.12.0` |
| `ax-std` | `0.5.33` | `0.6.0` |
| `axpoll` | `0.6.0` | `0.7.0` |
| `axpoll-set` | `0.1.0` | `0.1.1` |
| `arm-gic-driver` | `0.17.13` | `0.18.0` |
| `x86_vcpu` | `0.6.2` | `0.7.0` |
| `axvm` | `0.6.2` | `0.7.0` |
| `axbuild` | `0.5.3` | `0.6.0` |

其中 `ax-cpu`、`ax-hal`、`ax-runtime` 分别在合法 `tls` / `uspace` 组合下被 semver 检查确认存在破坏性变化；其余变更依据删除的功能、必需 trait 方法、公开枚举成员、公开结构字段或公开函数签名核对。`axpoll-set` 的实现接口未改，补丁版本用于修正其发布依赖关系。

`x86_vcpu` 的例外不是公开 API 泄漏：`svm`、`vmcb` 和后端 `inner` 均为私有，公开接口使用 `X86VcpuSetupConfig`、`X86NestedPagingConfig` 等领域参数。普通 rustdoc JSON 的 `includes_private=false`，不包含 VMCB 寄存器类型；检查器额外收集私有项后，`FieldValueEnumTypes` 的深层嵌套超过解析器限制。

验证记录：

- 使用 CI 相同的 `release-plz 0.3.163` 和 `cargo-semver-checks 0.50.0`，复现原始基线构建失败。
- 修复后在独立检出运行完整 `release-plz update --allow-dirty --no-changelog --repo-url https://github.com/rcore-os/tgoskits`，使用本轮更新的 Cargo 缓存，退出码为 0；自动检查仍正确识别受支持软件包的破坏性变化。
- `release-plz release --dry-run`：退出码为 0，普通开发提交按预期输出 `skipping release: current commit is not from a release PR`。
- `cargo xtask test`：59 个软件包的标准库测试全部通过。此结果取得于变基前；变基到最新 `dev` 后再次检查锁文件、元数据与最终差异。
- `cargo metadata --locked --no-deps --format-version 1`、工作流 YAML / 工具链选择、`git diff --check` 通过。
- `arm_vcpu`、`arm_vgic`、`riscv_vcpu`、`riscv_vplic`、`loongarch_vcpu`、`loongarch-intc-driver`、`aarch64_sysreg` 的宿主 semver 命令均成功；这不代替相应目标架构验证。
- clippy 按请求停止，未作为通过项。

限制：包级例外不代表兼容性检查通过。`ax-posix-api 0.5.34` 缺少生成文件、`axbuild 0.5.3` 缺少包外素材的问题并未被原地修复；在发布可独立构建的基线后应重新开启相关检查。互斥功能和架构专用接口仍需按合法配置人工审查。
