### PR TITLE
fix(arceos): exercise real std and repair queued task affinity

### DIFF
--- a/.github/ci/checks/arceos.toml
+++ b/.github/ci/checks/arceos.toml
@@ -9,6 +9,8 @@ impact_targets = ["arceos:x86_64"]
 name = "QEMU x86_64 · Suites"
 command = '''
 cargo xtask arceos test qemu --arch x86_64
+cargo xtask arceos test qemu --arch x86_64 \
+  --test-group rust --test-case task-scheduler-irq-window
 '''
 
 [[check.suite]]
@@ -21,6 +23,8 @@ impact_targets = ["arceos:riscv64"]
 name = "QEMU riscv64 · Suites + task IPI"
 command = '''
 cargo xtask arceos test qemu --arch riscv64
+cargo xtask arceos test qemu --arch riscv64 \
+  --test-group rust --test-case task-scheduler-irq-window
 taskset -c 0 cargo xtask arceos test qemu --arch riscv64 \
   --test-group rust --test-case task-ipi
 '''
@@ -39,6 +43,8 @@ cargo xtask arceos qemu --arch aarch64 --smp 4 \
   --qemu-config os/arceos/configs/qemu/qemu-aarch64-gicv2-boot.toml
 echo "==> arceos aarch64 test suites (Rust GICv2 SMP4 IPI + C GICv3 SMP4)"
 cargo xtask arceos test qemu --arch aarch64
+cargo xtask arceos test qemu --arch aarch64 \
+  --test-group rust --test-case task-scheduler-irq-window
 '''
 
 [[check.suite]]
@@ -51,6 +57,8 @@ impact_targets = ["arceos:loongarch64"]
 name = "QEMU loongarch64 · Suites"
 command = '''
 cargo xtask arceos test qemu --arch loongarch64
+cargo xtask arceos test qemu --arch loongarch64 \
+  --test-group rust --test-case task-scheduler-irq-window
 '''
 
 [[check.suite]]

--- a/components/ax-task/src/sched/system/cpu/remote/run_queue/runtime_state.rs
+++ b/components/ax-task/src/sched/system/cpu/remote/run_queue/runtime_state.rs
@@ -146,16 +146,19 @@ impl CpuRunQueueState {
         if self.queue.is_linked_current(thread) {
             return self.queue.update_affinity(thread, affinity);
         }
-        let current_updated = self
+        if let Some(current) = self
             .queue
             .current_mut()
             .filter(|current| current.thread() == thread)
-            .map(|current| current.update_affinity(affinity))
-            .is_some();
-        if current_updated {
+        {
+            current.update_affinity(affinity);
             self.queue.mark_publication_dirty();
+            return true;
         }
-        current_updated
+        // A runnable non-current task retains its affinity in the class queue.
+        // Like Linux's queued-task affinity update, change that metadata under
+        // the owner rq transaction before detaching it for migration.
+        self.queue.update_affinity(thread, affinity)
     }
 
     pub(crate) fn detach_current_schedule(

--- a/os/arceos/api/arceos_posix_api/src/imp/fd_ops.rs
+++ b/os/arceos/api/arceos_posix_api/src/imp/fd_ops.rs
@@ -13,6 +13,20 @@ use crate::{
 
 pub const AX_FILE_LIMIT: usize = 1024;
 
+pub(crate) struct FileDescriptor {
+    file: Arc<dyn FileLike>,
+    close_on_exec: bool,
+}
+
+impl FileDescriptor {
+    fn new(file: Arc<dyn FileLike>, close_on_exec: bool) -> Self {
+        Self {
+            file,
+            close_on_exec,
+        }
+    }
+}
+
 #[allow(dead_code)]
 pub trait FileLike: Send + Sync {
     fn read(&self, buf: &mut [u8]) -> PosixResult<usize>;
@@ -24,22 +38,22 @@ pub trait FileLike: Send + Sync {
 }
 
 scope_local! {
-    pub(crate) static FD_TABLE: Arc<Mutex<FlattenObjects<Arc<dyn FileLike>, AX_FILE_LIMIT>>> = Arc::new(Mutex::new({
+    pub(crate) static FD_TABLE: Arc<Mutex<FlattenObjects<FileDescriptor, AX_FILE_LIMIT>>> = Arc::new(Mutex::new({
         let mut fd_table = flatten_objects::FlattenObjects::new();
         fd_table
-            .add_at(0, Arc::new(stdin()) as _)
+            .add_at(0, FileDescriptor::new(Arc::new(stdin()), false))
             .unwrap_or_else(|_| panic!()); // stdin
         fd_table
-            .add_at(1, Arc::new(stdout()) as _)
+            .add_at(1, FileDescriptor::new(Arc::new(stdout()), false))
             .unwrap_or_else(|_| panic!()); // stdout
         fd_table
-            .add_at(2, Arc::new(stdout()) as _)
+            .add_at(2, FileDescriptor::new(Arc::new(stdout()), false))
             .unwrap_or_else(|_| panic!()); // stderr
         fd_table
     }));
 }
 
-fn current_fd_table() -> Arc<Mutex<FlattenObjects<Arc<dyn FileLike>, AX_FILE_LIMIT>>> {
+fn current_fd_table() -> Arc<Mutex<FlattenObjects<FileDescriptor, AX_FILE_LIMIT>>> {
     FD_TABLE.clone_current()
 }
 
@@ -47,15 +61,50 @@ pub fn get_file_like(fd: c_int) -> PosixResult<Arc<dyn FileLike>> {
     current_fd_table()
         .lock()
         .get(fd as usize)
-        .cloned()
+        .map(|entry| Arc::clone(&entry.file))
         .ok_or(PosixError::EBADF)
 }
 
+#[cfg(any(
+    feature = "fs",
+    feature = "net",
+    feature = "epoll",
+    feature = "eventfd"
+))]
 pub fn add_file_like(f: Arc<dyn FileLike>) -> PosixResult<c_int> {
     Ok(current_fd_table()
         .lock()
-        .add(f)
+        .add(FileDescriptor::new(f, false))
         .map_err(|_| PosixError::EMFILE)? as c_int)
+}
+
+/// Installs both endpoints with their descriptor flags under one table lock.
+#[cfg(feature = "pipe")]
+pub(super) fn add_file_like_pair(
+    read_end: Arc<dyn FileLike>,
+    write_end: Arc<dyn FileLike>,
+    close_on_exec: bool,
+) -> PosixResult<[c_int; 2]> {
+    let table = current_fd_table();
+    let mut table = table.lock();
+    let read_fd = match table.add(FileDescriptor::new(read_end, close_on_exec)) {
+        Ok(fd) => fd,
+        Err(entry) => {
+            drop(table);
+            drop(entry);
+            return Err(PosixError::EMFILE);
+        }
+    };
+    match table.add(FileDescriptor::new(write_end, close_on_exec)) {
+        Ok(write_fd) => Ok([read_fd as c_int, write_fd as c_int]),
+        Err(write_entry) => {
+            let read_entry = table.remove(read_fd).expect("new pipe endpoint must exist");
+            drop(table);
+            drop(read_entry);
+            drop(write_entry);
+            Err(PosixError::EMFILE)
+        }
+    }
 }
 
 pub fn close_file_like(fd: c_int) -> PosixResult {
@@ -76,16 +125,26 @@ pub fn sys_close(fd: c_int) -> c_int {
     syscall_body!(sys_close, close_file_like(fd).map(|_| 0))
 }
 
-fn dup_fd(old_fd: c_int) -> PosixResult<c_int> {
-    let f = get_file_like(old_fd)?;
-    let new_fd = add_file_like(f)?;
-    Ok(new_fd)
+fn dup_fd(old_fd: c_int, minimum: usize, close_on_exec: bool) -> PosixResult<c_int> {
+    let table = current_fd_table();
+    let mut table = table.lock();
+    let file = Arc::clone(&table.get(old_fd as usize).ok_or(PosixError::EBADF)?.file);
+    if minimum >= AX_FILE_LIMIT {
+        return Err(PosixError::EINVAL);
+    }
+    let fd = (minimum..AX_FILE_LIMIT)
+        .find(|fd| table.get(*fd).is_none())
+        .ok_or(PosixError::EMFILE)?;
+    table
+        .add_at(fd, FileDescriptor::new(file, close_on_exec))
+        .unwrap_or_else(|_| panic!("vacant fd must remain free under the table lock"));
+    Ok(fd as c_int)
 }
 
 /// Duplicate a file descriptor.
 pub fn sys_dup(old_fd: c_int) -> c_int {
     debug!("sys_dup <= {old_fd}");
-    syscall_body!(sys_dup, dup_fd(old_fd))
+    syscall_body!(sys_dup, dup_fd(old_fd, 0, false))
 }
 
 /// Duplicate a file descriptor, but it uses the file descriptor number specified in `new_fd`.
@@ -109,7 +168,7 @@ pub fn sys_dup2(old_fd: c_int, new_fd: c_int) -> c_int {
         let f = get_file_like(old_fd)?;
         current_fd_table()
             .lock()
-            .add_at(new_fd as usize, f)
+            .add_at(new_fd as usize, FileDescriptor::new(f, false))
             .map_err(|_| PosixError::EMFILE)?;
 
         Ok(new_fd)
@@ -118,17 +177,31 @@ pub fn sys_dup2(old_fd: c_int, new_fd: c_int) -> c_int {
 
 /// Manipulate file descriptor.
 ///
-/// TODO: `SET/GET` command is ignored, hard-code stdin/stdout
+/// Descriptor flags belong to each fd, independently of the shared file.
 pub fn sys_fcntl(fd: c_int, cmd: c_int, arg: usize) -> c_int {
     debug!("sys_fcntl <= fd: {fd} cmd: {cmd} arg: {arg}");
     syscall_body!(sys_fcntl, {
         #[allow(unreachable_patterns)]
         match cmd as u32 {
-            ctypes::F_DUPFD => dup_fd(fd),
-            ctypes::F_DUPFD_CLOEXEC => {
-                // TODO: Change fd flags
-                dup_fd(fd)
+            ctypes::F_GETFD => {
+                let table = current_fd_table();
+                let table = table.lock();
+                let entry = table.get(fd as usize).ok_or(PosixError::EBADF)?;
+                Ok(if entry.close_on_exec {
+                    ctypes::FD_CLOEXEC as c_int
+                } else {
+                    0
+                })
             }
+            ctypes::F_SETFD => {
+                let table = current_fd_table();
+                let mut table = table.lock();
+                let entry = table.get_mut(fd as usize).ok_or(PosixError::EBADF)?;
+                entry.close_on_exec = arg & ctypes::FD_CLOEXEC as usize != 0;
+                Ok(0)
+            }
+            ctypes::F_DUPFD => dup_fd(fd, arg, false),
+            ctypes::F_DUPFD_CLOEXEC => dup_fd(fd, arg, true),
             ctypes::F_SETFL => {
                 if fd == 0 || fd == 1 || fd == 2 {
                     return Ok(0);

--- a/os/arceos/api/arceos_posix_api/src/imp/pipe.rs
+++ b/os/arceos/api/arceos_posix_api/src/imp/pipe.rs
@@ -3,7 +3,7 @@ use core::ffi::c_int;
 
 use ax_io::PollState;
 
-use super::fd_ops::{FileLike, add_file_like, close_file_like};
+use super::fd_ops::{FileLike, add_file_like_pair};
 use crate::{PosixError, PosixResult, ctypes, sync::Mutex};
 
 #[derive(Copy, Clone, PartialEq)]
@@ -245,20 +245,33 @@ impl FileLike for Pipe {
 ///
 /// Return 0 if succeed
 pub fn sys_pipe(fds: &mut [c_int]) -> c_int {
-    debug!("sys_pipe <= {:#x}", fds.as_ptr() as usize);
-    syscall_body!(sys_pipe, {
+    sys_pipe2(fds, 0)
+}
+
+/// Creates a blocking byte-stream pipe, optionally marking both fds close-on-exec.
+///
+/// Packet, notification and nonblocking pipe modes are not supported.
+/// Outputs and the descriptor table remain unchanged on failure.
+pub fn sys_pipe2(fds: &mut [c_int], flags: c_int) -> c_int {
+    debug!(
+        "sys_pipe2 <= {:#x}, flags: {flags:#x}",
+        fds.as_ptr() as usize
+    );
+    syscall_body!(sys_pipe2, {
+        if flags as u32 & !ctypes::O_CLOEXEC != 0 {
+            return Err(PosixError::EINVAL);
+        }
         if fds.len() != 2 {
             return Err(PosixError::EFAULT);
         }
 
         let (read_end, write_end) = Pipe::new();
-        let read_fd = add_file_like(Arc::new(read_end))?;
-        let write_fd = add_file_like(Arc::new(write_end)).inspect_err(|_| {
-            close_file_like(read_fd).ok();
-        })?;
-
-        fds[0] = read_fd as c_int;
-        fds[1] = write_fd as c_int;
+        let endpoints = add_file_like_pair(
+            Arc::new(read_end),
+            Arc::new(write_end),
+            flags as u32 & ctypes::O_CLOEXEC != 0,
+        )?;
+        fds.copy_from_slice(&endpoints);
 
         Ok(0)
     })

--- a/os/arceos/api/arceos_posix_api/src/lib.rs
+++ b/os/arceos/api/arceos_posix_api/src/lib.rs
@@ -57,7 +57,7 @@ pub use imp::net::{
     sys_shutdown, sys_socket,
 };
 #[cfg(feature = "pipe")]
-pub use imp::pipe::sys_pipe;
+pub use imp::pipe::{sys_pipe, sys_pipe2};
 pub use imp::{
     io::{sys_read, sys_write, sys_writev},
     pthread::{

--- a/os/arceos/ulib/axlibc/c/unistd.c
+++ b/os/arceos/ulib/axlibc/c/unistd.c
@@ -126,33 +126,6 @@ int truncate(const char *path, off_t length)
 
 #endif // AX_CONFIG_FS
 
-#ifdef AX_CONFIG_PIPE
-
-int pipe2(int fd[2], int flag)
-{
-    if (!flag)
-        return pipe(fd);
-    if (flag & ~(O_CLOEXEC | O_NONBLOCK))
-        return -EINVAL;
-
-    int res = pipe(fd);
-    if (res != 0)
-        return res;
-
-    if (flag & O_CLOEXEC) {
-        fcntl(fd[0], F_SETFD, FD_CLOEXEC);
-        fcntl(fd[1], F_SETFD, FD_CLOEXEC);
-    }
-    if (flag & O_NONBLOCK) {
-        fcntl(fd[0], F_SETFL, O_NONBLOCK);
-        fcntl(fd[1], F_SETFL, O_NONBLOCK);
-    }
-
-    return 0;
-}
-
-#endif // AX_CONFIG_PIPE
-
 // TODO
 _Noreturn void _exit(int status)
 {

--- a/os/arceos/ulib/axlibc/src/pipe.rs
+++ b/os/arceos/ulib/axlibc/src/pipe.rs
@@ -1,14 +1,31 @@
 use core::ffi::c_int;
 
-use ax_posix_api::sys_pipe;
+use ax_posix_api::{PosixError, sys_pipe2};
 
 use crate::utils::e;
 
 /// Create a pipe
 ///
 /// Return 0 if succeed
+///
+/// # Safety
+/// A non-null `fd` must point to two uniquely writable, aligned integers.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn pipe(fd: *mut c_int) -> c_int {
+    // SAFETY: pipe and pipe2 have the same output buffer contract.
+    unsafe { pipe2(fd, 0) }
+}
+
+/// Creates a byte-stream pipe, optionally marking both fds close-on-exec.
+///
+/// # Safety
+/// A non-null `fd` must point to two uniquely writable, aligned integers.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn pipe2(fd: *mut c_int, flags: c_int) -> c_int {
+    if fd.is_null() {
+        return e(-PosixError::EFAULT.errno().into_raw());
+    }
+    // SAFETY: the caller supplies the two writable descriptor slots.
     let fds = unsafe { core::slice::from_raw_parts_mut(fd, 2) };
-    e(sys_pipe(fds))
+    e(sys_pipe2(fds, flags))
 }

--- a/os/arceos/ulib/axstd/src/os/libc_compat.rs
+++ b/os/arceos/ulib/axstd/src/os/libc_compat.rs
@@ -886,6 +886,32 @@ pub unsafe extern "C" fn pipe(_pipefd: *mut c_int) -> c_int {
     fail(Errno::ENOSYS)
 }
 
+/// Creates a byte-stream pipe with the supported creation flags.
+///
+/// # Safety
+///
+/// A non-null `pipefd` must point to two writable, aligned `c_int` values
+/// exclusively borrowed for this call.
+#[cfg(feature = "fd")]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn pipe2(pipefd: *mut c_int, flags: c_int) -> c_int {
+    if pipefd.is_null() {
+        return fail(Errno::EFAULT);
+    }
+    // SAFETY: the caller supplies two uniquely writable descriptor slots.
+    let fds = unsafe { core::slice::from_raw_parts_mut(pipefd, 2) };
+    ok_or_errno(ax_posix_api::sys_pipe2(fds, flags))
+}
+
+/// # Safety
+///
+/// Callers must uphold the Linux/musl ABI contract for this libc symbol.
+#[cfg(not(feature = "fd"))]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn pipe2(_pipefd: *mut c_int, _flags: c_int) -> c_int {
+    fail(Errno::ENOSYS)
+}
+
 /// # Safety
 ///
 /// Callers must uphold the Linux/musl ABI contract for this libc symbol.

--- a/test-suit/arceos/axtest/sg2002-usb-msc/tests/axtest.rs
+++ b/test-suit/arceos/axtest/sg2002-usb-msc/tests/axtest.rs
@@ -4,7 +4,7 @@
 extern crate alloc;
 
 #[cfg(feature = "ax-std")]
-extern crate ax_std as std;
+extern crate ax_std;
 
 use arceos_axtest_sg2002_usb_msc::{
     BenchConfig, WriteBenchConfig, bench_iterations, blocks_per_transfer, build_read10_command,

--- a/test-suit/arceos/c/c/pipe_epoll.c
+++ b/test-suit/arceos/c/c/pipe_epoll.c
@@ -1,6 +1,7 @@
 #include "test.h"
 
 #include <errno.h>
+#include <fcntl.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
@@ -81,6 +82,17 @@ int arceos_c_test_pipe(char *reason, size_t reason_len)
     CHECK_RET(close(fd[1]), 0);
     CHECK_RET(read(fd[0], buf, sizeof(buf)), 0);
     CHECK_RET(close(fd[0]), 0);
+    CHECK_RET(pipe2(fd, O_CLOEXEC), 0);
+    CHECK_RET(fcntl(fd[0], F_GETFD), FD_CLOEXEC);
+    CHECK_RET(fcntl(fd[1], F_GETFD), FD_CLOEXEC);
+    CHECK_RET(close(fd[0]), 0);
+    CHECK_RET(close(fd[1]), 0);
+    fd[0] = fd[1] = -1;
+    errno = 0;
+    CHECK_RET(pipe2(fd, -1), -1);
+    CHECK_RET(errno, EINVAL);
+    CHECK_RET(fd[0], -1);
+    CHECK_RET(fd[1], -1);
     puts("pipe: pipe APIs OK");
     return 0;
 }

--- a/test-suit/arceos/loongarch/unaligned-fixup/src/main.rs
+++ b/test-suit/arceos/loongarch/unaligned-fixup/src/main.rs
@@ -1,11 +1,7 @@
-#![cfg_attr(any(feature = "ax-std", target_os = "none"), no_std)]
-#![cfg_attr(any(feature = "ax-std", target_os = "none"), no_main)]
-
-#[cfg(feature = "ax-std")]
-extern crate ax_std as std;
-
 #[cfg(feature = "ax-std")]
 use ax_cpu as _;
+#[cfg(feature = "ax-std")]
+use ax_std as _;
 
 #[cfg(feature = "ax-std")]
 const UNMAPPED_ADDRESS: u64 = 0x1000;
@@ -24,7 +20,6 @@ unsafe extern "C" {
     fn _unaligned_write(address: u64, value: u64, size: u64, fault_address: &mut u64) -> i32;
 }
 
-#[cfg_attr(feature = "ax-std", unsafe(no_mangle))]
 #[cfg(feature = "ax-std")]
 fn main() {
     let mut value = u64::MAX;
@@ -67,14 +62,4 @@ fn main() {
 #[cfg(not(feature = "ax-std"))]
 fn main() {
     eprintln!("this target requires the ax-std feature");
-}
-
-#[cfg(all(target_os = "none", not(feature = "ax-std")))]
-#[unsafe(no_mangle)]
-pub extern "C" fn _start() {}
-
-#[cfg(all(target_os = "none", not(feature = "ax-std")))]
-#[panic_handler]
-fn panic(_info: &core::panic::PanicInfo<'_>) -> ! {
-    loop {}
 }

--- a/test-suit/arceos/rust/Cargo.toml
+++ b/test-suit/arceos/rust/Cargo.toml
@@ -6,7 +6,6 @@ publish = false
 
 [features]
 default = []
-std = []
 # Every kernel test reaches ax-std through this feature, so it owns the ArceOS
 # baseline instead of relying on axbuild to add it for the selected test case.
 ax-std = ["dep:ax-driver", "dep:ax-hal", "dep:ax-std", "ax-std/arceos"]
@@ -41,7 +40,7 @@ fs-basic = ["ax-std", "ax-driver/nvme", "ax-std/alloc", "ax-std/fatfs"]
 debug-backtrace = ["ax-std", "dep:axbacktrace", "ax-std/backtrace"]
 debug-panic-path = ["ax-std", "dep:axbacktrace", "ax-std/backtrace"]
 display-basic = ["ax-std", "ax-driver/virtio-gpu", "dep:embedded-graphics", "ax-std/display"]
-eventfd-epoll = ["ax-std", "ax-std/fd"]
+eventfd-epoll = ["ax-std", "ax-std/fd", "dep:libc"]
 exception-breakpoint = ["ax-std"]
 exception-page-fault = ["ax-std", "ax-std/paging"]
 futex-errno-order = ["ax-std", "dep:libc"]

--- a/test-suit/arceos/rust/README.md
+++ b/test-suit/arceos/rust/README.md
@@ -1,20 +1,59 @@
-# ArceOS Rust Test Suite
+# ArceOS Rust 测试套件
 
-`arceos-test-suit` is the single Rust QEMU test entry for ArceOS. Individual
-tests are crate modules gated by Cargo features, and the `all` feature enables
-the runnable regression set in a deterministic order.
+`arceos-test-suit` 通过真正的 Rust `std` 运行普通功能测试，覆盖标准库到 libc、POSIX 适配层和 ArceOS 的调用链。`src/lib.rs` 的 `SELECTED_TESTS` 按 Cargo feature 登记用例，`src/main.rs` 负责逐项执行、恢复运行器的调度状态和汇总结果。
 
-Run all Rust tests in one QEMU boot:
+## 1. 接口边界
+
+接口选择取决于测试要证明的行为。普通功能优先使用标准库；只有标准库无法表达的 Linux ABI 或内核能力才使用更低层入口。
+
+### 1.1 标准库与 libc
+
+`std` 必须指向工具链提供的标准库，不能通过 `extern crate ax_std as std` 替换。`ax_std` 作为运行时链接依赖提供 libc 符号；`axbuild` 的 `RustStd` 路径选择 musl 目标、链接 ArceOS，并经 `__axstd_std_check_entry` 进入 Rust 标准启动流程。
+
+`task/mutex.rs` 使用 `std::sync::{Mutex, Condvar, Barrier, mpsc}` 检查互斥、通知和数据发布，`task/parallel.rs` 使用标准屏障同步计算线程。`task/tls.rs` 使用 `thread_local!` 检查线程隔离和退出析构，`mem/test.rs` 的对齐分配通过 `std::alloc`，文件、网络、时间及普通线程分别使用 `std::fs`、`std::net`、`std::time` 和 `std::thread`。
+
+`io_mpx/syscalls.rs` 使用 `std::io::pipe` 创建管道，由 `std::fs::File` 管理描述符、读写及关闭。标准库没有 eventfd 和 epoll 接口，因此这些操作使用 `libc` 的函数、常量和 `epoll_event` 布局。`futex.rs` 通过 `libc::syscall` 验证错误优先级，不直接调用 `ax_std::os::libc_compat` 的 Rust 函数。
+
+`std::io::pipe()` 所需的 `pipe2(O_CLOEXEC)` 由 `ax-posix-api::sys_pipe2` 实现，两端及其描述符标志在 fd 表锁内一起安装；容量不足时回收首个槽位，输出数组保持不变。`FileDescriptor` 保存每个 fd 独立的关闭标志，`F_GETFD`、`F_SETFD` 和复制操作读取或更新该状态。目前管道仅支持阻塞字节流和 `O_CLOEXEC`，非阻塞、packet、notification 模式不会被静默接受。
+
+### 1.2 内核专用能力
+
+调度策略、CPU 拓扑、亲和性、IPI、IRQ、WaitQueue、内核定时器、页表、显示硬件和异常恢复使用明确的 `ax_std::os::arceos` 入口。普通 std 线程仍由 ArceOS 的 pthread 实现创建任务，可以与这些 OS 能力共同用于测试；只有需要定制任务资源或生命周期的用例才直接创建内核任务。
+
+`task/pi_mutex.rs` 和 `lockdep/baseline.rs` 保留 OS `Mutex`，因为 PI 捐赠与内核 lockdep 不是 `std::sync::Mutex` 的契约。`task/stack_guard_page.rs` 用 `spawn_raw` 明确创建被测内核栈。`task/scheduler_irq_window.rs` 用带亲和性的内核任务建立排队工作，并让 FIFO 控制器持有准备阶段，避免依赖每个 Fair 任务先取得一次时间片。该专项在四架构 CI 中独立运行，覆盖非 current 任务的亲和性更新和 IRQ 返回的分批调度窗口。`task/pi_mutex.rs` 在 owner 线程内部发布内核 `ThreadId`，不把标准库 `ThreadId` 的数值当作内核标识。
+
+CPU 拓扑测试通过 `cpu_topology_len()` 获取运行时 CPU 数；`std::thread::available_parallelism()` 表达调用者可用并行度，不能代替内核拓扑。`RunnerTaskState` 在每项任务测试后恢复原亲和性和调度策略，防止用例互相影响。
+
+## 2. 运行与判定
+
+所有 ArceOS 构建和运行通过 `cargo xtask` 进行。feature、`test_runner!`、`SELECTED_TESTS` 和构建配置共同决定实际执行内容，不能用缺少运行时的空函数返回成功。
+
+### 2.1 选择用例
+
+默认 Rust 批次运行 `all`，并按发现器安排需要独立调度配置的用例。可以先通过 `--list` 核对可选 feature，再用 `--test-case` 定向运行。
 
 ```bash
-cargo xtask arceos test qemu --test-group rust --target x86_64-unknown-none
+cargo xtask arceos test qemu --test-group rust --arch riscv64 --list
+cargo xtask arceos test qemu --test-group rust --arch riscv64
+cargo xtask arceos test qemu --test-group rust --arch riscv64 --test-case task-mutex
 ```
 
-Run one test feature:
+`--test-case` 使用 feature 名称。测试通过不只要求程序退出正常，还要求运行器匹配对应成功标志。
 
-```bash
-cargo xtask arceos test qemu --test-group rust --test-case task-yield --target x86_64-unknown-none
-```
+### 2.2 回归证据
 
-The old per-test Rust crates and `--package` selection are intentionally
-removed. Use `--test-case` with the feature name printed by `--list`.
+`main.rs` 为每项测试输出 `ARCEOS_TEST_BEGIN` 和 `ARCEOS_TEST_END`，全部成功后输出 `ArceOS test suite run OK!`。测试失败或 panic 必须传播为最外层 `xtask` 的非零退出码，预期异常和 lockdep 检测则使用发现器配置的专用判定规则。
+
+`lockdep/baseline.rs` 的双线程自旋锁测试在释放 A、B 后才发布完成阶段，并在发布前检查两把锁已释放。工作线程持有 A、B 时提前通知，不能保证另一线程取得 B 后也能取得 A；恢复该错误顺序时，前置断言会确定性失败。
+
+## 3. 其他测试入口
+
+`test-suit/arceos` 还包含直接验证 C ABI 和硬件行为的测试。选择 std 是为了覆盖实际调用边界，不应删除这些入口的独立职责。
+
+### 3.1 C 接口
+
+`../c` 通过 musl 与 `ax-libc` 验证 malloc、pthread、时间、管道、epoll 和 socket 的 C/POSIX 语义。它与 Rust std suite 覆盖不同的消费者入口，继续保留 C harness 和 `ARCEOS_C_TEST_*` 判定。
+
+### 3.2 平台与板卡
+
+`../loongarch/unaligned-fixup` 使用标准 Rust 启动入口，异常表修复仍调用架构 helper。`../board-orangepi-5-plus/ipi` 复用 Rust suite 的 IPI/SMP feature。`../axtest/sg2002-usb-msc` 保留 no_std 硬件 harness，直接检查 USB、IRQ、DMA 和传输完成；其中的纯逻辑模块可以通过宿主单元测试验证，但不能替代实体板卡运行。

--- a/test-suit/arceos/rust/src/display/basic/display.rs
+++ b/test-suit/arceos/rust/src/display/basic/display.rs
@@ -1,5 +1,4 @@
-use std::os::arceos::api::display as api;
-
+use ax_std::os::arceos::api::display as api;
 use embedded_graphics::{
     draw_target::DrawTarget,
     pixelcolor::Rgb888,

--- a/test-suit/arceos/rust/src/exception/page_fault.rs
+++ b/test-suit/arceos/rust/src/exception/page_fault.rs
@@ -1,23 +1,16 @@
-use std::{
-    io::{self, Write},
-    os::arceos::modules::ax_hal,
-    println,
-};
-
 use ax_hal::{
     mem::VirtAddr,
     trap::{PageFaultFlags, set_page_fault_handler},
 };
+use ax_std::os::arceos::modules::{ax_hal, ax_runtime::emergency_console};
 
 fn handle_page_fault(vaddr: VirtAddr, access_flags: PageFaultFlags) -> bool {
-    println!(
-        "Page fault @ {:#x}, access_flags: {:?}",
+    // This handler terminates the machine from exception context. std output
+    // can still be queued to the serial worker when power is cut.
+    emergency_console::write_fmt(format_args!(
+        "Page fault @ {:#x}, access_flags: {:?}\nPage fault test OK!\n",
         vaddr, access_flags
-    );
-    println!("Page fault test OK!");
-    io::stdout()
-        .flush()
-        .expect("failed to flush page fault test output");
+    ));
     ax_hal::power::system_off();
 }
 

--- a/test-suit/arceos/rust/src/fs/basic.rs
+++ b/test-suit/arceos/rust/src/fs/basic.rs
@@ -40,7 +40,7 @@ pub fn run() -> crate::TestResult {
 
     env::set_current_dir(DIR).expect("failed to change into fs smoke directory");
     let current_dir = env::current_dir().expect("failed to read changed current dir");
-    assert_eq!(normalize_dir_path(&current_dir), DIR);
+    assert_eq!(current_dir, std::path::Path::new(DIR));
     assert_eq!(
         fs::read_to_string("basic.txt").expect("failed to read relative fs smoke file"),
         CONTENT
@@ -61,16 +61,10 @@ fn sorted_dir_entries(path: &str) -> Vec<String> {
             entry
                 .expect("failed to read fs smoke directory entry")
                 .file_name()
+                .into_string()
+                .expect("test entry name must be UTF-8")
         })
         .collect::<Vec<_>>();
     entries.sort();
     entries
-}
-
-fn normalize_dir_path(path: &str) -> &str {
-    if path == "/" {
-        path
-    } else {
-        path.trim_end_matches('/')
-    }
 }

--- a/test-suit/arceos/rust/src/futex.rs
+++ b/test-suit/arceos/rust/src/futex.rs
@@ -1,8 +1,8 @@
-use core::ptr;
+use std::{io, ptr};
 
 use crate::TestResult;
 
-const FUTEX_WAIT: libc::c_long = 0;
+const FUTEX_WAIT: libc::c_long = libc::FUTEX_WAIT as libc::c_long;
 
 pub fn run() -> TestResult {
     let mut word = 1_u32;
@@ -17,7 +17,7 @@ pub fn run() -> TestResult {
             tv_nsec: 1_000_000_000,
         },
     ] {
-        let (result, errno) = futex_wait(&raw mut word, 0, &raw const timeout);
+        let (result, errno) = futex_wait(&mut word, 0, &timeout);
         if result != -1 || errno != libc::EAGAIN {
             return Err("value mismatch must return EAGAIN before validating timeout");
         }
@@ -28,7 +28,7 @@ pub fn run() -> TestResult {
         tv_sec: 0,
         tv_nsec: 1_000_000_000,
     };
-    let (result, errno) = futex_wait(&raw mut word, 0, &raw const invalid_timeout);
+    let (result, errno) = futex_wait(&mut word, 0, &invalid_timeout);
     if result != -1 || errno != libc::EINVAL {
         return Err("matching value with invalid timeout must return EINVAL");
     }
@@ -37,22 +37,28 @@ pub fn run() -> TestResult {
 }
 
 fn futex_wait(
-    word: *mut u32,
+    word: &mut u32,
     expected: u32,
-    timeout: *const libc::timespec,
+    timeout: &libc::timespec,
 ) -> (libc::c_long, libc::c_int) {
-    let errno = unsafe { std::os::libc_compat::__errno_location() };
-    unsafe { errno.write(0) };
+    // SAFETY: word and timeout are initialized, correctly aligned objects
+    // borrowed for this synchronous call. Invalid timespec fields deliberately
+    // exercise validation; neither address is retained after the failed wait.
     let result = unsafe {
-        std::os::libc_compat::syscall(
+        libc::syscall(
             libc::SYS_futex,
-            word.addr() as libc::c_long,
+            ptr::from_mut(word).addr() as libc::c_long,
             FUTEX_WAIT,
             expected as libc::c_long,
-            timeout.addr() as libc::c_long,
+            ptr::from_ref(timeout).addr() as libc::c_long,
             0,
             0,
         )
     };
-    (result, unsafe { ptr::read(errno) })
+    (
+        result,
+        io::Error::last_os_error()
+            .raw_os_error()
+            .expect("futex failure must preserve errno"),
+    )
 }

--- a/test-suit/arceos/rust/src/io_mpx/epoll.rs
+++ b/test-suit/arceos/rust/src/io_mpx/epoll.rs
@@ -11,21 +11,14 @@
 //! it is naturally aligned (16-byte struct). `epoll_wait` is always called
 //! with `timeout = 0` so the test never blocks in the cooperative scheduler.
 
-use core::ffi::c_int;
-use std::println;
+use std::{os::fd::AsRawFd, println};
+
+use libc::{EFD_NONBLOCK, EPOLL_CLOEXEC};
 
 use super::syscalls::{self, EpollEvent, assert_errno};
-
-const EFD_NONBLOCK: c_int = 0o4000;
-/// `EPOLL_CLOEXEC` = `O_CLOEXEC`.
-const EPOLL_CLOEXEC: c_int = 0o2000000;
-const EPOLLIN: u32 = 0x001;
-const EPOLLOUT: u32 = 0x004;
-const EPOLL_CTL_ADD: c_int = 1;
-const EPOLL_CTL_DEL: c_int = 2;
-
-const EEXIST: c_int = 17;
-const EINVAL: c_int = 22;
+const EPOLLIN: u32 = libc::EPOLLIN as u32;
+const EPOLLOUT: u32 = libc::EPOLLOUT as u32;
+use libc::{EEXIST, EINVAL, EPOLL_CTL_ADD, EPOLL_CTL_DEL};
 
 /// Opaque token carried through `epoll_event.data` to prove passthrough.
 const DATA_TOKEN: u64 = 0xdead_beef;
@@ -38,7 +31,7 @@ fn test_create_rejects_unknown_flags() {
     );
     let epfd = syscalls::epoll_create1(EPOLL_CLOEXEC).expect("epoll_create1(EPOLL_CLOEXEC) failed");
     assert!(
-        epfd.as_raw() >= 0,
+        epfd.as_raw_fd() >= 0,
         "epoll_create1(EPOLL_CLOEXEC) returned an invalid fd"
     );
 }
@@ -49,12 +42,12 @@ fn test_eventfd_roundtrip_via_epoll() {
 
     let mut interest = EpollEvent {
         events: EPOLLIN,
-        data: DATA_TOKEN,
+        u64: DATA_TOKEN,
     };
     syscalls::epoll_ctl(&epfd, EPOLL_CTL_ADD, &fd, Some(&mut interest))
         .expect("epoll_ctl ADD failed");
 
-    let mut ready = [EpollEvent::default(); 4];
+    let mut ready = [EpollEvent { events: 0, u64: 0 }; 4];
     assert_eq!(
         syscalls::epoll_wait(&epfd, &mut ready, 0).unwrap(),
         0,
@@ -74,7 +67,7 @@ fn test_eventfd_roundtrip_via_epoll() {
         "reported event must carry EPOLLIN"
     );
     assert_eq!(
-        ready[0].data(),
+        { ready[0].u64 },
         DATA_TOKEN,
         "epoll_event.data must round-trip the registered value"
     );
@@ -108,7 +101,7 @@ fn test_epoll_ctl_on_non_epoll_fd_is_einval() {
     let fd = syscalls::eventfd(0, EFD_NONBLOCK).expect("eventfd failed");
     let mut interest = EpollEvent {
         events: EPOLLIN,
-        data: 0,
+        u64: 0,
     };
     assert_errno(
         syscalls::epoll_ctl(&fd, EPOLL_CTL_ADD, &fd, Some(&mut interest)),
@@ -134,12 +127,12 @@ fn test_full_counter_writability_via_epoll() {
 
     let mut interest = EpollEvent {
         events: EPOLLOUT,
-        data: 0,
+        u64: 0,
     };
     syscalls::epoll_ctl(&epfd, EPOLL_CTL_ADD, &fd, Some(&mut interest))
         .expect("epoll_ctl ADD EPOLLOUT failed");
 
-    let mut ready = [EpollEvent::default(); 4];
+    let mut ready = [EpollEvent { events: 0, u64: 0 }; 4];
     assert_eq!(
         syscalls::epoll_wait(&epfd, &mut ready, 0).unwrap(),
         0,

--- a/test-suit/arceos/rust/src/io_mpx/eventfd.rs
+++ b/test-suit/arceos/rust/src/io_mpx/eventfd.rs
@@ -1,4 +1,4 @@
-//! `eventfd` unit tests.
+//! `eventfd` ABI tests.
 //!
 //! These exercise the Linux `eventfd(2)` semantics implemented by
 //! `ax-posix-api`'s `EventFd`:
@@ -17,38 +17,25 @@
 //! All fds are created nonblocking where an empty-counter read is expected, so
 //! no test ever blocks in the cooperative scheduler.
 
-use core::ffi::c_int;
-use std::println;
+use std::{os::fd::AsRawFd, println};
+
+use libc::{EAGAIN, EFD_CLOEXEC, EFD_NONBLOCK, EFD_SEMAPHORE, EINVAL};
 
 use super::syscalls::{self, EpollEvent, assert_errno};
 
-/// `EFD_SEMAPHORE` = 1.
-const EFD_SEMAPHORE: c_int = 1;
-/// `EFD_CLOEXEC` = `O_CLOEXEC` = 02000000 octal = 0x80000.
-const EFD_CLOEXEC: c_int = 0o2000000;
-/// `EFD_NONBLOCK` = `O_NONBLOCK` = 04000 octal = 0x800.
-const EFD_NONBLOCK: c_int = 0o4000;
-
-const EINVAL: c_int = 22;
-const EAGAIN: c_int = 11;
-
-/// `EPOLLIN` = 0x001.
-const EPOLLIN: u32 = 0x001;
-/// `EPOLLOUT` = 0x004.
-const EPOLLOUT: u32 = 0x004;
-/// `EPOLLET` = `1 << 31`, requesting edge-triggered delivery.
-const EPOLLET: u32 = 1 << 31;
-/// `EPOLL_CTL_ADD` = 1.
-const EPOLL_CTL_ADD: c_int = 1;
+const EPOLLIN: u32 = libc::EPOLLIN as u32;
+const EPOLLOUT: u32 = libc::EPOLLOUT as u32;
+const EPOLLET: u32 = libc::EPOLLET as u32;
+use libc::EPOLL_CTL_ADD;
 
 fn test_create_and_flag_validation() {
     let fd = syscalls::eventfd(0, 0).expect("eventfd(0, 0) failed");
-    assert!(fd.as_raw() >= 0, "eventfd(0, 0) returned an invalid fd");
+    assert!(fd.as_raw_fd() >= 0, "eventfd(0, 0) returned an invalid fd");
 
     let fd = syscalls::eventfd(0, EFD_SEMAPHORE | EFD_CLOEXEC | EFD_NONBLOCK)
         .expect("eventfd with all supported flags failed");
     assert!(
-        fd.as_raw() >= 0,
+        fd.as_raw_fd() >= 0,
         "eventfd with all supported flags returned an invalid fd"
     );
 
@@ -206,12 +193,12 @@ fn test_every_write_is_a_readiness_edge() {
 
     let mut interest = EpollEvent {
         events: EPOLLIN | EPOLLET,
-        data: 0,
+        u64: 0,
     };
     syscalls::epoll_ctl(&epfd, EPOLL_CTL_ADD, &fd, Some(&mut interest))
         .expect("epoll_ctl ADD failed");
 
-    let mut ready = [EpollEvent::default(); 4];
+    let mut ready = [EpollEvent { events: 0, u64: 0 }; 4];
 
     // First write: the counter goes 0 -> 1, so the fd becomes readable. This
     // edge is reported whether or not readiness tracks the readability flip.
@@ -268,7 +255,7 @@ fn test_saturated_read_is_a_writable_edge() {
 
     let mut interest = EpollEvent {
         events: EPOLLOUT | EPOLLET,
-        data: 0,
+        u64: 0,
     };
     syscalls::epoll_ctl(&epfd, EPOLL_CTL_ADD, &fd, Some(&mut interest))
         .expect("epoll_ctl ADD failed");
@@ -280,7 +267,7 @@ fn test_saturated_read_is_a_writable_edge() {
         8,
         "write must return 8"
     );
-    let mut ready = [EpollEvent::default(); 4];
+    let mut ready = [EpollEvent { events: 0, u64: 0 }; 4];
     assert_eq!(
         syscalls::epoll_wait(&epfd, &mut ready, 0).unwrap(),
         0,
@@ -323,14 +310,14 @@ fn test_write_does_not_spoof_writable_edge() {
 
     let mut interest = EpollEvent {
         events: EPOLLOUT | EPOLLET,
-        data: 0,
+        u64: 0,
     };
     syscalls::epoll_ctl(&epfd, EPOLL_CTL_ADD, &fd, Some(&mut interest))
         .expect("epoll_ctl ADD failed");
 
     // The freshly created counter is writable (0 < u64::MAX - 1), so the
     // initial writable edge is reported and consumed.
-    let mut ready = [EpollEvent::default(); 4];
+    let mut ready = [EpollEvent { events: 0, u64: 0 }; 4];
     assert_eq!(
         syscalls::epoll_wait(&epfd, &mut ready, 0).unwrap(),
         1,
@@ -374,13 +361,13 @@ fn test_writable_edge_between_waits_is_reported() {
 
     let mut interest = EpollEvent {
         events: EPOLLOUT | EPOLLET,
-        data: 0,
+        u64: 0,
     };
     syscalls::epoll_ctl(&epfd, EPOLL_CTL_ADD, &fd, Some(&mut interest))
         .expect("epoll_ctl ADD failed");
 
     // The counter starts writable, so the initial edge is reported and consumed.
-    let mut ready = [EpollEvent::default(); 4];
+    let mut ready = [EpollEvent { events: 0, u64: 0 }; 4];
     assert_eq!(
         syscalls::epoll_wait(&epfd, &mut ready, 0).unwrap(),
         1,
@@ -434,12 +421,12 @@ fn test_write_stream_delivers_every_wake() {
 
     let mut interest = EpollEvent {
         events: EPOLLIN | EPOLLET,
-        data: 0,
+        u64: 0,
     };
     syscalls::epoll_ctl(&epfd, EPOLL_CTL_ADD, &fd, Some(&mut interest))
         .expect("epoll_ctl ADD failed");
 
-    let mut ready = [EpollEvent::default(); 4];
+    let mut ready = [EpollEvent { events: 0, u64: 0 }; 4];
     for i in 0..WAKES {
         assert_eq!(
             syscalls::write_u64(&fd, 1).unwrap(),
@@ -469,6 +456,6 @@ pub fn run() -> crate::TestResult {
     test_writable_edge_between_waits_is_reported();
     test_write_does_not_spoof_writable_edge();
     test_write_stream_delivers_every_wake();
-    println!("io_mpx: eventfd unit tests OK");
+    println!("io_mpx: eventfd ABI tests OK");
     Ok(())
 }

--- a/test-suit/arceos/rust/src/io_mpx/mod.rs
+++ b/test-suit/arceos/rust/src/io_mpx/mod.rs
@@ -1,7 +1,8 @@
-//! I/O multiplexing primitives: `eventfd` and `pipe` unit tests plus an
+//! I/O multiplexing primitives: `eventfd` and `pipe` ABI tests plus an
 //! `epoll` smoke test. These cover the syscall surface that async runtimes
 //! (e.g. tokio/mio) need to drive timers and wake-ups on ArceOS.
 
+use std::os::fd::AsRawFd;
 mod epoll;
 mod eventfd;
 mod pipe;
@@ -9,14 +10,14 @@ mod syscalls;
 
 pub fn run() -> crate::TestResult {
     let baseline = syscalls::eventfd(0, 0).expect("failed to probe the baseline fd slot");
-    let baseline_slot = baseline.as_raw();
+    let baseline_slot = baseline.as_raw_fd();
     drop(baseline);
     pipe::run()?;
     eventfd::run()?;
     epoll::run()?;
     let after = syscalls::eventfd(0, 0).expect("failed to probe the final fd slot");
     assert_eq!(
-        after.as_raw(),
+        after.as_raw_fd(),
         baseline_slot,
         "eventfd/pipe/epoll tests must release every fd they allocate"
     );

--- a/test-suit/arceos/rust/src/io_mpx/pipe.rs
+++ b/test-suit/arceos/rust/src/io_mpx/pipe.rs
@@ -1,4 +1,4 @@
-//! `pipe` + `epoll` unit tests.
+//! `pipe` + `epoll` ABI tests.
 //!
 //! These cover the write-end readiness contract that an edge-triggered
 //! `EPOLLOUT` watcher relies on:
@@ -13,22 +13,116 @@
 //! fill loop probes writability with a level-triggered `EPOLLOUT` watch on a
 //! throwaway epoll instance instead of assuming a pipe capacity.
 
-use core::ffi::c_int;
-use std::println;
+use std::{
+    fs::File,
+    io::{self, Read, Write},
+    os::fd::{AsRawFd, FromRawFd, OwnedFd},
+    println,
+};
 
 use super::syscalls::{self, EpollEvent};
 
-/// `EPOLLOUT` = 0x004.
-const EPOLLOUT: u32 = 0x004;
-/// `EPOLLET` = `1 << 31`, requesting edge-triggered delivery.
-const EPOLLET: u32 = 1 << 31;
-/// `EPOLL_CTL_ADD` = 1.
-const EPOLL_CTL_ADD: c_int = 1;
-/// `EPOLL_CTL_DEL` = 2.
-const EPOLL_CTL_DEL: c_int = 2;
+const EPOLLOUT: u32 = libc::EPOLLOUT as u32;
+const EPOLLET: u32 = libc::EPOLLET as u32;
+use libc::{EPOLL_CTL_ADD, EPOLL_CTL_DEL};
 
 /// Upper bound for the fill loop: the probe stops as soon as the pipe is full.
 const PIPE_FILL_LIMIT: usize = 4096;
+
+fn test_std_pipe_descriptor_flags_and_io() {
+    let (mut reader, mut writer) = io::pipe().expect("std pipe creation failed");
+    for fd in [reader.as_raw_fd(), writer.as_raw_fd()] {
+        // SAFETY: each descriptor is owned by a live pipe endpoint; F_GETFD
+        // only reads descriptor metadata and takes no pointer argument.
+        let flags = unsafe { libc::fcntl(fd, libc::F_GETFD) };
+        assert_eq!(
+            flags,
+            libc::FD_CLOEXEC,
+            "std pipe must set CLOEXEC on both ends"
+        );
+    }
+    writer.write_all(b"std pipe through libc").unwrap();
+    drop(writer);
+    let mut message = String::new();
+    reader.read_to_string(&mut message).unwrap();
+    assert_eq!(message, "std pipe through libc");
+}
+
+fn test_pipe2_rejects_flags_without_creating_descriptors() {
+    let mut fds = [-1; 2];
+    // SAFETY: fds has room for the two output descriptors. The deliberately
+    // invalid flag must fail before publishing either descriptor.
+    assert_eq!(unsafe { libc::pipe2(fds.as_mut_ptr(), -1) }, -1);
+    assert_eq!(
+        io::Error::last_os_error().raw_os_error(),
+        Some(libc::EINVAL)
+    );
+    assert_eq!(fds, [-1; 2]);
+}
+
+fn test_descriptor_flags_are_not_shared_by_duplicates() {
+    let (reader, _writer) = io::pipe().unwrap();
+    let reader = File::from(OwnedFd::from(reader));
+    let duplicate = reader.try_clone().unwrap();
+    // SAFETY: both descriptors remain owned by their File objects. These
+    // fcntl commands only inspect or change per-descriptor scalar flags.
+    unsafe {
+        assert_eq!(
+            libc::fcntl(duplicate.as_raw_fd(), libc::F_GETFD),
+            libc::FD_CLOEXEC
+        );
+        assert_eq!(libc::fcntl(reader.as_raw_fd(), libc::F_SETFD, 0), 0);
+        assert_eq!(libc::fcntl(reader.as_raw_fd(), libc::F_GETFD), 0);
+        assert_eq!(
+            libc::fcntl(duplicate.as_raw_fd(), libc::F_GETFD),
+            libc::FD_CLOEXEC
+        );
+    }
+    // SAFETY: F_DUPFD creates a new descriptor at or above the requested
+    // minimum. A successful return transfers its sole ownership to File.
+    let fd = unsafe { libc::fcntl(reader.as_raw_fd(), libc::F_DUPFD, 64) };
+    assert!(fd >= 64);
+    // SAFETY: fd is the freshly created descriptor checked above.
+    let high = unsafe { File::from_raw_fd(fd) };
+    // SAFETY: high owns a live descriptor and F_GETFD has no pointer arguments.
+    assert_eq!(unsafe { libc::fcntl(high.as_raw_fd(), libc::F_GETFD) }, 0);
+}
+
+fn test_pipe2_rolls_back_when_only_one_fd_is_free() {
+    let mut occupied = Vec::new();
+    loop {
+        match syscalls::eventfd(0, 0) {
+            Ok(fd) => occupied.push(fd),
+            Err(errno) => {
+                assert_eq!(errno, libc::EMFILE);
+                break;
+            }
+        }
+        assert!(
+            occupied.len() < 4096,
+            "fd exhaustion probe exceeded its bound"
+        );
+    }
+    let freed = occupied
+        .pop()
+        .expect("the test must have allocated a descriptor");
+    let slot = freed.as_raw_fd();
+    drop(freed);
+    let mut fds = [-1; 2];
+    // SAFETY: fds provides two writable output slots; a single available
+    // table slot must cause failure without publishing or leaking either fd.
+    assert_eq!(
+        unsafe { libc::pipe2(fds.as_mut_ptr(), libc::O_CLOEXEC) },
+        -1
+    );
+    assert_eq!(
+        io::Error::last_os_error().raw_os_error(),
+        Some(libc::EMFILE)
+    );
+    assert_eq!(fds, [-1; 2]);
+    let recovered = syscalls::eventfd(0, 0).expect("failed pipe must return its reserved slot");
+    assert_eq!(recovered.as_raw_fd(), slot);
+}
 
 fn test_write_end_is_writable_until_full() {
     // This test only exercises the write end; the read end is never drained.
@@ -37,13 +131,13 @@ fn test_write_end_is_writable_until_full() {
     let epfd = syscalls::epoll_create1(0).expect("epoll_create1(0) failed");
     let mut interest = EpollEvent {
         events: EPOLLOUT,
-        data: 0,
+        u64: 0,
     };
     syscalls::epoll_ctl(&epfd, EPOLL_CTL_ADD, &write_fd, Some(&mut interest))
         .expect("epoll_ctl ADD failed");
 
     // Level-triggered: the write end must stay reportable while space remains.
-    let mut ready = [EpollEvent::default(); 4];
+    let mut ready = [EpollEvent { events: 0, u64: 0 }; 4];
     for i in 0..PIPE_FILL_LIMIT {
         let n = syscalls::epoll_wait(&epfd, &mut ready, 0).expect("epoll_wait failed");
         if n == 0 {
@@ -77,13 +171,13 @@ fn test_writable_edge_between_waits_is_reported() {
 
     let mut interest = EpollEvent {
         events: EPOLLOUT | EPOLLET,
-        data: 0,
+        u64: 0,
     };
     syscalls::epoll_ctl(&epfd, EPOLL_CTL_ADD, &write_fd, Some(&mut interest))
         .expect("epoll_ctl ADD failed");
 
     // The write end starts writable, so the initial edge is reported once.
-    let mut ready = [EpollEvent::default(); 4];
+    let mut ready = [EpollEvent { events: 0, u64: 0 }; 4];
     assert_eq!(
         syscalls::epoll_wait(&epfd, &mut ready, 0).unwrap(),
         1,
@@ -100,7 +194,7 @@ fn test_writable_edge_between_waits_is_reported() {
     let probe = syscalls::epoll_create1(0).expect("epoll_create1(0) failed");
     let mut probe_interest = EpollEvent {
         events: EPOLLOUT,
-        data: 0,
+        u64: 0,
     };
     syscalls::epoll_ctl(&probe, EPOLL_CTL_ADD, &write_fd, Some(&mut probe_interest))
         .expect("epoll_ctl ADD on probe failed");
@@ -141,8 +235,12 @@ fn test_writable_edge_between_waits_is_reported() {
 }
 
 pub fn run() -> crate::TestResult {
+    test_std_pipe_descriptor_flags_and_io();
+    test_pipe2_rejects_flags_without_creating_descriptors();
+    test_descriptor_flags_are_not_shared_by_duplicates();
+    test_pipe2_rolls_back_when_only_one_fd_is_free();
     test_write_end_is_writable_until_full();
     test_writable_edge_between_waits_is_reported();
-    println!("io_mpx: pipe unit tests OK");
+    println!("io_mpx: pipe ABI tests OK");
     Ok(())
 }

--- a/test-suit/arceos/rust/src/io_mpx/syscalls.rs
+++ b/test-suit/arceos/rust/src/io_mpx/syscalls.rs
@@ -1,165 +1,100 @@
-//! Raw syscall shims for the eventfd/epoll tests.
+//! Standard file ownership and I/O with libc's Linux eventfd/epoll ABI.
 //!
-//! `ax_std` exposes `eventfd`, `epoll_create1`, `epoll_ctl`, `epoll_wait`,
-//! `read`, `write`, and `close` as `#[no_mangle]` `extern "C"` symbols in
-//! `ax_std::os::libc_compat`. The test crate declares them here with plain C
-//! ABI types (the layout is erased at link time), so the tests can call them
-//! without depending on the `libc` crate. Error results follow the Linux
-//! convention: `-1` and the global `errno` set to the error code.
+//! std has no eventfd or epoll interface. Those operations use libc types and
+//! symbols; pipe creation, reads, writes, errno and descriptor lifetime use std.
 
-use core::{ffi::c_int, ptr};
+use std::{
+    fs::File,
+    io::{self, Read, Write},
+    os::fd::{AsRawFd, FromRawFd, OwnedFd},
+    ptr,
+};
 
-/// Linux `struct epoll_event` ABI. On x86_64 the `data` field is packed to
-/// offset 4 (12-byte struct); on other architectures it is naturally aligned
-/// (16-byte struct). Must match `ax-posix-api`'s bindgen `epoll_event`.
-#[cfg(target_arch = "x86_64")]
-#[repr(C, packed)]
-#[derive(Clone, Copy, Default)]
-pub struct EpollEvent {
-    pub events: u32,
-    pub data: u64,
+use libc::c_int;
+pub use libc::epoll_event as EpollEvent;
+
+fn errno(error: io::Error) -> c_int {
+    error
+        .raw_os_error()
+        .expect("libc I/O errors must preserve errno")
 }
 
-#[cfg(not(target_arch = "x86_64"))]
-#[repr(C)]
-#[derive(Clone, Copy, Default)]
-pub struct EpollEvent {
-    pub events: u32,
-    pub data: u64,
-}
-
-impl EpollEvent {
-    /// Reads `data`, which may be unaligned on x86_64 (packed layout).
-    pub fn data(&self) -> u64 {
-        unsafe { ptr::read_unaligned(ptr::addr_of!(self.data)) }
-    }
-}
-
-/// The `#[no_mangle]` symbols provided by `ax_std::os::libc_compat`.
-mod raw {
-    use core::ffi::{c_int, c_void};
-
-    use super::EpollEvent;
-
-    unsafe extern "C" {
-        pub(super) fn eventfd(initval: u32, flags: c_int) -> c_int;
-        pub(super) fn pipe(pipefd: *mut c_int) -> c_int;
-        pub(super) fn epoll_create1(flags: c_int) -> c_int;
-        pub(super) fn epoll_ctl(epfd: c_int, op: c_int, fd: c_int, event: *mut EpollEvent)
-        -> c_int;
-        pub(super) fn epoll_wait(
-            epfd: c_int,
-            events: *mut EpollEvent,
-            maxevents: c_int,
-            timeout: c_int,
-        ) -> c_int;
-        pub(super) fn read(fd: c_int, buf: *mut c_void, count: usize) -> isize;
-        pub(super) fn write(fd: c_int, buf: *const c_void, count: usize) -> isize;
-        pub(super) fn close(fd: c_int) -> c_int;
-        pub(super) fn __errno_location() -> *mut c_int;
-    }
-}
-
-/// The `errno` set by the libc-compat layer on failure.
-fn last_errno() -> c_int {
-    unsafe { *raw::__errno_location() }
-}
-
-fn fd_syscall(result: c_int) -> Result<c_int, c_int> {
+fn fd_result(result: c_int) -> Result<c_int, c_int> {
     if result < 0 {
-        Err(last_errno())
+        Err(errno(io::Error::last_os_error()))
     } else {
         Ok(result)
     }
 }
 
-fn io_syscall(result: isize) -> Result<usize, c_int> {
-    if result < 0 {
-        Err(last_errno())
-    } else {
-        Ok(result as usize)
-    }
+fn owned_file(result: c_int) -> Result<File, c_int> {
+    let fd = fd_result(result)?;
+    // SAFETY: a successful descriptor-creating call returns a fresh fd. File
+    // takes its sole ownership and closes it when the test releases it.
+    Ok(unsafe { File::from_raw_fd(fd) })
 }
 
-/// One test-owned descriptor, closed exactly once when its scope ends.
-#[derive(Debug)]
-pub struct OwnedFd(c_int);
-
-impl OwnedFd {
-    pub fn as_raw(&self) -> c_int {
-        self.0
-    }
+pub fn eventfd(initval: u32, flags: c_int) -> Result<File, c_int> {
+    // SAFETY: eventfd takes scalar values and returns a new descriptor.
+    owned_file(unsafe { libc::eventfd(initval, flags) })
 }
 
-impl Drop for OwnedFd {
-    fn drop(&mut self) {
-        // SAFETY: `OwnedFd` is constructed only from a successful descriptor
-        // creation and cannot be cloned, so this is its unique close.
-        if let Err(errno) = fd_syscall(unsafe { raw::close(self.0) }) {
-            panic!("failed to close test fd {}: errno {errno}", self.0);
-        }
-    }
+pub fn pipe() -> Result<(File, File), c_int> {
+    let (reader, writer) = io::pipe().map_err(errno)?;
+    Ok((
+        File::from(OwnedFd::from(reader)),
+        File::from(OwnedFd::from(writer)),
+    ))
 }
 
-pub fn eventfd(initval: u32, flags: c_int) -> Result<OwnedFd, c_int> {
-    fd_syscall(unsafe { raw::eventfd(initval, flags) }).map(OwnedFd)
-}
-
-/// Creates a pipe and returns its uniquely owned read and write descriptors.
-pub fn pipe() -> Result<(OwnedFd, OwnedFd), c_int> {
-    let mut fds = [0 as c_int; 2];
-    fd_syscall(unsafe { raw::pipe(fds.as_mut_ptr()) })?;
-    Ok((OwnedFd(fds[0]), OwnedFd(fds[1])))
-}
-
-pub fn epoll_create1(flags: c_int) -> Result<OwnedFd, c_int> {
-    fd_syscall(unsafe { raw::epoll_create1(flags) }).map(OwnedFd)
+pub fn epoll_create1(flags: c_int) -> Result<File, c_int> {
+    // SAFETY: epoll_create1 takes a scalar flag value and returns a new fd.
+    owned_file(unsafe { libc::epoll_create1(flags) })
 }
 
 pub fn epoll_ctl(
-    epfd: &OwnedFd,
+    epfd: &File,
     op: c_int,
-    fd: &OwnedFd,
+    fd: &File,
     event: Option<&mut EpollEvent>,
 ) -> Result<c_int, c_int> {
-    let ptr = event.map_or(ptr::null_mut(), |event| event as *mut EpollEvent);
-    fd_syscall(unsafe { raw::epoll_ctl(epfd.as_raw(), op, fd.as_raw(), ptr) })
+    let event = event.map_or(ptr::null_mut(), ptr::from_mut);
+    // SAFETY: both files stay alive for the call; event is either null for DEL
+    // or a uniquely borrowed initialized libc epoll_event of the target ABI.
+    fd_result(unsafe { libc::epoll_ctl(epfd.as_raw_fd(), op, fd.as_raw_fd(), event) })
 }
 
-pub fn epoll_wait(
-    epfd: &OwnedFd,
-    events: &mut [EpollEvent],
-    timeout: c_int,
-) -> Result<c_int, c_int> {
-    fd_syscall(unsafe {
-        raw::epoll_wait(
-            epfd.as_raw(),
-            events.as_mut_ptr(),
-            events.len() as c_int,
-            timeout,
-        )
+pub fn epoll_wait(epfd: &File, events: &mut [EpollEvent], timeout: c_int) -> Result<c_int, c_int> {
+    let maxevents = c_int::try_from(events.len()).expect("epoll test buffer exceeds c_int");
+    // SAFETY: the mutable slice provides maxevents writable, ABI-correct events
+    // and the epoll descriptor remains owned throughout the synchronous call.
+    fd_result(unsafe {
+        libc::epoll_wait(epfd.as_raw_fd(), events.as_mut_ptr(), maxevents, timeout)
     })
 }
 
-pub fn read(fd: &OwnedFd, buf: &mut [u8]) -> Result<usize, c_int> {
-    io_syscall(unsafe { raw::read(fd.as_raw(), buf.as_mut_ptr().cast(), buf.len()) })
+pub fn read(mut fd: &File, buf: &mut [u8]) -> Result<usize, c_int> {
+    fd.read(buf).map_err(errno)
 }
 
-pub fn write(fd: &OwnedFd, buf: &[u8]) -> Result<usize, c_int> {
-    io_syscall(unsafe { raw::write(fd.as_raw(), buf.as_ptr().cast(), buf.len()) })
+pub fn write(mut fd: &File, buf: &[u8]) -> Result<usize, c_int> {
+    fd.write(buf).map_err(errno)
 }
 
-pub fn read_u64(fd: &OwnedFd) -> Result<u64, c_int> {
+pub fn read_u64(fd: &File) -> Result<u64, c_int> {
     let mut buf = [0u8; 8];
-    read(fd, &mut buf)?;
+    assert_eq!(
+        read(fd, &mut buf)?,
+        buf.len(),
+        "eventfd read must return a full counter"
+    );
     Ok(u64::from_ne_bytes(buf))
 }
 
-pub fn write_u64(fd: &OwnedFd, value: u64) -> Result<usize, c_int> {
+pub fn write_u64(fd: &File, value: u64) -> Result<usize, c_int> {
     write(fd, &value.to_ne_bytes())
 }
 
-/// Asserts that a syscall failed with the given errno.
 pub fn assert_errno<T>(result: Result<T, c_int>, expected: c_int, what: &str) {
     match result {
         Err(errno) => assert_eq!(

--- a/test-suit/arceos/rust/src/lib.rs
+++ b/test-suit/arceos/rust/src/lib.rs
@@ -1,8 +1,5 @@
-#![cfg_attr(all(not(test), not(feature = "std")), no_std)]
-#![cfg_attr(feature = "task-tls", feature(thread_local))]
-
 #[cfg(feature = "ax-std")]
-extern crate ax_std as std;
+use ax_std as _;
 
 pub type TestResult = Result<(), &'static str>;
 
@@ -88,11 +85,6 @@ macro_rules! test_runner {
         #[cfg(all(feature = $feature, feature = "ax-std"))]
         fn $runner() -> TestResult {
             $body()
-        }
-
-        #[cfg(all(feature = $feature, not(feature = "ax-std")))]
-        fn $runner() -> TestResult {
-            Ok(())
         }
     };
 }

--- a/test-suit/arceos/rust/src/lockdep/baseline.rs
+++ b/test-suit/arceos/rust/src/lockdep/baseline.rs
@@ -2,14 +2,14 @@ use core::any::Any;
 use std::{
     string::ToString,
     sync::{
-        Arc, Mutex,
+        Arc,
         atomic::{AtomicBool, AtomicUsize, Ordering},
     },
     thread,
     vec::Vec,
 };
 
-use ax_std::os::arceos::sync::SpinLock;
+use ax_std::os::arceos::sync::{Mutex, SpinLock};
 use axfs_ng_vfs::{
     DeviceId, DirEntry, DirEntrySink, DirNode, DirNodeOps, DirectoryCursor, FilesystemOps,
     Metadata, MetadataUpdate, NodeFlags, NodeOps, NodePermission, NodeType, Reference,

--- a/test-suit/arceos/rust/src/lockdep/baseline.rs
+++ b/test-suit/arceos/rust/src/lockdep/baseline.rs
@@ -137,8 +137,20 @@ fn spin_two_task_abba() {
     let thread_stage = stage.clone();
 
     let handle = thread::spawn(move || {
-        let _guard_a = thread_lock_a.lock();
-        let _guard_b = thread_lock_b.lock();
+        {
+            let _guard_a = thread_lock_a.lock();
+            let _guard_b = thread_lock_b.lock();
+        }
+        // The peer cannot touch either lock until stage 1 is published. Check
+        // this precondition here so early publication fails deterministically.
+        assert!(
+            thread_lock_a.try_lock().is_some(),
+            "stage 1 requires spin lock A to be released"
+        );
+        assert!(
+            thread_lock_b.try_lock().is_some(),
+            "stage 1 requires spin lock B to be released"
+        );
         thread_stage.store(1, Ordering::Release);
     });
 

--- a/test-suit/arceos/rust/src/main.rs
+++ b/test-suit/arceos/rust/src/main.rs
@@ -1,20 +1,16 @@
-#![cfg_attr(any(feature = "ax-std", target_os = "none"), no_std)]
-#![cfg_attr(any(feature = "ax-std", target_os = "none"), no_main)]
-
-#[cfg(feature = "ax-std")]
-extern crate ax_std as std;
-
 #[cfg(feature = "ax-std")]
 use std::{println, time::Instant};
 
 #[cfg(feature = "ax-std")]
 use arceos_test_suit::selected_tests;
+#[cfg(feature = "ax-std")]
+use ax_std as _;
 #[cfg(feature = "task-runtime")]
 use {
-    std::os::arceos::task::sched::CpuSet, std::os::arceos::task::sched::SchedulePolicy,
-    std::os::arceos::task::thread::ThreadId,
-    std::os::arceos::task::thread::current::current_thread_id,
-    std::os::arceos::task::thread::current::set_current_thread_affinity,
+    ax_std::os::arceos::task::sched::CpuSet, ax_std::os::arceos::task::sched::SchedulePolicy,
+    ax_std::os::arceos::task::thread::ThreadId,
+    ax_std::os::arceos::task::thread::current::current_thread_id,
+    ax_std::os::arceos::task::thread::current::set_current_thread_affinity,
 };
 
 #[cfg(feature = "task-runtime")]
@@ -28,10 +24,10 @@ struct RunnerTaskState {
 impl RunnerTaskState {
     fn capture() -> Self {
         let thread = current_thread_id().expect("test runner must have a task identity");
-        let affinity = std::os::arceos::task::thread::ThreadHandle::lookup(thread)
+        let affinity = ax_std::os::arceos::task::thread::ThreadHandle::lookup(thread)
             .and_then(|thread| thread.affinity())
             .expect("test runner must have CPU affinity");
-        let policy = std::os::arceos::task::thread::ThreadHandle::lookup(thread)
+        let policy = ax_std::os::arceos::task::thread::ThreadHandle::lookup(thread)
             .map(|thread| thread.base_policy())
             .expect("test runner must have a scheduling policy");
         Self {
@@ -47,15 +43,15 @@ impl RunnerTaskState {
             Ok(self.thread),
             "an ArceOS test must not replace the shared runner task"
         );
-        if std::os::arceos::task::thread::ThreadHandle::lookup(self.thread)
+        if ax_std::os::arceos::task::thread::ThreadHandle::lookup(self.thread)
             .map(|thread| thread.base_policy())
             != Ok(self.policy)
         {
-            std::os::arceos::task::thread::ThreadHandle::lookup(self.thread)
+            ax_std::os::arceos::task::thread::ThreadHandle::lookup(self.thread)
                 .and_then(|thread| thread.set_policy(self.policy))
                 .expect("failed to restore the test runner scheduling policy");
         }
-        if std::os::arceos::task::thread::ThreadHandle::lookup(self.thread)
+        if ax_std::os::arceos::task::thread::ThreadHandle::lookup(self.thread)
             .and_then(|thread| thread.affinity())
             != Ok(self.affinity.clone())
         {
@@ -63,13 +59,13 @@ impl RunnerTaskState {
                 .expect("failed to restore the test runner CPU affinity");
         }
         assert_eq!(
-            std::os::arceos::task::thread::ThreadHandle::lookup(self.thread)
+            ax_std::os::arceos::task::thread::ThreadHandle::lookup(self.thread)
                 .and_then(|thread| thread.affinity()),
             Ok(self.affinity.clone()),
             "an ArceOS test must not leak runner CPU affinity"
         );
         assert_eq!(
-            std::os::arceos::task::thread::ThreadHandle::lookup(self.thread)
+            ax_std::os::arceos::task::thread::ThreadHandle::lookup(self.thread)
                 .map(|thread| thread.base_policy()),
             Ok(self.policy),
             "an ArceOS test must not leak runner scheduling policy"
@@ -77,7 +73,6 @@ impl RunnerTaskState {
     }
 }
 
-#[cfg_attr(feature = "ax-std", unsafe(no_mangle))]
 #[cfg(feature = "ax-std")]
 fn main() {
     let tests = selected_tests();
@@ -125,14 +120,4 @@ fn main() {
 #[cfg(not(feature = "ax-std"))]
 fn main() {
     eprintln!("arceos-test-suit requires an ArceOS feature such as `all` for kernel runs");
-}
-
-#[cfg(all(target_os = "none", not(feature = "ax-std")))]
-#[unsafe(no_mangle)]
-pub extern "C" fn _start() {}
-
-#[cfg(all(target_os = "none", not(feature = "ax-std")))]
-#[panic_handler]
-fn panic(_info: &core::panic::PanicInfo<'_>) -> ! {
-    loop {}
 }

--- a/test-suit/arceos/rust/src/mem/stage1_transition.rs
+++ b/test-suit/arceos/rust/src/mem/stage1_transition.rs
@@ -1,21 +1,5 @@
 use core::{alloc::Layout, ptr::NonNull};
 use std::{
-    os::arceos::api::{
-        mem::{ax_alloc, ax_dealloc},
-        modules::{
-            ax_hal::{
-                mem::{virt_to_phys, virtual_address_space},
-                paging::MappingFlags,
-                percpu::this_cpu_id,
-                trap::{PageFaultFlags, set_page_fault_handler},
-            },
-            ax_runtime::kernel_mapping::{
-                map_kernel_pages, map_kernel_range, protect_kernel_range, query_kernel_mapping,
-                unmap_kernel_range,
-            },
-        },
-        task::{AxCpuMask, ax_set_current_affinity},
-    },
     sync::{
         Arc,
         atomic::{AtomicUsize, Ordering},
@@ -24,6 +8,22 @@ use std::{
 };
 
 use ax_memory_addr::{MemoryAddr, VirtAddr};
+use ax_std::os::arceos::api::{
+    mem::{ax_alloc, ax_dealloc},
+    modules::{
+        ax_hal::{
+            mem::{virt_to_phys, virtual_address_space},
+            paging::MappingFlags,
+            percpu::this_cpu_id,
+            trap::{PageFaultFlags, set_page_fault_handler},
+        },
+        ax_runtime::kernel_mapping::{
+            map_kernel_pages, map_kernel_range, protect_kernel_range, query_kernel_mapping,
+            unmap_kernel_range,
+        },
+    },
+    task::{AxCpuMask, ax_set_current_affinity},
+};
 
 const PAGE_SIZE: usize = 4096;
 const OLD_VALUE: u8 = 0x51;

--- a/test-suit/arceos/rust/src/mem/test.rs
+++ b/test-suit/arceos/rust/src/mem/test.rs
@@ -3,19 +3,9 @@ use core::{
     ptr::{self, NonNull},
     slice,
 };
-#[cfg(target_arch = "loongarch64")]
-use std::os::arceos::api::modules::ax_hal::mem::{phys_to_virt, virtual_address_space};
 use std::{
     collections::BTreeMap,
-    format,
-    os::arceos::{
-        api::{
-            mem::{ax_alloc, ax_dealloc},
-            task::{AxCpuMask, ax_set_current_affinity},
-        },
-        modules::ax_hal::percpu::this_cpu_id,
-    },
-    println,
+    format, println,
     sync::{
         Arc,
         atomic::{AtomicUsize, Ordering},
@@ -24,6 +14,12 @@ use std::{
     vec::Vec,
 };
 
+#[cfg(target_arch = "loongarch64")]
+use ax_std::os::arceos::api::modules::ax_hal::mem::{phys_to_virt, virtual_address_space};
+use ax_std::os::arceos::{
+    api::task::{AxCpuMask, ax_set_current_affinity},
+    modules::ax_hal::percpu::this_cpu_id,
+};
 use rand::{RngCore, SeedableRng, rngs::SmallRng};
 
 const SLAB_LAYOUT_CASES: [LayoutCase; 9] = [
@@ -95,11 +91,12 @@ impl Allocation {
 }
 
 unsafe fn alloc_raw(layout: Layout) -> NonNull<u8> {
-    unsafe { ax_alloc(layout) }.unwrap_or_else(|| panic!("allocation failed for {layout:?}"))
+    NonNull::new(unsafe { std::alloc::alloc(layout) })
+        .unwrap_or_else(|| std::alloc::handle_alloc_error(layout))
 }
 
 unsafe fn dealloc_raw(ptr: NonNull<u8>, layout: Layout) {
-    unsafe { ax_dealloc(ptr, layout) };
+    unsafe { std::alloc::dealloc(ptr.as_ptr(), layout) };
 }
 
 fn allocation_pattern(index: usize, round: usize) -> u8 {

--- a/test-suit/arceos/rust/src/task/affinity.rs
+++ b/test-suit/arceos/rust/src/task/affinity.rs
@@ -1,10 +1,11 @@
 use std::{
-    os::arceos::{
-        api::task::{AxCpuMask, ax_set_current_affinity},
-        modules::ax_hal::percpu::this_cpu_id,
-    },
     sync::atomic::{AtomicUsize, Ordering},
     thread,
+};
+
+use ax_std::os::arceos::{
+    api::task::{AxCpuMask, ax_set_current_affinity},
+    modules::ax_hal::percpu::this_cpu_id,
 };
 
 const NUM_TASKS: usize = 8;
@@ -21,7 +22,7 @@ fn online_cpu_mask(cpu_num: usize) -> AxCpuMask {
 
 pub fn run() -> crate::TestResult {
     FINISHED_TASKS.store(0, Ordering::Release);
-    let available_cpus = thread::available_parallelism().unwrap().get();
+    let available_cpus = ax_std::os::arceos::task::sched::cpu_topology_len().unwrap();
     let mut workers = std::vec::Vec::new();
     for i in 0..NUM_TASKS {
         let cpu_id = i % available_cpus;

--- a/test-suit/arceos/rust/src/task/executor.rs
+++ b/test-suit/arceos/rust/src/task/executor.rs
@@ -4,7 +4,6 @@ use core::{
     task::{Context, Poll, Waker},
 };
 use std::{
-    os::arceos::task::executor::{BlockOnError, block_on, block_on_timeout},
     sync::{
         Arc, Mutex,
         atomic::{AtomicBool, Ordering},
@@ -12,6 +11,8 @@ use std::{
     thread,
     time::Duration,
 };
+
+use ax_std::os::arceos::task::executor::{BlockOnError, block_on, block_on_timeout};
 
 struct PendingUntilCancelled(Arc<AtomicBool>);
 
@@ -35,7 +36,7 @@ impl Future for RemoteCompletion {
     type Output = usize;
 
     fn poll(self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Self::Output> {
-        let mut state = self.0.lock();
+        let mut state = self.0.lock().unwrap();
         if state.0 {
             Poll::Ready(42)
         } else {
@@ -70,7 +71,7 @@ pub fn run() -> crate::TestResult {
     let producer = thread::spawn(move || {
         loop {
             let wake = {
-                let mut state = producer_state.lock();
+                let mut state = producer_state.lock().unwrap();
                 let wake = state.1.take();
                 if wake.is_some() {
                     state.0 = true;

--- a/test-suit/arceos/rust/src/task/fair_idle_pull.rs
+++ b/test-suit/arceos/rust/src/task/fair_idle_pull.rs
@@ -1,13 +1,4 @@
 use std::{
-    os::arceos::{
-        api::task::{AxCpuMask, ax_set_current_affinity},
-        modules::ax_hal::percpu::this_cpu_id,
-        task as scheduler,
-        task::{
-            sched::{CpuId, CpuSet},
-            thread::current::set_current_thread_affinity,
-        },
-    },
     string::String,
     sync::{
         Arc,
@@ -16,6 +7,16 @@ use std::{
     thread,
     time::{Duration, Instant},
     vec::Vec,
+};
+
+use ax_std::os::arceos::{
+    api::task::{AxCpuMask, ax_set_current_affinity},
+    modules::ax_hal::percpu::this_cpu_id,
+    task as scheduler,
+    task::{
+        sched::{CpuId, CpuSet},
+        thread::current::set_current_thread_affinity,
+    },
 };
 
 const SOURCE_WORKERS: usize = 4;
@@ -49,7 +50,7 @@ impl CooperativeWorkers {
             let mut affinity = CpuSet::empty(cpu_count);
             assert!(affinity.insert(CpuId::new(cpu as u32)));
             handles.push(
-                std::os::arceos::thread::spawn_raw_with_affinity(
+                ax_std::os::arceos::thread::spawn_raw_with_affinity(
                     move || {
                         assert_eq!(
                             this_cpu_id(),
@@ -91,7 +92,7 @@ impl CooperativeWorkers {
     fn stop_and_join(mut self) {
         self.stop.store(true, Ordering::Release);
         for handle in self.handles.drain(..) {
-            std::os::arceos::thread::join_thread(handle)
+            ax_std::os::arceos::thread::join_thread(handle)
                 .expect("cooperative Fair worker must exit");
         }
     }
@@ -106,7 +107,7 @@ fn wait_until(mut condition: impl FnMut() -> bool, message: &'static str) {
 }
 
 pub fn run() -> crate::TestResult {
-    let cpu_count = thread::available_parallelism().unwrap().get();
+    let cpu_count = ax_std::os::arceos::task::sched::cpu_topology_len().unwrap();
     assert!(
         cpu_count >= 2,
         "task-fair-idle-pull requires SMP >= 2, got {cpu_count}"

--- a/test-suit/arceos/rust/src/task/fair_wake_idle_sibling.rs
+++ b/test-suit/arceos/rust/src/task/fair_wake_idle_sibling.rs
@@ -1,18 +1,4 @@
 use std::{
-    os::arceos::{
-        api::{
-            task as api,
-            task::{AxCpuMask, AxWaitQueueHandle, ax_set_current_affinity},
-        },
-        modules::ax_hal::percpu::this_cpu_id,
-        task::{
-            sched::{CpuSet, FairMode, Nice, SchedulePolicy},
-            thread::{
-                ThreadState,
-                current::{current_thread_id, set_current_thread_affinity},
-            },
-        },
-    },
     string::String,
     sync::{
         Arc,
@@ -20,6 +6,21 @@ use std::{
     },
     thread,
     time::{Duration, Instant},
+};
+
+use ax_std::os::arceos::{
+    api::{
+        task as api,
+        task::{AxCpuMask, AxWaitQueueHandle, ax_set_current_affinity},
+    },
+    modules::ax_hal::percpu::this_cpu_id,
+    task::{
+        sched::{CpuSet, FairMode, Nice, SchedulePolicy},
+        thread::{
+            ThreadState,
+            current::{current_thread_id, set_current_thread_affinity},
+        },
+    },
 };
 
 const PROGRESS_TIMEOUT: Duration = Duration::from_secs(10);
@@ -71,7 +72,7 @@ fn sched_idle_makes_progress_against_normal_current() {
 
     let idle = thread::spawn(|| {
         pin_current_to_cpu(0);
-        std::os::arceos::task::thread::ThreadHandle::lookup(
+        ax_std::os::arceos::task::thread::ThreadHandle::lookup(
             current_thread_id().expect("the SCHED_IDLE worker must have an identity"),
         )
         .and_then(|thread| thread.set_policy(SchedulePolicy::fair(Nice::ZERO, FairMode::Idle)))
@@ -145,10 +146,10 @@ fn sched_batch_wake_uses_fair_hrtick() {
     NORMAL_READY.store(false, Ordering::Release);
     STOP_NORMAL.store(false, Ordering::Release);
 
-    let batch = std::os::arceos::thread::spawn_raw(
+    let batch = ax_std::os::arceos::thread::spawn_raw(
         || {
             pin_current_to_cpu(0);
-            std::os::arceos::task::thread::ThreadHandle::lookup(
+            ax_std::os::arceos::task::thread::ThreadHandle::lookup(
                 current_thread_id().expect("the SCHED_BATCH worker must have an identity"),
             )
             .and_then(|thread| thread.set_policy(SchedulePolicy::fair(Nice::ZERO, FairMode::Batch)))
@@ -209,7 +210,8 @@ fn sched_batch_wake_uses_fair_hrtick() {
     normal
         .join()
         .expect("the normal Fair occupier must exit normally");
-    std::os::arceos::thread::join_thread(batch).expect("the SCHED_BATCH worker must exit normally");
+    ax_std::os::arceos::thread::join_thread(batch)
+        .expect("the SCHED_BATCH worker must exit normally");
     assert!(
         made_progress,
         "SCHED_BATCH wakee did not run before the periodic scheduler tick fallback"
@@ -217,7 +219,7 @@ fn sched_batch_wake_uses_fair_hrtick() {
 }
 
 pub fn run() -> crate::TestResult {
-    let cpu_count = thread::available_parallelism().unwrap().get();
+    let cpu_count = ax_std::os::arceos::task::sched::cpu_topology_len().unwrap();
     assert!(
         cpu_count >= 4,
         "task-fair-wake-idle-sibling requires SMP >= 4, got {cpu_count}"

--- a/test-suit/arceos/rust/src/task/ipi.rs
+++ b/test-suit/arceos/rust/src/task/ipi.rs
@@ -2,25 +2,20 @@ use core::{
     cmp::min,
     sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
 };
-use std::{
-    os::arceos::{
-        api::{
-            task::{AxCpuMask, ax_set_current_affinity},
-            time::ax_monotonic_time,
-        },
-        modules::{
-            ax_hal,
-            ax_hal::{irq::CpuId, percpu::this_cpu_id},
-            ax_ipi,
-            ax_ipi::IpiNotification,
-        },
-        task::{sync::WaitQueue, time::MonotonicDeadline},
+use std::{println, sync::Arc, thread, time::Duration, vec::Vec};
+
+use ax_std::os::arceos::{
+    api::{
+        task::{AxCpuMask, ax_set_current_affinity},
+        time::ax_monotonic_time,
     },
-    println,
-    sync::Arc,
-    thread,
-    time::Duration,
-    vec::Vec,
+    modules::{
+        ax_hal,
+        ax_hal::{irq::CpuId, percpu::this_cpu_id},
+        ax_ipi,
+        ax_ipi::IpiNotification,
+    },
+    task::{sync::WaitQueue, time::MonotonicDeadline},
 };
 
 const MAX_SENDER_CPUS: usize = 3;
@@ -320,7 +315,7 @@ fn run_concurrent_hard_calls(target_cpu: usize, sender_cpus: &[usize]) {
 }
 
 pub fn run() -> crate::TestResult {
-    let cpu_num = thread::available_parallelism().unwrap().get();
+    let cpu_num = ax_std::os::arceos::task::sched::cpu_topology_len().unwrap();
     if cpu_num < 2 {
         println!("task_ipi: skipped on single CPU");
         return Ok(());

--- a/test-suit/arceos/rust/src/task/irq.rs
+++ b/test-suit/arceos/rust/src/task/irq.rs
@@ -1,12 +1,4 @@
 use std::{
-    os::arceos::{
-        modules::ax_hal,
-        task as scheduler,
-        task::sync::{
-            WaitQueue,
-            irq::{IrqRegisterResult, IrqWaitCell, IrqWaitRegistration},
-        },
-    },
     sync::{
         Arc,
         atomic::{AtomicBool, AtomicUsize, Ordering},
@@ -14,6 +6,15 @@ use std::{
     thread,
     time::Duration,
     vec::Vec,
+};
+
+use ax_std::os::arceos::{
+    modules::ax_hal,
+    task as scheduler,
+    task::sync::{
+        WaitQueue,
+        irq::{IrqRegisterResult, IrqWaitCell, IrqWaitRegistration},
+    },
 };
 
 const NUM_TASKS: usize = 16;

--- a/test-suit/arceos/rust/src/task/kernel_timer.rs
+++ b/test-suit/arceos/rust/src/task/kernel_timer.rs
@@ -1,22 +1,23 @@
 use std::{
     boxed::Box,
-    os::arceos::{
-        api::time::ax_monotonic_time,
-        task::time::{
-            MonotonicDeadline,
-            hard_timer::{
-                HardKernelTimerAction, HardKernelTimerCallback, arm_hard_kernel_timer,
-                register_hard_restartable_kernel_timer,
-            },
-            timer::{
-                KernelTimerAction, KernelTimerCancelOutcome, cancel_kernel_timer,
-                register_kernel_timer, register_restartable_kernel_timer,
-            },
-        },
-    },
     sync::atomic::{AtomicBool, AtomicUsize, Ordering},
     thread,
     time::{Duration, Instant},
+};
+
+use ax_std::os::arceos::{
+    api::time::ax_monotonic_time,
+    task::time::{
+        MonotonicDeadline,
+        hard_timer::{
+            HardKernelTimerAction, HardKernelTimerCallback, arm_hard_kernel_timer,
+            register_hard_restartable_kernel_timer,
+        },
+        timer::{
+            KernelTimerAction, KernelTimerCancelOutcome, cancel_kernel_timer,
+            register_kernel_timer, register_restartable_kernel_timer,
+        },
+    },
 };
 
 static SOFT_CALLBACK_ORDER: AtomicUsize = AtomicUsize::new(0);
@@ -161,7 +162,7 @@ pub fn run() -> crate::TestResult {
 }
 
 fn cancel_in_flight_callback() -> crate::TestResult {
-    use std::os::arceos::task::sync::WaitQueue;
+    use ax_std::os::arceos::task::sync::WaitQueue;
 
     static ENTERED: AtomicBool = AtomicBool::new(false);
     static RELEASE: AtomicBool = AtomicBool::new(false);

--- a/test-suit/arceos/rust/src/task/mutex.rs
+++ b/test-suit/arceos/rust/src/task/mutex.rs
@@ -1,103 +1,73 @@
 use std::{
-    os::arceos::api::task::{self as api, AxWaitQueueHandle},
-    sync::{
-        Arc,
-        atomic::{AtomicBool, AtomicUsize, Ordering},
-    },
+    sync::{Arc, Barrier, Condvar, Mutex, TryLockError, mpsc},
     thread,
-    vec::Vec,
 };
 
 const WORKERS: usize = 8;
 const ITERATIONS: usize = 256;
 
-/// Exercise the production mutex and task wake-up path under real ArceOS scheduling.
+/// Exercise std synchronization through the libc thread and futex boundary.
 pub fn run() -> crate::TestResult {
     contended_workers_make_progress();
     unlock_wakes_a_waiting_task();
+    condvar_publishes_the_predicate();
     Ok(())
 }
 
 fn contended_workers_make_progress() {
-    let value = Arc::new(std::sync::Mutex::new(0usize));
-    let started = Arc::new(AxWaitQueueHandle::new());
-    let started_count = Arc::new(AtomicUsize::new(0));
+    let value = Arc::new(Mutex::new(0usize));
+    let started = Arc::new(Barrier::new(WORKERS));
     let mut workers = Vec::with_capacity(WORKERS);
-
     for _ in 0..WORKERS {
         let value = Arc::clone(&value);
         let started = Arc::clone(&started);
-        let started_count = Arc::clone(&started_count);
         workers.push(thread::spawn(move || {
-            started_count.fetch_add(1, Ordering::Release);
-            api::ax_wait_queue_wake(started.as_ref(), 1);
+            started.wait();
             for _ in 0..ITERATIONS {
-                *value.lock() += 1;
+                *value.lock().unwrap() += 1;
             }
         }));
     }
-
-    api::ax_wait_queue_wait_until(
-        started.as_ref(),
-        || started_count.load(Ordering::Acquire) == WORKERS,
-        None,
-    );
     for worker in workers {
         worker.join().expect("mutex worker panicked");
     }
-    assert_eq!(*value.lock(), WORKERS * ITERATIONS);
+    assert_eq!(*value.lock().unwrap(), WORKERS * ITERATIONS);
 }
 
 fn unlock_wakes_a_waiting_task() {
-    let value = Arc::new(std::sync::Mutex::new(0usize));
-    let holder_ready = Arc::new(AxWaitQueueHandle::new());
-    let release_holder = Arc::new(AxWaitQueueHandle::new());
-    let waiter_started = Arc::new(AxWaitQueueHandle::new());
-    let holder_is_ready = Arc::new(AtomicBool::new(false));
-    let holder_may_exit = Arc::new(AtomicBool::new(false));
-    let waiter_has_started = Arc::new(AtomicBool::new(false));
-
-    let holder_value = Arc::clone(&value);
-    let holder_ready_signal = Arc::clone(&holder_ready);
-    let release_holder_signal = Arc::clone(&release_holder);
-    let holder_is_ready_signal = Arc::clone(&holder_is_ready);
-    let holder_may_exit_signal = Arc::clone(&holder_may_exit);
-    let holder = thread::spawn(move || {
-        let mut guard = holder_value.lock();
-        holder_is_ready_signal.store(true, Ordering::Release);
-        api::ax_wait_queue_wake(holder_ready_signal.as_ref(), 1);
-        api::ax_wait_queue_wait_until(
-            release_holder_signal.as_ref(),
-            || holder_may_exit_signal.load(Ordering::Acquire),
-            None,
-        );
-        *guard = 1;
-    });
-
-    api::ax_wait_queue_wait_until(
-        holder_ready.as_ref(),
-        || holder_is_ready.load(Ordering::Acquire),
-        None,
-    );
-
+    let value = Arc::new(Mutex::new(0usize));
+    let mut holder = value.lock().unwrap();
+    let (started, waiting) = mpsc::channel();
     let waiter_value = Arc::clone(&value);
-    let waiter_started_signal = Arc::clone(&waiter_started);
-    let waiter_has_started_signal = Arc::clone(&waiter_has_started);
     let waiter = thread::spawn(move || {
-        waiter_has_started_signal.store(true, Ordering::Release);
-        api::ax_wait_queue_wake(waiter_started_signal.as_ref(), 1);
-        *waiter_value.lock() = 2;
+        assert!(matches!(
+            waiter_value.try_lock(),
+            Err(TryLockError::WouldBlock)
+        ));
+        started.send(()).unwrap();
+        let mut guard = waiter_value.lock().unwrap();
+        assert_eq!(*guard, 1, "unlock must publish the holder's write");
+        *guard = 2;
     });
-
-    api::ax_wait_queue_wait_until(
-        waiter_started.as_ref(),
-        || waiter_has_started.load(Ordering::Acquire),
-        None,
-    );
-    holder_may_exit.store(true, Ordering::Release);
-    api::ax_wait_queue_wake(release_holder.as_ref(), 1);
-
-    holder.join().expect("mutex holder panicked");
+    waiting.recv().unwrap();
+    *holder = 1;
+    drop(holder);
     waiter.join().expect("mutex waiter panicked");
-    assert_eq!(*value.lock(), 2);
+    assert_eq!(*value.lock().unwrap(), 2);
+}
+
+fn condvar_publishes_the_predicate() {
+    let shared = Arc::new((Mutex::new(None), Condvar::new()));
+    let consumer_shared = Arc::clone(&shared);
+    let consumer = thread::spawn(move || {
+        let (value, ready) = &*consumer_shared;
+        let mut guard = ready
+            .wait_while(value.lock().unwrap(), |value| value.is_none())
+            .unwrap();
+        guard.take().unwrap()
+    });
+    let (value, ready) = &*shared;
+    *value.lock().unwrap() = Some(42);
+    ready.notify_one();
+    assert_eq!(consumer.join().unwrap(), 42);
 }

--- a/test-suit/arceos/rust/src/task/parallel.rs
+++ b/test-suit/arceos/rust/src/task/parallel.rs
@@ -1,6 +1,5 @@
 use std::{
-    os::arceos::api::task::{self as api, AxWaitQueueHandle},
-    sync::Arc,
+    sync::{Arc, Barrier},
     thread,
     vec::Vec,
 };
@@ -9,20 +8,6 @@ use rand::{RngCore, SeedableRng, rngs::SmallRng};
 
 const NUM_DATA: usize = 200_000;
 const NUM_TASKS: usize = 8;
-
-fn barrier() {
-    use std::sync::atomic::{AtomicUsize, Ordering};
-    static BARRIER_WQ: AxWaitQueueHandle = AxWaitQueueHandle::new();
-    static BARRIER_COUNT: AtomicUsize = AtomicUsize::new(0);
-
-    BARRIER_COUNT.fetch_add(1, Ordering::Release);
-    api::ax_wait_queue_wait_until(
-        &BARRIER_WQ,
-        || BARRIER_COUNT.load(Ordering::Acquire) == NUM_TASKS,
-        None,
-    );
-    api::ax_wait_queue_wake(&BARRIER_WQ, u32::MAX);
-}
 
 fn sqrt(n: &u64) -> u64 {
     let mut x = *n;
@@ -43,14 +28,16 @@ pub fn run() -> crate::TestResult {
     );
     let expect: u64 = values.iter().map(sqrt).sum();
 
+    let barrier = Arc::new(Barrier::new(NUM_TASKS));
     let mut tasks = Vec::with_capacity(NUM_TASKS);
     for i in 0..NUM_TASKS {
         let values = values.clone();
+        let barrier = Arc::clone(&barrier);
         tasks.push(thread::spawn(move || {
             let left = i * (NUM_DATA / NUM_TASKS);
             let right = (left + (NUM_DATA / NUM_TASKS)).min(NUM_DATA);
             let partial_sum: u64 = values[left..right].iter().map(sqrt).sum();
-            barrier();
+            barrier.wait();
             partial_sum
         }));
     }

--- a/test-suit/arceos/rust/src/task/pi_mutex.rs
+++ b/test-suit/arceos/rust/src/task/pi_mutex.rs
@@ -1,21 +1,23 @@
 use std::{
-    os::arceos::{
-        api::{
-            task as api,
-            task::{AxCpuMask, AxWaitQueueHandle, ax_set_current_affinity},
-        },
-        modules::ax_hal::percpu::this_cpu_id,
-        task::{
-            sched::{FairMode, Nice, RtPriority, SchedulePolicy},
-            thread::{ThreadId, current::current_thread_id},
-        },
-    },
     sync::{
-        Arc, Mutex,
-        atomic::{AtomicBool, AtomicUsize, Ordering},
+        Arc,
+        atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
     },
     thread,
     time::{Duration, Instant},
+};
+
+use ax_std::os::arceos::{
+    api::{
+        task as api,
+        task::{AxCpuMask, AxWaitQueueHandle, ax_set_current_affinity},
+    },
+    modules::ax_hal::percpu::this_cpu_id,
+    sync::Mutex,
+    task::{
+        sched::{FairMode, Nice, RtPriority, SchedulePolicy},
+        thread::{ThreadId, current::current_thread_id},
+    },
 };
 
 const PROGRESS_TIMEOUT: Duration = Duration::from_secs(2);
@@ -66,7 +68,7 @@ fn ownerless_lock_rekey_wakes_new_top() {
         let ack = Arc::clone(&probe_ack);
         thread::spawn(move || {
             pin_current_to_cpu(0);
-            std::os::arceos::task::thread::ThreadHandle::lookup(
+            ax_std::os::arceos::task::thread::ThreadHandle::lookup(
                 current_thread_id().expect("the PI probe must have an identity"),
             )
             .and_then(|thread| {
@@ -95,7 +97,7 @@ fn ownerless_lock_rekey_wakes_new_top() {
         let ready = Arc::clone(&lock_l_ready);
         thread::spawn(move || {
             pin_current_to_cpu(0);
-            std::os::arceos::task::thread::ThreadHandle::lookup(
+            ax_std::os::arceos::task::thread::ThreadHandle::lookup(
                 current_thread_id().expect("the PI owner must have an identity"),
             )
             .and_then(|thread| {
@@ -120,7 +122,7 @@ fn ownerless_lock_rekey_wakes_new_top() {
         let done = Arc::clone(&selected_done);
         thread::spawn(move || {
             pin_current_to_cpu(0);
-            std::os::arceos::task::thread::ThreadHandle::lookup(
+            ax_std::os::arceos::task::thread::ThreadHandle::lookup(
                 current_thread_id().expect("the selected PI waiter must have an identity"),
             )
             .and_then(|thread| {
@@ -146,7 +148,7 @@ fn ownerless_lock_rekey_wakes_new_top() {
         let done = Arc::clone(&boosted_done);
         thread::spawn(move || {
             pin_current_to_cpu(0);
-            std::os::arceos::task::thread::ThreadHandle::lookup(
+            ax_std::os::arceos::task::thread::ThreadHandle::lookup(
                 current_thread_id().expect("the boosted PI waiter must have an identity"),
             )
             .and_then(|thread| {
@@ -240,7 +242,7 @@ fn ownerless_lock_rekey_wakes_new_top() {
 
 pub fn run() -> crate::TestResult {
     assert!(
-        thread::available_parallelism().unwrap().get() >= 3,
+        ax_std::os::arceos::task::sched::cpu_topology_len().unwrap() >= 3,
         "task-pi-mutex requires at least three CPUs"
     );
     pin_current_to_cpu(2);
@@ -249,20 +251,23 @@ pub fn run() -> crate::TestResult {
 
     let mutex = Arc::new(Mutex::new(()));
     let owner_locked = Arc::new(AtomicBool::new(false));
+    let owner_identity = Arc::new(AtomicU64::new(0));
     let release_owner = Arc::new(AtomicBool::new(false));
     let owner = {
         let mutex = Arc::clone(&mutex);
         let owner_locked = Arc::clone(&owner_locked);
+        let owner_identity = Arc::clone(&owner_identity);
         let release_owner = Arc::clone(&release_owner);
         thread::spawn(move || {
             pin_current_to_cpu(0);
             let current = current_thread_id().expect("PI owner must have a thread identity");
-            std::os::arceos::task::thread::ThreadHandle::lookup(current)
+            ax_std::os::arceos::task::thread::ThreadHandle::lookup(current)
                 .and_then(|thread| {
                     thread.set_policy(SchedulePolicy::fair(Nice::ZERO, FairMode::Idle))
                 })
                 .expect("PI owner must enter the idle Fair class");
             let guard = mutex.lock();
+            owner_identity.store(current.as_u64(), Ordering::Relaxed);
             owner_locked.store(true, Ordering::Release);
             while !release_owner.load(Ordering::Acquire) {
                 core::hint::spin_loop();
@@ -270,12 +275,13 @@ pub fn run() -> crate::TestResult {
             drop(guard);
         })
     };
-    let owner_id = owner.thread().id().as_u64().get();
-    let owner_id = ThreadId::from_parts(owner_id as u32, (owner_id >> 32) as u32);
     wait_until(
         || owner_locked.load(Ordering::Acquire),
         "PI mutex owner did not acquire the lock",
     );
+    // The release/acquire on owner_locked publishes the kernel identity.
+    let owner_id = owner_identity.load(Ordering::Relaxed);
+    let owner_id = ThreadId::from_parts(owner_id as u32, (owner_id >> 32) as u32);
 
     // Keep normal Fair work runnable on the owner's CPU. Without PI donation,
     // the SCHED_IDLE owner cannot run again to release the mutex.
@@ -287,7 +293,7 @@ pub fn run() -> crate::TestResult {
         thread::spawn(move || {
             pin_current_to_cpu(0);
             let current = current_thread_id().expect("PI competitor must have a thread identity");
-            std::os::arceos::task::thread::ThreadHandle::lookup(current)
+            ax_std::os::arceos::task::thread::ThreadHandle::lookup(current)
                 .and_then(|thread| {
                     thread.set_policy(SchedulePolicy::fair(Nice::ZERO, FairMode::Normal))
                 })
@@ -314,7 +320,7 @@ pub fn run() -> crate::TestResult {
         thread::spawn(move || {
             pin_current_to_cpu(1);
             let current = current_thread_id().expect("PI waiter must have a thread identity");
-            std::os::arceos::task::thread::ThreadHandle::lookup(current)
+            ax_std::os::arceos::task::thread::ThreadHandle::lookup(current)
                 .and_then(|thread| {
                     thread.set_policy(SchedulePolicy::fifo(
                         RtPriority::new(80).expect("priority 80 must be valid"),
@@ -334,7 +340,7 @@ pub fn run() -> crate::TestResult {
     let donated_policy = SchedulePolicy::fifo(RtPriority::new(80).expect("priority 80 is valid"));
     wait_until(
         || {
-            std::os::arceos::task::thread::ThreadHandle::lookup(owner_id)
+            ax_std::os::arceos::task::thread::ThreadHandle::lookup(owner_id)
                 .is_ok_and(|owner| owner.effective_policy() == donated_policy)
         },
         "PI waiter did not donate FIFO priority to the owner",

--- a/test-suit/arceos/rust/src/task/preempt_guard.rs
+++ b/test-suit/arceos/rust/src/task/preempt_guard.rs
@@ -1,19 +1,20 @@
 use std::{
-    os::arceos::{
-        api::{
-            task as api,
-            task::{AxCpuMask, AxWaitQueueHandle, ax_set_current_affinity},
-        },
-        guard::PreemptGuard,
-        modules::ax_hal,
-        task::{
-            sched::{CpuSet, RtPriority, SchedulePolicy},
-            thread::current::current_thread_id,
-        },
-    },
     sync::atomic::{AtomicBool, Ordering},
     thread,
     time::{Duration, Instant},
+};
+
+use ax_std::os::arceos::{
+    api::{
+        task as api,
+        task::{AxCpuMask, AxWaitQueueHandle, ax_set_current_affinity},
+    },
+    guard::PreemptGuard,
+    modules::ax_hal,
+    task::{
+        sched::{CpuSet, RtPriority, SchedulePolicy},
+        thread::current::current_thread_id,
+    },
 };
 
 const PROGRESS_TIMEOUT: Duration = Duration::from_secs(2);
@@ -41,7 +42,7 @@ pub fn run() -> crate::TestResult {
     let worker = thread::spawn(|| {
         assert!(ax_set_current_affinity(AxCpuMask::one_shot(0)).is_ok());
         let current = current_thread_id().expect("preempt worker must have an identity");
-        std::os::arceos::task::thread::ThreadHandle::lookup(current)
+        ax_std::os::arceos::task::thread::ThreadHandle::lookup(current)
             .and_then(|thread| {
                 thread.set_policy(SchedulePolicy::fifo(
                     RtPriority::new(80).expect("priority 80 must be valid"),
@@ -78,8 +79,8 @@ pub fn run() -> crate::TestResult {
         "final preempt guard exit did not schedule the ready RT worker",
     );
     worker.join().expect("preempt worker must exit normally");
-    std::os::arceos::task::thread::current::set_current_thread_affinity(CpuSet::all(
-        thread::available_parallelism().unwrap().get(),
+    ax_std::os::arceos::task::thread::current::set_current_thread_affinity(CpuSet::all(
+        ax_std::os::arceos::task::sched::cpu_topology_len().unwrap(),
     ))
     .expect("test owner must restore full affinity");
     assert!(ax_hal::asm::irqs_enabled());

--- a/test-suit/arceos/rust/src/task/priority.rs
+++ b/test-suit/arceos/rust/src/task/priority.rs
@@ -1,14 +1,11 @@
-use std::{
-    os::arceos::{
-        api::task::ax_set_current_priority,
-        task::{
-            sched::{FairMode, Nice, RtPriority, SchedulePolicy},
-            thread::current::current_thread_id,
-        },
+use std::{sync::Arc, thread, time, vec, vec::Vec};
+
+use ax_std::os::arceos::{
+    api::task::ax_set_current_priority,
+    task::{
+        sched::{FairMode, Nice, RtPriority, SchedulePolicy},
+        thread::current::current_thread_id,
     },
-    sync::Arc,
-    thread, time, vec,
-    vec::Vec,
 };
 
 #[derive(Clone, Copy)]
@@ -39,13 +36,13 @@ impl SchedulerCase {
                 ax_set_current_priority(nice).expect("failed to set test thread priority")
             }
             Self::Fair | Self::RoundRobin => {
-                std::os::arceos::task::thread::ThreadHandle::lookup(current)
+                ax_std::os::arceos::task::thread::ThreadHandle::lookup(current)
                     .and_then(|thread| thread.set_policy(expected))
                     .expect("failed to set test thread scheduling policy")
             }
         }
         assert_eq!(
-            std::os::arceos::task::thread::ThreadHandle::lookup(current)
+            ax_std::os::arceos::task::thread::ThreadHandle::lookup(current)
                 .map(|thread| thread.base_policy()),
             Ok(expected),
             "test thread did not enter the selected scheduling policy"
@@ -125,7 +122,9 @@ fn run_workload(case: SchedulerCase) -> crate::TestResult {
         tasks.into_iter().map(|task| task.join().unwrap()).unzip();
     let actual = results.iter().sum::<u64>();
 
-    if matches!(case, SchedulerCase::Fair) && thread::available_parallelism().unwrap().get() == 1 {
+    if matches!(case, SchedulerCase::Fair)
+        && ax_std::os::arceos::task::sched::cpu_topology_len().unwrap() == 1
+    {
         assert!(
             leave_times[0] > leave_times[1]
                 && leave_times[1] > leave_times[2]

--- a/test-suit/arceos/rust/src/task/rt_policy.rs
+++ b/test-suit/arceos/rust/src/task/rt_policy.rs
@@ -1,25 +1,26 @@
 use std::{
     hint,
-    os::arceos::{
-        api::{
-            task as api,
-            task::{AxCpuMask, AxWaitQueueHandle, ax_set_current_affinity},
-        },
-        modules::ax_hal::percpu::this_cpu_id,
-        task::{
-            sched::{CpuSet, FairMode, Nice, RtPriority, SchedulePolicy},
-            thread::{
-                ThreadId,
-                current::{current_thread_id, set_current_thread_affinity},
-            },
-        },
-    },
     sync::{
         Arc,
         atomic::{AtomicBool, AtomicU64, Ordering},
     },
     thread,
     time::{Duration, Instant},
+};
+
+use ax_std::os::arceos::{
+    api::{
+        task as api,
+        task::{AxCpuMask, AxWaitQueueHandle, ax_set_current_affinity},
+    },
+    modules::ax_hal::percpu::this_cpu_id,
+    task::{
+        sched::{CpuSet, FairMode, Nice, RtPriority, SchedulePolicy},
+        thread::{
+            ThreadId,
+            current::{current_thread_id, set_current_thread_affinity},
+        },
+    },
 };
 
 const PROGRESS_TIMEOUT: Duration = Duration::from_secs(2);
@@ -66,7 +67,7 @@ fn higher_priority_wake_preempts_current() {
     let worker = thread::spawn(|| {
         assert!(ax_set_current_affinity(AxCpuMask::one_shot(0)).is_ok());
         let current = current_thread_id().expect("RT wakee must have a thread identity");
-        std::os::arceos::task::thread::ThreadHandle::lookup(current)
+        ax_std::os::arceos::task::thread::ThreadHandle::lookup(current)
             .and_then(|thread| {
                 thread.set_policy(SchedulePolicy::fifo(
                     RtPriority::new(80).expect("priority 80 must be valid"),
@@ -90,7 +91,7 @@ fn higher_priority_wake_preempts_current() {
     );
 
     let current = current_thread_id().expect("RT controller must have a thread identity");
-    std::os::arceos::task::thread::ThreadHandle::lookup(current)
+    ax_std::os::arceos::task::thread::ThreadHandle::lookup(current)
         .and_then(|thread| {
             thread.set_policy(SchedulePolicy::fifo(
                 RtPriority::new(10).expect("priority 10 must be valid"),
@@ -107,7 +108,7 @@ fn higher_priority_wake_preempts_current() {
         "a higher-priority FIFO wakee did not preempt a runnable lower-priority FIFO task"
     );
 
-    std::os::arceos::task::thread::ThreadHandle::lookup(current)
+    ax_std::os::arceos::task::thread::ThreadHandle::lookup(current)
         .and_then(|thread| thread.set_policy(SchedulePolicy::fair(Nice::ZERO, FairMode::Normal)))
         .expect("RT controller must restore Fair policy");
     worker.join().expect("RT wakee must exit normally");
@@ -129,7 +130,7 @@ fn preempted_rt_donor_is_pushed_to_a_lower_priority_cpu(cpu_count: usize) {
     let wakee = thread::spawn(|| {
         assert!(ax_set_current_affinity(AxCpuMask::one_shot(1)).is_ok());
         let current = current_thread_id().expect("the FIFO 90 wakee must have an identity");
-        std::os::arceos::task::thread::ThreadHandle::lookup(current)
+        ax_std::os::arceos::task::thread::ThreadHandle::lookup(current)
             .and_then(|thread| {
                 thread.set_policy(SchedulePolicy::fifo(
                     RtPriority::new(90).expect("priority 90 must be valid"),
@@ -151,7 +152,7 @@ fn preempted_rt_donor_is_pushed_to_a_lower_priority_cpu(cpu_count: usize) {
     let guard = thread::spawn(|| {
         assert!(ax_set_current_affinity(AxCpuMask::one_shot(2)).is_ok());
         let current = current_thread_id().expect("the FIFO 20 guard must have an identity");
-        std::os::arceos::task::thread::ThreadHandle::lookup(current)
+        ax_std::os::arceos::task::thread::ThreadHandle::lookup(current)
             .and_then(|thread| {
                 thread.set_policy(SchedulePolicy::fifo(
                     RtPriority::new(20).expect("priority 20 must be valid"),
@@ -171,7 +172,7 @@ fn preempted_rt_donor_is_pushed_to_a_lower_priority_cpu(cpu_count: usize) {
     let donor = thread::spawn(|| {
         assert!(ax_set_current_affinity(AxCpuMask::one_shot(1)).is_ok());
         let current = current_thread_id().expect("the FIFO 40 donor must have an identity");
-        std::os::arceos::task::thread::ThreadHandle::lookup(current)
+        ax_std::os::arceos::task::thread::ThreadHandle::lookup(current)
             .and_then(|thread| {
                 thread.set_policy(SchedulePolicy::fifo(
                     RtPriority::new(40).expect("priority 40 must be valid"),
@@ -236,13 +237,13 @@ fn promoted_fifo_keeps_running_after_one_period() -> crate::TestResult {
             worker_id.store(current.as_u64(), Ordering::Release);
             let fifo =
                 SchedulePolicy::fifo(RtPriority::new(20).expect("priority 20 must be valid"));
-            if std::os::arceos::task::thread::ThreadHandle::lookup(current)
+            if ax_std::os::arceos::task::thread::ThreadHandle::lookup(current)
                 .map(|thread| thread.base_policy())
                 != Ok(SchedulePolicy::fair(Nice::ZERO, FairMode::Normal))
-                || std::os::arceos::task::thread::ThreadHandle::lookup(current)
+                || ax_std::os::arceos::task::thread::ThreadHandle::lookup(current)
                     .and_then(|thread| thread.set_policy(fifo))
                     .is_err()
-                || std::os::arceos::task::thread::ThreadHandle::lookup(current)
+                || ax_std::os::arceos::task::thread::ThreadHandle::lookup(current)
                     .map(|thread| thread.base_policy())
                     != Ok(fifo)
             {
@@ -269,7 +270,7 @@ fn promoted_fifo_keeps_running_after_one_period() -> crate::TestResult {
             let raw = worker_id.load(Ordering::Acquire);
             if raw != 0 {
                 let _ =
-                    std::os::arceos::task::thread::ThreadHandle::lookup(thread_id_from_raw(raw))
+                    ax_std::os::arceos::task::thread::ThreadHandle::lookup(thread_id_from_raw(raw))
                         .and_then(|thread| {
                             thread.set_policy(SchedulePolicy::fair(Nice::ZERO, FairMode::Normal))
                         });
@@ -293,7 +294,7 @@ fn promoted_fifo_keeps_running_after_one_period() -> crate::TestResult {
     if stalled {
         let raw = worker_id.load(Ordering::Acquire);
         if raw != 0 {
-            let _ = std::os::arceos::task::thread::ThreadHandle::lookup(thread_id_from_raw(raw))
+            let _ = ax_std::os::arceos::task::thread::ThreadHandle::lookup(thread_id_from_raw(raw))
                 .and_then(|thread| {
                     thread.set_policy(SchedulePolicy::fair(Nice::ZERO, FairMode::Normal))
                 });
@@ -307,7 +308,7 @@ fn promoted_fifo_keeps_running_after_one_period() -> crate::TestResult {
 }
 
 pub fn run() -> crate::TestResult {
-    let cpu_count = thread::available_parallelism().unwrap().get();
+    let cpu_count = ax_std::os::arceos::task::sched::cpu_topology_len().unwrap();
     assert!(
         cpu_count >= 3,
         "task-rt-policy requires at least three CPUs"

--- a/test-suit/arceos/rust/src/task/scheduler_irq_window.rs
+++ b/test-suit/arceos/rust/src/task/scheduler_irq_window.rs
@@ -1,42 +1,40 @@
 use std::{
     hint,
-    os::arceos::{
-        api::task::{AxCpuMask, ax_set_current_affinity},
-        modules::{
-            ax_hal,
-            ax_runtime::{
-                diagnostics::qperf_runtime_scheduler_metrics_snapshot,
-                task::{
-                    runtime::config::DEFAULT_BATCH_LIMIT,
-                    sched::{
-                        CpuId, CpuSet, FairMode, Nice, RtPriority, SchedulePolicy, cpu_topology_len,
-                    },
-                    thread::{ThreadId, ThreadState, current::current_thread_id},
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::{Duration, Instant},
+    vec::Vec,
+};
+
+use ax_std::os::arceos::{
+    api::task::{AxCpuMask, ax_set_current_affinity},
+    modules::{
+        ax_hal,
+        ax_runtime::{
+            diagnostics::qperf_runtime_scheduler_metrics_snapshot,
+            task::{
+                runtime::config::DEFAULT_BATCH_LIMIT,
+                sched::{
+                    CpuId, CpuSet, FairMode, Nice, RtPriority, SchedulePolicy, cpu_topology_len,
                 },
+                thread::{ThreadState, current::current_thread_id},
             },
         },
     },
-    sync::{
-        Arc,
-        atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
-    },
-    thread,
-    time::{Duration, Instant},
-    vec::Vec,
+    thread::{default_task_stack_size, join_thread, spawn_raw_with_affinity},
 };
 
 const OWNER_BACKLOG: usize = DEFAULT_BATCH_LIMIT + 1;
 const PROGRESS_TIMEOUT: Duration = Duration::from_secs(5);
 
-fn thread_id_from_raw(raw: u64) -> ThreadId {
-    ThreadId::from_parts(raw as u32, (raw >> 32) as u32)
-}
-
 fn wait_until(mut condition: impl FnMut() -> bool, message: &'static str) {
     let started = Instant::now();
     while !condition() {
         assert!(started.elapsed() < PROGRESS_TIMEOUT, "{message}");
-        thread::yield_now();
+        ax_std::os::arceos::task::thread::current::yield_current_cpu()
+            .expect("kernel probe must be able to yield");
     }
 }
 
@@ -45,40 +43,41 @@ pub fn run() -> crate::TestResult {
     assert!(cpu_count >= 2, "IRQ-window regression requires SMP");
     assert!(ax_set_current_affinity(AxCpuMask::one_shot(0)).is_ok());
 
+    let current = current_thread_id().expect("controller must have a scheduler identity");
+    let controller_handle = ax_std::os::arceos::task::thread::ThreadHandle::lookup(current)
+        .expect("controller must remain registered");
+    controller_handle
+        .set_policy(SchedulePolicy::fifo(RtPriority::new(90).unwrap()))
+        .expect("CPU0 controller must enter FIFO policy");
+
+    let mut cpu0 = CpuSet::empty(cpu_count);
+    assert!(cpu0.insert(CpuId::new(0)));
+    let mut cpu1 = CpuSet::empty(cpu_count);
+    assert!(cpu1.insert(CpuId::new(1)));
     let stop_workers = Arc::new(AtomicBool::new(false));
-    let ready_workers = Arc::new(AtomicUsize::new(0));
-    let worker_ids = Arc::new(
-        (0..OWNER_BACKLOG)
-            .map(|_| AtomicU64::new(0))
-            .collect::<Vec<_>>(),
-    );
     let mut workers = Vec::with_capacity(OWNER_BACKLOG);
+    // Keep the Fair backlog runnable on CPU0 without waiting for every worker
+    // to get an initial timeslice. The FIFO controller owns the setup phase.
     for index in 0..OWNER_BACKLOG {
         let stop_workers = Arc::clone(&stop_workers);
-        let ready_workers = Arc::clone(&ready_workers);
-        let worker_ids = Arc::clone(&worker_ids);
-        workers.push(thread::spawn(move || {
-            assert!(ax_set_current_affinity(AxCpuMask::one_shot(0)).is_ok());
-            let current = current_thread_id().expect("worker must have a scheduler identity");
-            worker_ids[index].store(current.as_u64(), Ordering::Release);
-            ready_workers.fetch_add(1, Ordering::Release);
-            while !stop_workers.load(Ordering::Acquire) {
-                hint::spin_loop();
-            }
-        }));
+        workers.push(
+            spawn_raw_with_affinity(
+                move || {
+                    while !stop_workers.load(Ordering::Acquire) {
+                        hint::spin_loop();
+                    }
+                },
+                format!("irq-window-worker-{index}"),
+                default_task_stack_size(),
+                cpu0.clone(),
+            )
+            .expect("failed to publish the kernel scheduler backlog"),
+        );
     }
-
-    wait_until(
-        || ready_workers.load(Ordering::Acquire) == OWNER_BACKLOG,
-        "CPU0 workers did not all become runnable",
-    );
-    let worker_ids = worker_ids
-        .iter()
-        .map(|raw| thread_id_from_raw(raw.load(Ordering::Acquire)))
-        .collect::<Vec<_>>();
+    let worker_ids = workers.iter().map(|worker| worker.id()).collect::<Vec<_>>();
     assert!(worker_ids.iter().all(|thread| {
         matches!(
-            std::os::arceos::task::thread::ThreadHandle::lookup(*thread)
+            ax_std::os::arceos::task::thread::ThreadHandle::lookup(*thread)
                 .map(|handle| handle.state()),
             Ok(ThreadState::Running)
         )
@@ -91,40 +90,37 @@ pub fn run() -> crate::TestResult {
         let controller_ready = Arc::clone(&controller_ready);
         let publish_owner_work = Arc::clone(&publish_owner_work);
         let owner_work_published = Arc::clone(&owner_work_published);
-        thread::spawn(move || {
-            assert!(ax_set_current_affinity(AxCpuMask::one_shot(1)).is_ok());
-            let mut cpu1 = CpuSet::empty(cpu_count);
-            assert!(cpu1.insert(CpuId::new(1)));
-            controller_ready.store(true, Ordering::Release);
-            while !publish_owner_work.load(Ordering::Acquire) {
-                hint::spin_loop();
-            }
-            for worker in worker_ids {
-                // This case deliberately leaves reconciliation to IRQ return.
-                drop(
-                    std::os::arceos::modules::ax_runtime::task::thread::ThreadHandle::lookup(
+        spawn_raw_with_affinity(
+            move || {
+                let mut cpu1 = CpuSet::empty(cpu_count);
+                assert!(cpu1.insert(CpuId::new(1)));
+                controller_ready.store(true, Ordering::Release);
+                while !publish_owner_work.load(Ordering::Acquire) {
+                    hint::spin_loop();
+                }
+                for worker in worker_ids {
+                    // This case deliberately leaves reconciliation to IRQ return.
+                    drop(
+                    ax_std::os::arceos::modules::ax_runtime::task::thread::ThreadHandle::lookup(
                         worker,
                     )
                     .and_then(|thread| thread.request_affinity(cpu1.clone()))
                     .expect("remote affinity update must publish owner work"),
                 );
-            }
-            owner_work_published.store(true, Ordering::Release);
-        })
+                }
+                owner_work_published.store(true, Ordering::Release);
+            },
+            "irq-window-controller".into(),
+            default_task_stack_size(),
+            cpu1,
+        )
+        .expect("failed to create the kernel affinity controller")
     };
     wait_until(
         || controller_ready.load(Ordering::Acquire),
         "CPU1 affinity controller did not become ready",
     );
 
-    let current = current_thread_id().expect("controller must have a scheduler identity");
-    std::os::arceos::modules::ax_runtime::task::thread::ThreadHandle::lookup(current)
-        .and_then(|thread| {
-            thread.set_policy(SchedulePolicy::fifo(
-                RtPriority::new(90).expect("priority 90 must be valid"),
-            ))
-        })
-        .expect("CPU0 controller must enter FIFO policy");
     let before = qperf_runtime_scheduler_metrics_snapshot();
 
     assert!(ax_hal::asm::irqs_enabled());
@@ -154,15 +150,13 @@ pub fn run() -> crate::TestResult {
         "an IRQ-return continuation must open interrupts between scheduler passes"
     );
 
-    std::os::arceos::modules::ax_runtime::task::thread::ThreadHandle::lookup(current)
-        .and_then(|thread| thread.set_policy(SchedulePolicy::fair(Nice::ZERO, FairMode::Normal)))
-        .expect("CPU0 controller must restore Fair policy");
     stop_workers.store(true, Ordering::Release);
-    controller
-        .join()
-        .expect("affinity controller must exit cleanly");
+    controller_handle
+        .set_policy(SchedulePolicy::fair(Nice::ZERO, FairMode::Normal))
+        .expect("CPU0 controller must restore Fair policy");
+    join_thread(controller).expect("affinity controller must exit cleanly");
     for worker in workers {
-        worker.join().expect("CPU0 worker must exit cleanly");
+        join_thread(worker).expect("CPU0 worker must exit cleanly");
     }
     Ok(())
 }

--- a/test-suit/arceos/rust/src/task/smp_online.rs
+++ b/test-suit/arceos/rust/src/task/smp_online.rs
@@ -1,11 +1,4 @@
 use std::{
-    os::arceos::{
-        api::task::{AxCpuMask, ax_set_current_affinity},
-        modules::{
-            ax_hal::{irq::CpuId, percpu::this_cpu_id},
-            ax_ipi,
-        },
-    },
     println,
     sync::{
         Arc,
@@ -13,6 +6,14 @@ use std::{
     },
     thread,
     vec::Vec,
+};
+
+use ax_std::os::arceos::{
+    api::task::{AxCpuMask, ax_set_current_affinity},
+    modules::{
+        ax_hal::{irq::CpuId, percpu::this_cpu_id},
+        ax_ipi,
+    },
 };
 
 static IPI_ACKS: AtomicUsize = AtomicUsize::new(0);
@@ -58,7 +59,7 @@ fn wait_for_ipi_acks(expected: usize) -> bool {
 }
 
 pub fn run() -> crate::TestResult {
-    let cpu_num = thread::available_parallelism().unwrap().get();
+    let cpu_num = ax_std::os::arceos::task::sched::cpu_topology_len().unwrap();
     println!("task_smp_online: cpu_num={cpu_num}");
     assert!(
         cpu_num >= 2,

--- a/test-suit/arceos/rust/src/task/stack_guard_page.rs
+++ b/test-suit/arceos/rust/src/task/stack_guard_page.rs
@@ -1,10 +1,9 @@
 use core::{arch::asm, hint::black_box, ptr};
-use std::{
-    os::arceos::{
-        api::task::{AxCpuMask, ax_set_current_affinity},
-        modules::ax_hal::percpu::this_cpu_id,
-    },
-    println, thread,
+use std::{println, thread};
+
+use ax_std::os::arceos::{
+    api::task::{AxCpuMask, ax_set_current_affinity},
+    modules::ax_hal::percpu::this_cpu_id,
 };
 
 const STACK_SIZE: usize = 64 * 1024;
@@ -12,7 +11,7 @@ const WRITE_STRIDE: usize = 64;
 const SEARCH_BYTES: usize = STACK_SIZE + 2 * 4096;
 
 pub fn run() -> crate::TestResult {
-    let cpu_num = thread::available_parallelism().unwrap().get();
+    let cpu_num = ax_std::os::arceos::task::sched::cpu_topology_len().unwrap();
     let creator_cpu = this_cpu_id();
     let target_cpu = if cpu_num > 1 {
         (creator_cpu + 1) % cpu_num
@@ -24,10 +23,12 @@ pub fn run() -> crate::TestResult {
          cpu_num={cpu_num}"
     );
 
-    let _ = thread::Builder::new()
-        .name("stack-guard-page-overflow".into())
-        .stack_size(STACK_SIZE)
-        .spawn(move || hit_guard_page(target_cpu));
+    ax_std::os::arceos::thread::spawn_raw(
+        move || hit_guard_page(target_cpu),
+        "stack-guard-page-overflow".into(),
+        STACK_SIZE,
+    )
+    .expect("failed to spawn the kernel stack guard probe");
 
     loop {
         thread::yield_now();

--- a/test-suit/arceos/rust/src/task/tls.rs
+++ b/test-suit/arceos/rust/src/task/tls.rs
@@ -1,78 +1,86 @@
-#![allow(unused_unsafe)]
+use std::{
+    cell::RefCell,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    thread,
+};
 
-use std::{ptr::addr_of, str::from_utf8_unchecked, thread, vec::Vec};
-
-#[thread_local]
-static mut BOOL: bool = true;
-#[thread_local]
-static mut U8: u8 = 0xAA;
-#[thread_local]
-static mut U16: u16 = 0xcafe;
-#[thread_local]
-static mut U32: u32 = 0xdeadbeed;
-#[thread_local]
-static mut U64: u64 = 0xa2ce05_a2ce05;
-#[thread_local]
-static mut STR: [u8; 13] = *b"Hello, world!";
-
-const STR_LEN: usize = 13;
-
-macro_rules! get {
-    ($var:expr) => {
-        unsafe { $var }
-    };
+#[derive(Debug, PartialEq)]
+struct Values {
+    boolean: bool,
+    byte: u8,
+    half: u16,
+    word: u32,
+    double: u64,
+    text: [u8; 13],
 }
 
-macro_rules! set {
-    ($var:expr, $value:expr) => {
-        unsafe { $var = $value }
-    };
+impl Values {
+    const fn initial() -> Self {
+        Self {
+            boolean: true,
+            byte: 0xAA,
+            half: 0xcafe,
+            word: 0xdeadbeed,
+            double: 0xa2ce05_a2ce05,
+            text: *b"Hello, world!",
+        }
+    }
 }
 
-macro_rules! add {
-    ($var:expr, $value:expr) => {
-        unsafe { $var += $value }
-    };
+struct DropProbe(Arc<AtomicUsize>);
+
+impl Drop for DropProbe {
+    fn drop(&mut self) {
+        self.0.fetch_add(1, Ordering::Release);
+    }
+}
+
+thread_local! {
+    static VALUES: RefCell<Values> = const { RefCell::new(Values::initial()) };
+    static DROP_PROBE: RefCell<Option<DropProbe>> = const { RefCell::new(None) };
 }
 
 pub fn run() -> crate::TestResult {
-    assert!(get!(BOOL));
-    assert_eq!(get!(U8), 0xAA);
-    assert_eq!(get!(U16), 0xcafe);
-    assert_eq!(get!(U32), 0xdeadbeed);
-    assert_eq!(get!(U64), 0xa2ce05_a2ce05);
-    assert_eq!(get!(&*addr_of!(STR)), b"Hello, world!");
-
-    let mut tasks = Vec::new();
+    VALUES.with_borrow(|values| assert_eq!(*values, Values::initial()));
+    let drops = Arc::new(AtomicUsize::new(0));
+    let mut workers = Vec::new();
     for i in 1..=10 {
-        tasks.push(thread::spawn(move || {
-            set!(BOOL, i % 2 == 0);
-            add!(U8, i as u8);
-            add!(U16, i as u16);
-            add!(U32, i as u32);
-            add!(U64, i as u64);
-            set!(STR[5], 48 + i as u8);
-
+        let drops = Arc::clone(&drops);
+        workers.push(thread::spawn(move || {
+            VALUES.with_borrow(|values| assert_eq!(*values, Values::initial()));
+            DROP_PROBE.with_borrow_mut(|slot| *slot = Some(DropProbe(drops)));
+            VALUES.with_borrow_mut(|values| {
+                values.boolean = i % 2 == 0;
+                values.byte += i as u8;
+                values.half += i as u16;
+                values.word += i as u32;
+                values.double += i as u64;
+                values.text[5] = 48 + i as u8;
+            });
             thread::yield_now();
-
-            assert_eq!(get!(BOOL), i % 2 == 0);
-            assert_eq!(get!(U8), 0xAA + i as u8);
-            assert_eq!(get!(U16), 0xcafe + i as u16);
-            assert_eq!(get!(U32), 0xdeadbeed + i as u32);
-            assert_eq!(get!(U64), 0xa2ce05_a2ce05 + i as u64);
-            assert_eq!(get!(STR[5]), 48 + i as u8);
-            assert_eq!(STR_LEN, 13);
-            let _ = get!(from_utf8_unchecked(&*addr_of!(STR)));
+            VALUES.with_borrow(|values| {
+                assert_eq!(values.boolean, i % 2 == 0);
+                assert_eq!(values.byte, 0xAA + i as u8);
+                assert_eq!(values.half, 0xcafe + i as u16);
+                assert_eq!(values.word, 0xdeadbeed + i as u32);
+                assert_eq!(values.double, 0xa2ce05_a2ce05 + i as u64);
+                let mut expected_text = *b"Hello, world!";
+                expected_text[5] = 48 + i as u8;
+                assert_eq!(values.text, expected_text);
+            });
         }));
     }
-
-    tasks.into_iter().for_each(|task| task.join().unwrap());
-
-    assert!(get!(BOOL));
-    assert_eq!(get!(U8), 0xAA);
-    assert_eq!(get!(U16), 0xcafe);
-    assert_eq!(get!(U32), 0xdeadbeed);
-    assert_eq!(get!(U64), 0xa2ce05_a2ce05);
-    assert_eq!(get!(&*addr_of!(STR)), b"Hello, world!");
+    for worker in workers {
+        worker.join().expect("TLS worker panicked");
+    }
+    VALUES.with_borrow(|values| assert_eq!(*values, Values::initial()));
+    assert_eq!(
+        drops.load(Ordering::Acquire),
+        10,
+        "pthread exit must run std TLS destructors"
+    );
     Ok(())
 }

--- a/test-suit/arceos/rust/src/task/wait_queue.rs
+++ b/test-suit/arceos/rust/src/task/wait_queue.rs
@@ -1,5 +1,4 @@
 use std::{
-    os::arceos::api::task::{self as api, AxWaitQueueHandle},
     println,
     sync::{
         Arc,
@@ -9,6 +8,8 @@ use std::{
     time::Duration,
     vec::Vec,
 };
+
+use ax_std::os::arceos::api::task::{self as api, AxWaitQueueHandle};
 
 const NUM_TASKS: usize = 16;
 
@@ -161,7 +162,7 @@ fn test_release_all_runtime_tasks() {
 }
 
 fn test_wake_before_admission() {
-    use std::os::arceos::{
+    use ax_std::os::arceos::{
         guard::PreemptGuard,
         modules::ax_runtime::task::{
             sched::{CpuId, CpuSet},
@@ -169,38 +170,38 @@ fn test_wake_before_admission() {
         },
     };
 
-    let owner = std::os::arceos::task::thread::current::current_thread_id().unwrap();
-    let old_affinity = std::os::arceos::task::thread::ThreadHandle::lookup(owner)
+    let owner = ax_std::os::arceos::task::thread::current::current_thread_id().unwrap();
+    let old_affinity = ax_std::os::arceos::task::thread::ThreadHandle::lookup(owner)
         .and_then(|thread| thread.affinity())
         .unwrap();
-    let mut cpu0 = CpuSet::empty(std::os::arceos::task::sched::cpu_topology_len().unwrap());
+    let mut cpu0 = CpuSet::empty(ax_std::os::arceos::task::sched::cpu_topology_len().unwrap());
     assert!(cpu0.insert(CpuId::new(0)));
-    std::os::arceos::task::thread::current::set_current_thread_affinity(cpu0.clone()).unwrap();
-    let prepared = std::os::arceos::thread::prepare_raw(
+    ax_std::os::arceos::task::thread::current::set_current_thread_affinity(cpu0.clone()).unwrap();
+    let prepared = ax_std::os::arceos::thread::prepare_raw(
         || {
             let CurrentParkStart::Prepared(park) =
-                std::os::arceos::task::thread::current::begin_current_park().unwrap()
+                ax_std::os::arceos::task::thread::current::begin_current_park().unwrap()
             else {
                 panic!("a New-state wake must not notify the first admitted park");
             };
             park.cancel().unwrap();
             // Admission must clear only earlier wakes: a Running-state wake
             // still interrupts the next park through the public facade.
-            std::os::arceos::task::thread::current::current_thread_handle()
+            ax_std::os::arceos::task::thread::current::current_thread_handle()
                 .unwrap()
                 .wake_handle()
                 .wake();
             assert!(matches!(
-                std::os::arceos::task::thread::current::begin_current_park().unwrap(),
+                ax_std::os::arceos::task::thread::current::begin_current_park().unwrap(),
                 CurrentParkStart::Notified
             ));
         },
         "admission-wake".into(),
-        std::os::arceos::thread::default_task_stack_size(),
+        ax_std::os::arceos::thread::default_task_stack_size(),
     )
     .unwrap();
     let handle = prepared.thread_handle();
-    std::os::arceos::task::thread::ThreadHandle::lookup(handle.id())
+    ax_std::os::arceos::task::thread::ThreadHandle::lookup(handle.id())
         .and_then(|thread| thread.request_affinity(cpu0))
         .unwrap()
         .wait()
@@ -215,7 +216,10 @@ fn test_wake_before_admission() {
         prepared.publish().unwrap()
     };
     drop(handle);
-    assert_eq!(std::os::arceos::thread::join_thread(published).unwrap(), 0);
-    std::os::arceos::task::thread::current::set_current_thread_affinity(old_affinity).unwrap();
+    assert_eq!(
+        ax_std::os::arceos::thread::join_thread(published).unwrap(),
+        0
+    );
+    ax_std::os::arceos::task::thread::current::set_current_thread_affinity(old_affinity).unwrap();
     println!("task_wait_queue: pre-admission wake isolation OK");
 }

--- a/test-suit/arceos/rust/src/task/wait_queue_remote_wake.rs
+++ b/test-suit/arceos/rust/src/task/wait_queue_remote_wake.rs
@@ -1,20 +1,21 @@
 use core::sync::atomic::AtomicUsize;
 use std::{
-    os::arceos::{
-        api::{
-            task as api,
-            task::{AxCpuMask, AxWaitQueueHandle, ax_set_current_affinity},
-        },
-        modules::ax_hal::percpu::this_cpu_id,
-        task::{
-            sched::{CpuId, CpuSet, SchedulePolicy},
-            thread::{SwitchReason, ThreadExtension, ThreadExtensionOps, ThreadId},
-        },
-    },
     println,
     sync::atomic::{AtomicBool, Ordering},
     thread,
     time::{Duration, Instant},
+};
+
+use ax_std::os::arceos::{
+    api::{
+        task as api,
+        task::{AxCpuMask, AxWaitQueueHandle, ax_set_current_affinity},
+    },
+    modules::ax_hal::percpu::this_cpu_id,
+    task::{
+        sched::{CpuId, CpuSet, SchedulePolicy},
+        thread::{SwitchReason, ThreadExtension, ThreadExtensionOps, ThreadId},
+    },
 };
 
 static SLEEP_WQ: AxWaitQueueHandle = AxWaitQueueHandle::new();
@@ -108,7 +109,7 @@ fn wait_for_probe(flag: &AtomicBool, message: &str) {
 }
 
 pub fn run() -> crate::TestResult {
-    let cpu_num = thread::available_parallelism().unwrap().get();
+    let cpu_num = ax_std::os::arceos::task::sched::cpu_topology_len().unwrap();
     if cpu_num < 3 {
         println!("task_wait_queue_remote_wake: skipped with fewer than three CPUs");
         return Ok(());
@@ -151,7 +152,7 @@ pub fn run() -> crate::TestResult {
     // SAFETY: this call transfers the extension's unique logical ownership and
     // installs the affinity before publishing the scheduler thread.
     let sleeper = unsafe {
-        std::os::arceos::thread::spawn_raw_with_extension_and_affinity(
+        ax_std::os::arceos::thread::spawn_raw_with_extension_and_affinity(
             move || {
                 assert_eq!(this_cpu_id(), sleeper_cpu);
                 SLEEPER_CPU.store(this_cpu_id(), Ordering::Release);
@@ -205,6 +206,6 @@ pub fn run() -> crate::TestResult {
         ),
         "remote wait-queue wakeup did not make bounded progress"
     );
-    std::os::arceos::thread::join_thread(sleeper).expect("remote sleeper must exit cleanly");
+    ax_std::os::arceos::thread::join_thread(sleeper).expect("remote sleeper must exit cleanly");
     Ok(())
 }

--- a/test-suit/arceos/rust/src/task/yield.rs
+++ b/test-suit/arceos/rust/src/task/yield.rs
@@ -1,18 +1,18 @@
 use core::f64::consts;
 use std::{
-    format,
-    os::arceos::{
-        api::{config::TASK_STACK_SIZE, task as api},
-        guard::PreemptIrqSaveGuard,
-        sync::RawSpinLock,
-    },
-    println,
+    format, println,
     sync::{
         Arc,
         atomic::{AtomicBool, AtomicUsize, Ordering},
     },
     thread,
     vec::Vec,
+};
+
+use ax_std::os::arceos::{
+    api::{config::TASK_STACK_SIZE, task as api},
+    guard::PreemptIrqSaveGuard,
+    sync::RawSpinLock,
 };
 
 const NUM_TASKS: usize = 10;

--- a/test-suit/starryos/qemu/system/test-queued-affinity/CMakeLists.txt
+++ b/test-suit/starryos/qemu/system/test-queued-affinity/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.20)
+project(test-queued-affinity C)
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS ON)
+add_executable(test-queued-affinity src/main.c)
+target_compile_options(test-queued-affinity PRIVATE -Wall -Wextra -Werror)
+install(TARGETS test-queued-affinity RUNTIME DESTINATION usr/bin/starry-test-suit)

--- a/test-suit/starryos/qemu/system/test-queued-affinity/src/main.c
+++ b/test-suit/starryos/qemu/system/test-queued-affinity/src/main.c
@@ -1,0 +1,178 @@
+#define _GNU_SOURCE
+#include <errno.h>
+#include <sched.h>
+#include <signal.h>
+#include <stdatomic.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/syscall.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+
+struct shared_state {
+    _Atomic int victim_ready;
+    _Atomic int setter_ready;
+    _Atomic int migrate;
+    _Atomic int completed;
+    _Atomic int entered;
+    pid_t victim;
+    int result;
+    int error;
+    unsigned int cpu;
+};
+
+static int pin(pid_t pid, int cpu)
+{
+    cpu_set_t mask;
+    CPU_ZERO(&mask);
+    CPU_SET(cpu, &mask);
+    return (int)syscall(SYS_sched_setaffinity, pid, sizeof(mask), &mask);
+}
+
+static int wait_flag(_Atomic int *flag)
+{
+    struct timespec start, now;
+    if (clock_gettime(CLOCK_MONOTONIC, &start) != 0)
+        return -1;
+    while (!atomic_load_explicit(flag, memory_order_acquire)) {
+        if (clock_gettime(CLOCK_MONOTONIC, &now) != 0)
+            return -1;
+        if (now.tv_sec - start.tv_sec >= 5) {
+            errno = ETIMEDOUT;
+            return -1;
+        }
+        syscall(SYS_sched_yield);
+    }
+    return 0;
+}
+
+static int reap(pid_t pid)
+{
+    int status;
+    return waitpid(pid, &status, 0) == pid && WIFEXITED(status) && WEXITSTATUS(status) == 0;
+}
+
+int main(void)
+{
+    cpu_set_t original;
+    struct sched_param saved, fifo = {.sched_priority = 90};
+    int cpus[2], count = 0, gate[2] = {-1, -1}, result = 1;
+    int policy = (int)syscall(SYS_sched_getscheduler, 0);
+    pid_t victim = -1, setter = -1;
+    const char *failure = "initialize queued affinity fixture";
+    CPU_ZERO(&original);
+    if (policy < 0 || syscall(SYS_sched_getparam, 0, &saved) != 0 ||
+        syscall(SYS_sched_getaffinity, 0, sizeof(original), &original) < 0) {
+        perror(failure);
+        return 1;
+    }
+    for (int cpu = 0; cpu < CPU_SETSIZE && count < 2; ++cpu) {
+        if (CPU_ISSET(cpu, &original))
+            cpus[count++] = cpu;
+    }
+    if (count != 2) {
+        fprintf(stderr, "queued affinity regression requires two allowed CPUs\n");
+        return 1;
+    }
+    struct shared_state *shared = mmap(NULL, sizeof(*shared), PROT_READ | PROT_WRITE,
+                                      MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+    if (shared == MAP_FAILED)
+        return 1;
+    memset(shared, 0, sizeof(*shared));
+    atomic_init(&shared->victim_ready, 0);
+    atomic_init(&shared->setter_ready, 0);
+    atomic_init(&shared->migrate, 0);
+    atomic_init(&shared->completed, 0);
+    atomic_init(&shared->entered, 0);
+    if (pipe(gate) != 0)
+        goto cleanup;
+    victim = fork();
+    if (victim < 0)
+        goto cleanup;
+    if (victim == 0) {
+        char byte;
+        if (pin(0, cpus[0]) != 0)
+            _exit(11);
+        atomic_store_explicit(&shared->victim_ready, 1, memory_order_release);
+        if (read(gate[0], &byte, 1) != 1)
+            _exit(12);
+        if (syscall(SYS_getcpu, &shared->cpu, NULL, NULL) != 0)
+            _exit(13);
+        atomic_store_explicit(&shared->entered, 1, memory_order_release);
+        _exit(0);
+    }
+    shared->victim = victim;
+    setter = fork();
+    if (setter < 0)
+        goto cleanup;
+    if (setter == 0) {
+        if (pin(0, cpus[1]) != 0)
+            _exit(21);
+        atomic_store_explicit(&shared->setter_ready, 1, memory_order_release);
+        if (wait_flag(&shared->migrate) != 0)
+            _exit(22);
+        shared->result = pin(shared->victim, cpus[1]);
+        shared->error = errno;
+        atomic_store_explicit(&shared->completed, 1, memory_order_release);
+        _exit(0);
+    }
+    if (wait_flag(&shared->victim_ready) != 0 || wait_flag(&shared->setter_ready) != 0 ||
+        pin(0, cpus[0]) != 0)
+        goto cleanup;
+    failure = "establish FIFO owner of the source CPU";
+    if (syscall(SYS_sched_setscheduler, 0, SCHED_FIFO, &fifo) != 0)
+        goto cleanup;
+    /* Wake the Fair victim while the FIFO parent keeps CPU0. The target is
+     * runnable but cannot execute or consume the pipe byte on the source CPU.
+     * CPU1 must therefore update a queued, non-current task's affinity. */
+    failure = "publish runnable victim";
+    if (write(gate[1], "x", 1) != 1 ||
+        atomic_load_explicit(&shared->entered, memory_order_acquire))
+        goto cleanup;
+    atomic_store_explicit(&shared->migrate, 1, memory_order_release);
+    failure = "remote sched_setaffinity must complete for a queued target";
+    if (wait_flag(&shared->completed) != 0)
+        goto cleanup;
+    if (shared->result != 0) {
+        errno = shared->error;
+        goto cleanup;
+    }
+    failure = "restore source CPU scheduling policy";
+    if (syscall(SYS_sched_setscheduler, 0, policy, &saved) != 0)
+        goto cleanup;
+    failure = "victim must execute on the requested destination CPU";
+    if (!reap(victim))
+        goto cleanup;
+    victim = -1;
+    if (!atomic_load_explicit(&shared->entered, memory_order_acquire) ||
+        shared->cpu != (unsigned int)cpus[1])
+        goto cleanup;
+    if (!reap(setter))
+        goto cleanup;
+    setter = -1;
+    result = 0;
+cleanup:
+    if (result != 0)
+        fprintf(stderr, "queued affinity FAIL: %s: errno=%d\n", failure, errno);
+    if (syscall(SYS_sched_setscheduler, 0, policy, &saved) != 0 ||
+        syscall(SYS_sched_setaffinity, 0, sizeof(original), &original) != 0)
+        result = 1;
+    if (victim > 0) {
+        kill(victim, SIGKILL);
+        waitpid(victim, NULL, 0);
+    }
+    if (setter > 0) {
+        kill(setter, SIGKILL);
+        waitpid(setter, NULL, 0);
+    }
+    if (gate[0] >= 0)
+        close(gate[0]);
+    if (gate[1] >= 0)
+        close(gate[1]);
+    munmap(shared, sizeof(*shared));
+    if (result == 0)
+        puts("QUEUED_AFFINITY_PASSED");
+    return result;
+}


### PR DESCRIPTION
本次按完整 ArceOS suite 的调用边界整理测试：普通功能使用工具链提供的 Rust `std`，经过 libc 和 POSIX 适配层；调度、IRQ、IPI、PI、lockdep、页表和设备等内核能力使用明确的 OS 入口。同时修复原 CI 竞态，以及真实标准库和内核专项暴露的两个实现缺口。

## 问题与根因

- 原失败任务：[ArceOS RISC-V suites](https://github.com/rcore-os/tgoskits/actions/runs/34311018613/job/102342765484)，提交 `21c7d4cb934203846dddffbe9cc2ec892165a7b6`。`spin_two_task_abba` 持有 A、B 时发布完成标志，退出时先释放 B 再释放 A；主线程取得 B 后 `try_lock(A)` 可以合法失败。完成标志必须在两把锁均释放后发布。
- Rust suite 的 `extern crate ax_std as std` 实际使用 mini-std，绕过 libc。去掉别名并使用正常 Rust 启动入口后，`std::io::pipe()` 暴露 `pipe2` 链接缺失；C 侧另有一个事后 `fcntl` 的包装，未正确保留描述符标志，且错误返回不符合 libc 的 `-1/errno` 契约。
- `CpuRunQueueState::update_thread_affinity` 只处理 current 任务，漏掉仍在队列中的非 current 任务。FIFO 控制器让 Fair 任务留在 CPU0 队列，CPU1 请求迁移时，已有 membership 没有被查询，触发 `0x5251_100e`。

## Linux RT 对照与实现

本地 Linux v7.1 PREEMPT_RT 对照提交为 `8cd9520d35a6c38db6567e97dd93b1f11f185dc6`。

`kernel/locking/spinlock_rt.c:78-86` 的 `rt_spin_unlock` 只释放当前锁，`kernel/locking/rtmutex.c:1383-1406` 的 trylock 在锁有 owner 时立即失败。因此修改测试的发布顺序，保留原来的 B→A 检查，并在工作线程发布前检查 A、B 已释放，使恢复旧顺序时确定性失败。

`kernel/sched/core.c:2734-2750,3012-3049` 和 `kernel/sched/fair.c:8970-8974` 允许更新 queued、非 current 任务的 affinity，并在所属 rq 和任务锁保护下完成源队列移除及目标队列激活。`ax-task` 现在将非 current 分支交给现有 `RunQueue::update_affinity`，更新各调度类的 metadata 后再迁移；未知任务仍返回失败，不移除原 invariant。

`task-scheduler-irq-window` 使用 FIFO 控制器和预先设置亲和性的内核任务，保留 `DEFAULT_BATCH_LIMIT + 1` 个 runnable 任务以及 IRQ continuation/window 两项断言。准备阶段不再依赖 65 个忙循环任务各先取得一次时间片。该专项已加入四架构 ArceOS CI 命令。

## std 与 OS 测试边界

- 文件、网络、普通线程、时间、分配与集合使用真正 std；普通同步改用 `Mutex`、`Condvar`、`Barrier` 和 channel。
- TLS 用 `thread_local!` 检查线程隔离和 pthread 退出后的析构；删除原来的 unsafe TLS 宏和 `unused_unsafe` 屏蔽。
- 管道创建使用 `std::io::pipe`，描述符由 `std::fs::File` 持有并读写、关闭。eventfd、epoll、futex 没有相同的 std 接口，使用 libc 的函数、常量和 ABI 类型，删除自建 epoll 布局与 OwnedFd。
- PI 与 lockdep 仍测试 `ax_std::os::arceos::sync::Mutex`，不替换成没有这些内核契约的 std Mutex。标准库 ThreadId 与内核 ThreadId 分开，PI owner 在任务内发布自己的内核标识。
- 栈保护页、受控调度 backlog 使用内核任务创建入口；缺页异常即将关机时使用同步的 OS 紧急控制台，避免 std/TTY 队列尚未排空就丢失判定标志。
- C suite 保留 C/POSIX ABI 覆盖并新增 pipe2 标志/errno 检查；LoongArch fixup 使用正常 Rust std 启动，架构 helper 保留；SG2002 USB no_std 硬件 harness 保留，移除混淆 std 名称的别名。

## pipe2 所有权与兼容范围

复用 `ax-posix-api` 的 fd 表和 Pipe 实现，由两个 libc 前端调用同一 `sys_pipe2`，删除 C 侧重复包装。`FileDescriptor` 将关闭标志与共享文件对象分开；`F_GETFD/F_SETFD`、`dup`、`F_DUPFD` 与 `F_DUPFD_CLOEXEC` 使用同一份 fd 状态。两个管道端点在 fd 表锁内安装，第二个槽位分配失败时撤回第一个，解锁后销毁端点，输出数组保持不变。

当前只支持既有阻塞字节流模式及 `O_CLOEXEC`；不承诺 nonblocking、packet 或 notification pipe，其他创建标志明确返回 `EINVAL`，不会静默接受无效模式。没有引入 exec 或新的持久状态。改动可按提交回退；回退 libc 补齐部分时也须回退依赖 `std::io::pipe` 的测试迁移。

## Starry 系统调用回归

`test-queued-affinity` 直接调用 `sched_setaffinity`：FIFO 父进程持有源 CPU，唤醒同 CPU 的 Fair 子进程，使它保持 runnable、非 current；另一 CPU 上的 setter 修改其亲和性并等待成功，子进程通过 `getcpu` 验证实际目的 CPU。PID、权限和用户 mask 经 Starry 的真实系统调用入口进入同一 owner-rq 更新链路。

x86_64 QEMU 的同一用例在恢复旧内核分支时确定性触发 `0x5251_100e`，恢复修复后输出 `QUEUED_AFFINITY_PASSED`。x86_64、RISC-V、AArch64、LoongArch 四架构的本地系统回归均已通过；该用例由现有 system CMake 发现与隔离运行器自动纳入四架构 CI，不增加单独配置或放宽判定。

## 系统调用兼容性对照

此表限定于本次修改的合法远端请求：目标任务 runnable、非 current，在亲和性变更完成后才从 `sched_setaffinity` 返回。权限和非法参数的既有处理未在本次改变，不将本表视为整个系统调用的全范围兼容声明。

| 系统调用/编号 | Linux 基准与稳定链接 | Linux 可观察语义 | StarryOS 入口与调用链 | 实现结论 | 测试与证据 |
| --- | --- | --- | --- | --- | --- |
| sched_setaffinity：x86_64/203；riscv64、aarch64、loongarch64/122 | Linux v7.1 `8cd9520d35a6`：[入口](https://github.com/torvalds/linux/blob/8cd9520d35a6c38db6567e97dd93b1f11f185dc6/kernel/sched/syscalls.c#L1262)、[queued 迁移](https://github.com/torvalds/linux/blob/8cd9520d35a6c38db6567e97dd93b1f11f185dc6/kernel/sched/core.c#L3012) | 合法 mask 下，queued 目标的允许 CPU 与所属 rq 一起完成更新/迁移，再返回 0 | `sys_sched_setaffinity` → `check_sched_permission`/`PidView`/`vm_load` → `ThreadHandle::set_affinity_and_wait` → owner affinity reconciliation → `CpuRunQueueState::update_thread_affinity` → class queue metadata；状态归目标线程及所属 rq | 正确 | `qemu/system/test-queued-affinity`：x86_64 恢复旧分支触发 `0x5251_100e`，恢复修复后通过；四架构均由运行器报告该用例退出 0；直接 syscall 返回成功且 `getcpu` 确认目的 CPU |

## 验证

- 原锁发布回归：旧顺序在 RISC-V QEMU 确定性报 `stage 1 requires spin lock A to be released`；相同用例修复后通过。
- queued affinity：受控 `task-scheduler-irq-window` 修复前触发 `0x5251_100e`，接回 class queue 更新后通过；四架构均通过，保留原断言和超时。
- libc：真实 std pipe 修复前链接失败 `undefined symbol: pipe2`；修复后验证两端 CLOEXEC、标准读写/EOF、重复 fd 标志独立、复制下限、非法标志、仅余一个 fd 槽位时的回滚与资源回收。
- `cargo xtask arceos test qemu --arch <arch>`：四架构 Rust/C suites 通过；LoongArch unaligned-fixup 通过。最终提交另完整重跑原 RISC-V suites 与 `taskset -c 0 ... --test-case task-ipi`，通过。
- RISC-V 内核专项补跑：缺页、panic、lockdep、CFS、RR、SMP online、栈保护页、remote wake 与 IRQ window 均通过。
- 定向 `cargo xtask clippy`：6 个软件包 113 项通过；queued affinity 最终修复后另检查 `ax-task`、`ax-posix-api`、`arceos-test-suit`，57 项通过。
- `cargo xtask test --since origin/dev`：13 个受影响软件包全部通过。
- `cargo xtask sync-lint --since origin/dev`：42 个变更 Rust 文件通过；`cargo fmt --all -- --check`、`git diff --check` 通过。
- CI 配置检查通过，Python 3.12 下运行现有 CI impact/plan/routing 共 63 项测试全部通过。
- `cargo publish --workspace --dry-run --no-verify`：通过，未执行实际发布。

本地未执行实体板卡测试，相关项目已由远端 CI 验证。最终提交 `7bbd30292fd906ac7d80b1f720fd41d2e2b78a10` 的 [push CI](https://github.com/rcore-os/tgoskits/actions/runs/34320873695) 和 [以 dev 基线覆盖全部改动的 CI](https://github.com/rcore-os/tgoskits/actions/runs/34321021027) 均已达到 `completed/success`，各 34/34 项通过。完整运行显式使用 `since_sha=4c757cc0e1fcda825c1a4cedbcf9d187c11485c8`，覆盖整个补丁的增量 Clippy、std tests、sync-lint 和运行测试。

完整基线首轮的 OrangePi robot Linux guest 在第一段摄像头性能检查后出现 `No frame (timeout)`，最终超时，另三项被矩阵连带取消；同一提交的 push 对应任务此前已通过。保留首轮失败记录，仅重跑失败及取消项，未改代码、阈值或超时。第二轮四项全部成功，Linux guest 两段有效帧率为 29.74/29.33 fps，完整流程输出 `RESULT=PASS attempts=1`。这次复测通过不代表已修复该板卡摄像头路径的偶发超时。

PR 包含必要的接口、所有权和迁移说明，合入前仍需调度及 libc 维护者审查。
