### PR TITLE
fix(ci): allow fork pull requests to run checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,8 +67,7 @@ jobs:
     if: >-
       github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request' &&
-       github.event.pull_request.head.repo.full_name == github.repository)
+      github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       actions: write

--- a/.github/workflows/reusable-check-matrix.yml
+++ b/.github/workflows/reusable-check-matrix.yml
@@ -42,8 +42,7 @@ jobs:
       github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch' ||
       github.event_name == 'schedule' ||
-      (github.event_name == 'pull_request' &&
-       github.event.pull_request.head.repo.full_name == github.repository)
+      github.event_name == 'pull_request'
     strategy:
       fail-fast: ${{ inputs.fail_fast }}
       max-parallel: ${{ inputs.max_parallel }}

--- a/scripts/test/test_ci_routing.py
+++ b/scripts/test/test_ci_routing.py
@@ -36,7 +36,7 @@ class RunnerTrustTests(unittest.TestCase):
         )
         self.assertNotIn("steps.route.outputs.should_run", cleanup)
 
-    def test_cross_repository_pr_is_rejected_before_planning_or_matrix_allocation(
+    def test_cross_repository_pr_can_enter_planning_and_matrix_allocation(
         self,
     ) -> None:
         for workflow_path, job_name, scheduled in (
@@ -51,8 +51,7 @@ class RunnerTrustTests(unittest.TestCase):
                     "github.event_name == 'push' || "
                     "github.event_name == 'workflow_dispatch' || "
                     + ("github.event_name == 'schedule' || " if scheduled else "")
-                    + "(github.event_name == 'pull_request' && "
-                    "github.event.pull_request.head.repo.full_name == github.repository)"
+                    + "github.event_name == 'pull_request'"
                 )
                 self.assertEqual(" ".join(condition.split()), expected)
 


### PR DESCRIPTION
## 问题与修复

#2328 的 fork PR 在 `Plan CI` 作业入口被整体跳过；可复用矩阵 `run` 还有同样的来源仓库限制，即使只放开规划阶段，实际检查仍不会执行。

同时移除两个作业入口对 PR 来源仓库的限制，使 fork PR 可以进入规划并执行受影响检查。保留现有同仓库去重：同分支、同 SHA 存在可用 push 运行时，由 push 承担检查，PR 跳过重复矩阵；缺少可用 push 或查询失败时，PR 正常执行。fork PR 不查询上游 push 进行去重，也不执行需要写权限的旧运行取消步骤。

将原先要求拒绝 fork PR 的入口测试改为允许其进入规划和矩阵，保留已有去重、取消及失败回退回归。

## 验证

- 修改回归断言后，旧工作流在 `ci.yml` 和 `reusable-check-matrix.yml` 两个子用例上均确定性失败；修复后同一测试通过。
- Python 3.12.11：`python3 scripts/test/check_ci_routing.py` 通过。
- `python3 -m unittest scripts/test/test_ci_impact.py scripts/test/test_ci_plan.py scripts/test/test_ci_routing.py`：63 项测试全部通过。
- `git diff --check` 通过。

远端实际矩阵运行结果以本 PR 当前提交的 CI 为准；fork PR 的恢复需在包含修复的新运行上确认，不能通过重跑旧配置证明。
