### PR TITLE
fix(release): restore semver checks and package Axvisor linker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1572,7 +1572,7 @@ dependencies = [
 
 [[package]]
 name = "axvisor"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "ax-api",

--- a/os/axvisor/Cargo.toml
+++ b/os/axvisor/Cargo.toml
@@ -2,7 +2,7 @@
 name = "axvisor"
 authors = ["Keyang Hu <keyang.hu@qq.com>", "周睿 <zrufo747@outlook.com>"]
 edition.workspace = true
-version = "0.7.0"
+version = "0.7.1"
 description = "A lightweight type-1 hypervisor based on ArceOS"
 repository = "https://github.com/arceos-hypervisor/axvisor"
 documentation = "https://docs.rs/axvisor"
@@ -13,6 +13,7 @@ include = [
     ".cargo/config.toml",
     "src/**",
     "build.rs",
+    "linker.ld",
     "configs/**",
     "xtask/src/**",
     "README.md",

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -5,13 +5,6 @@ publish_no_verify = true
 # PR, rather than publishing new crates before their dependencies are released.
 release_always = false
 
-# 0.18.1 exposes the same API on host targets with internal architecture stubs.
-# The published 0.17.13 baseline still fails host rustdoc. Re-enable after the
-# fixed baseline is published; retain AArch64 validation for hardware behavior.
-[[package]]
-name = "arm-gic-driver"
-semver_check = false
-
 # These crates expose mutually exclusive kernel TLS and Linux userspace modes.
 # release-plz does not expose cargo-semver-checks feature selection, so its
 # default feature union is not a supported build. Check valid modes separately
@@ -36,36 +29,8 @@ semver_check = false
 name = "ax-std"
 semver_check = false
 
-# ax-posix-api 0.6.1 packages its C headers and generates bindings in OUT_DIR.
-# The published 0.5.34 baseline still lacks those inputs. These crates use it.
-# Re-enable checks after a self-contained baseline is published; review ABI
-# changes manually in the meantime.
-[[package]]
-name = "ax-posix-api"
-semver_check = false
-
-[[package]]
-name = "ax-libc"
-semver_check = false
-
-[[package]]
-name = "axvm"
-semver_check = false
-
-# axbuild 0.6.1 packages its review-bench assets; published 0.5.3 does not.
-# Axvisor's host entry depends on it. Re-enable after a self-contained baseline
-# is published; review the build-tool API and CLI changes manually meanwhile.
-[[package]]
-name = "axbuild"
-semver_check = false
-
+# The published axvisor 0.7.0 omits linker.ld, which build.rs embeds.
+# Re-enable after the complete 0.7.1 package is published and checked.
 [[package]]
 name = "axvisor"
-semver_check = false
-
-[[package]]
-name = "x86_vcpu"
-# 0.7.1 uses flat bitflags for instruction/event interception. The published
-# 0.6.2 baseline still has recursive tock debug types that the JSON parser
-# cannot load. Re-enable after publishing the fixed baseline (or a parser fix).
 semver_check = false


### PR DESCRIPTION
# 问题与改动

#2331 的修复已通过 #2334 发布。使用 crates.io 的真实发布包验证后，恢复 `arm-gic-driver`、`x86_vcpu`、`ax-posix-api`、`ax-libc`、`axvm`、`axbuild` 的 semver 检查：删除包级 `semver_check = false` 及过期说明，使用 release-plz 默认开启检查的行为。

实际注册表验证还发现 `axvisor 0.7.0` 的 `build.rs` 通过 `include_str!` 引用 `linker.ld`，但发布白名单遗漏了该文件，导致发布包不能生成 rustdoc。本次将 `linker.ld` 加入 Cargo 打包清单，并将 `axvisor` 升级到 `0.7.1`。保留其 semver 例外并更新原因，待新版本实际发布、注册表基线验证通过后再恢复。

`ax-cpu`、`ax-hal`、`axplat-dyn`、`ax-runtime`、`ax-std` 的 `tls/uspace` 特性互斥仍存在，继续保留这 5 项例外。构建输出位置、硬件逻辑和公开 Rust API 均未修改。

# 验证

使用仓库固定 nightly 和 cargo-semver-checks 0.50.0，以默认特性选择直接读取 crates.io 基线，6 个恢复检查的软件包均通过，每包 196 项检查通过、58 项不适用：

| 软件包 | 注册表基线 |
| --- | --- |
| arm-gic-driver | 0.18.1 |
| x86_vcpu | 0.7.1 |
| ax-posix-api | 0.6.1 |
| ax-libc | 0.5.34 |
| axvm | 0.7.0 |
| axbuild | 0.6.1 |

`axvisor 0.7.0` 的真实注册表检查因缺少 `linker.ld` 失败；`cargo package --list` 的文件存在断言在修复前失败、修复后通过。

依据：[release-plz semver_check 官方配置文档](https://release-plz.dev/docs/config#the-semver_check-field)。

补齐后的 `axvisor 0.7.1` 实际 `.crate` 解包作为独立基线，rustdoc 构建与 semver 比较通过；这证明新产物完整，不替代尚未发布的注册表基线验证。

已通过 `cargo fmt --all -- --check`、`git diff --check`、`python3 scripts/test/check_posix_bindings.py` 的 4 组配置。未运行本地 clippy。`cargo publish --workspace --dry-run --no-verify` 已通过，没有执行实际发布。
