### PR TITLE
feat(axbuild): support to_bin in ArceOS build configs and log bin path

### DIFF
--- a/scripts/axbuild/src/arceos/build/cargo_config.rs
+++ b/scripts/axbuild/src/arceos/build/cargo_config.rs
@@ -31,8 +31,9 @@ pub(crate) fn load_c_app_cargo_config(request: &ResolvedBuildRequest) -> anyhow:
     let metadata =
         build::cached_workspace_metadata().context("failed to load workspace metadata")?;
     let makefile_features = build::makefile_features_from_env();
-    let mut build_info =
-        load_build_config_with_makefile_features(request, &makefile_features)?.build_info;
+    let config = load_build_config_with_makefile_features(request, &makefile_features)?;
+    let to_bin = config.to_bin;
+    let mut build_info = config.build_info;
     build_info.validated_max_cpu_num()?;
     build_info.resolve_c_app_features()?;
     let mut cargo = build_info.into_prepared_no_std_cargo_config_with_metadata(
@@ -41,6 +42,6 @@ pub(crate) fn load_c_app_cargo_config(request: &ResolvedBuildRequest) -> anyhow:
         metadata,
         build::BareKernelLinkMode::Default,
     )?;
-    cargo.to_bin = false;
+    cargo.to_bin = to_bin;
     Ok(cargo)
 }

--- a/scripts/axbuild/src/arceos/build/cargo_config.rs
+++ b/scripts/axbuild/src/arceos/build/cargo_config.rs
@@ -15,13 +15,16 @@ pub(crate) fn load_cargo_config(request: &ResolvedBuildRequest) -> anyhow::Resul
             request.build_info_path.display()
         );
     }
-    let build_info = config.build_info;
-
-    build_info.into_prepared_std_cargo_config_with_metadata(
-        &request.package,
-        &request.target,
-        metadata,
-    )
+    let to_bin = config.to_bin;
+    let mut cargo = config
+        .build_info
+        .into_prepared_std_cargo_config_with_metadata(
+            &request.package,
+            &request.target,
+            metadata,
+        )?;
+    cargo.to_bin = to_bin;
+    Ok(cargo)
 }
 
 pub(crate) fn load_c_app_cargo_config(request: &ResolvedBuildRequest) -> anyhow::Result<Cargo> {

--- a/scripts/axbuild/src/arceos/build/tests.rs
+++ b/scripts/axbuild/src/arceos/build/tests.rs
@@ -129,6 +129,25 @@ fn rust_build_config_to_bin_is_passed_to_cargo_config() {
 }
 
 #[test]
+fn app_c_build_config_to_bin_is_passed_to_cargo_config() {
+    let root = tempdir().unwrap();
+    let source_dir = root.path().join("c");
+    fs::create_dir_all(&source_dir).unwrap();
+    fs::write(source_dir.join("main.c"), "int main(void) { return 0; }\n").unwrap();
+    let path = root.path().join("build-x86_64-unknown-none.toml");
+    fs::write(
+        &path,
+        "app-c = \"c\"\nfeatures = []\nlog = \"Warn\"\nto_bin = true\n",
+    )
+    .unwrap();
+    let request = request("ax-libc", "x86_64-unknown-none", path);
+
+    let cargo = load_c_app_cargo_config(&request).unwrap();
+
+    assert!(cargo.to_bin);
+}
+
+#[test]
 fn app_c_build_config_resolves_source_dir_relative_to_config() {
     let root = tempdir().unwrap();
     let case_dir = root.path().join("case");

--- a/scripts/axbuild/src/arceos/build/tests.rs
+++ b/scripts/axbuild/src/arceos/build/tests.rs
@@ -8,7 +8,8 @@ use tempfile::tempdir;
 use super::{
     ArceosBuildInfo, ArceosBuildMode,
     info::{load_build_info, resolve_build_info_path_in_dir},
-    load_arceos_build_mode, load_c_app_cargo_config, resolve_app_c_dir, resolve_app_c_mode,
+    load_arceos_build_mode, load_c_app_cargo_config, load_cargo_config, resolve_app_c_dir,
+    resolve_app_c_mode, resolve_build_info_path,
 };
 use crate::{build, context::ResolvedBuildRequest};
 
@@ -111,6 +112,20 @@ fn build_config_without_app_c_uses_std_rust_mode() {
     let mode = load_arceos_build_mode(&path).unwrap();
 
     assert_eq!(mode, ArceosBuildMode::RustStd);
+}
+
+#[test]
+fn rust_build_config_to_bin_is_passed_to_cargo_config() {
+    let root = tempdir().unwrap();
+    let path = root
+        .path()
+        .join("build-aarch64-unknown-none-softfloat.toml");
+    fs::write(&path, "features = []\nlog = \"Info\"\nto_bin = true\n").unwrap();
+    let request = request("arceos-helloworld", "aarch64-unknown-none-softfloat", path);
+
+    let cargo = load_cargo_config(&request).unwrap();
+
+    assert!(cargo.to_bin);
 }
 
 #[test]

--- a/scripts/axbuild/src/arceos/build/types.rs
+++ b/scripts/axbuild/src/arceos/build/types.rs
@@ -11,6 +11,8 @@ pub type ArceosBuildInfo = BuildInfo;
 pub(crate) struct ArceosBuildConfig {
     #[serde(flatten, default)]
     pub(crate) build_info: ArceosBuildInfo,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub(crate) to_bin: bool,
     #[serde(rename = "app-c", skip_serializing_if = "Option::is_none")]
     pub(crate) app_c: Option<PathBuf>,
 }
@@ -19,9 +21,14 @@ impl ArceosBuildConfig {
     pub(super) fn default_config() -> Self {
         Self {
             build_info: ArceosBuildInfo::default(),
+            to_bin: false,
             app_c: None,
         }
     }
+}
+
+fn is_false(value: &bool) -> bool {
+    !*value
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Deserialize, Serialize)]

--- a/scripts/axbuild/src/arceos/mod.rs
+++ b/scripts/axbuild/src/arceos/mod.rs
@@ -472,8 +472,18 @@ impl ArceOS {
                     .map(|_| ())
             }
             build::ArceosBuildMode::AppC { app_dir, app_name } => {
+                let cargo = build::load_c_app_cargo_config(&request)?;
                 let output = self.build_c_app_request(&request, app_dir, app_name)?;
-                println!("Built ArceOS C app ELF: {}", output.elf_path.display());
+                println!("[axbuild] cargo build elf={}", output.elf_path.display());
+                if cargo.to_bin {
+                    self.app
+                        .prepare_elf_artifact(output.elf_path.clone(), true)
+                        .await?;
+                    println!(
+                        "[axbuild] cargo build bin={}",
+                        crate::context::cargo_bin_path_for_elf(&output.elf_path).display()
+                    );
+                }
                 Ok(())
             }
         }

--- a/scripts/axbuild/src/context/mod.rs
+++ b/scripts/axbuild/src/context/mod.rs
@@ -582,7 +582,7 @@ fn display_optional_path(path: Option<&Path>) -> String {
         .unwrap_or_else(|| "<default>".to_string())
 }
 
-fn cargo_bin_path_for_elf(elf_path: &Path) -> PathBuf {
+pub(crate) fn cargo_bin_path_for_elf(elf_path: &Path) -> PathBuf {
     elf_path.with_extension("bin")
 }
 

--- a/scripts/axbuild/src/context/mod.rs
+++ b/scripts/axbuild/src/context/mod.rs
@@ -140,6 +140,12 @@ impl AppContext {
                 .await?;
         stage.done();
         println!("[axbuild] cargo build elf={}", output.elf_path().display());
+        if cargo.to_bin {
+            println!(
+                "[axbuild] cargo build bin={}",
+                cargo_bin_path_for_elf(output.elf_path()).display()
+            );
+        }
         println!(
             "[axbuild] cargo build artifact_dir={}",
             output.cargo_artifact_dir().display()
@@ -574,6 +580,10 @@ impl StageLog {
 fn display_optional_path(path: Option<&Path>) -> String {
     path.map(|path| path.display().to_string())
         .unwrap_or_else(|| "<default>".to_string())
+}
+
+fn cargo_bin_path_for_elf(elf_path: &Path) -> PathBuf {
+    elf_path.with_extension("bin")
 }
 
 struct EnvRestoreGuard {

--- a/scripts/axbuild/src/context/tests.rs
+++ b/scripts/axbuild/src/context/tests.rs
@@ -7,3 +7,15 @@ mod common;
 mod snapshot;
 mod starry;
 mod workspace;
+
+#[test]
+fn cargo_bin_path_replaces_elf_extension() {
+    assert_eq!(
+        cargo_bin_path_for_elf(Path::new("/workspace/target/release/kernel")),
+        PathBuf::from("/workspace/target/release/kernel.bin")
+    );
+    assert_eq!(
+        cargo_bin_path_for_elf(Path::new("/workspace/target/release/kernel.elf")),
+        PathBuf::from("/workspace/target/release/kernel.bin")
+    );
+}


### PR DESCRIPTION
修复 arceos 的测例构建配置文件的配置项 `to_bin = true` 未能生效，未构建出 .bin 文件
例如 
`cargo xtask arceos build --package arceos-helloworld --target aarch64-unknown-none-softfloat` 
没有构建出 `arceos-helloworld.bin`