### PR TITLE
fix(runtime): prefer userspace over kernel TLS through build cfg

### DIFF
--- a/.agents/skills/arch-platform-porting/SKILL.md
+++ b/.agents/skills/arch-platform-porting/SKILL.md
@@ -35,7 +35,7 @@ description: 为 ArceOS、StarryOS、Axvisor、someboot、动态统一可扩展�
 ## 移植检查清单
 
 - **目标与工具链**：检查 `scripts/targets` 目标规格、目标三元组、内核恐慌策略、重定位与代码模型、二进制接口、软浮点、musl 或标准库支持、链接器、目标文件复制工具和 `rust-src`。四架构裸机构建和 Clippy 必须通过共享 `BareBuildTarget` 统一解析 `scripts/targets/bare/<逻辑目标名>.json`，不得为单一架构退回内置目标或另加命令行 target feature；逻辑目标名、`AX_TARGET` 和产物目录仍使用原目标三元组，JSON 路径只作为 Cargo `--target` 输入。各 JSON 精确保持固定 nightly 对应内置目标的二进制接口和指令集基线；LoongArch 目标额外保持 `lp64s` soft-float，并在 target specification 的 `features` 中声明 `-ual`，不得恢复会产生 unstable target feature 警报的命令行 `-Ctarget-feature=-ual`。改动 LoongArch 规格后同时运行 ArceOS `unaligned-fixup` 与 Starry `c-regression-test-loongarch-unaligned-cross-page` 回归，确认未对齐异常修复、跨页访问和 `SIGBUS` 语义。
-- **内核运行模式**：明确最终映像契约。Starry 是以 `build-std=core,alloc` 构建的独立 `no_std`、`no_main` 位置无关可执行文件，始终保留对称多处理能力且不得含内核线程局部存储。Axvisor 保持标准库与 musl 位置无关可执行文件，并显式启用线程局部存储。ArceOS 默认启用线程局部存储，但配置必须拒绝 `uspace + tls`，不能构造寄存器所有权重叠的映像。
+- **内核运行模式**：明确最终映像契约。Starry 是以 `build-std=core,alloc` 构建的独立 `no_std`、`no_main` 位置无关可执行文件，始终保留对称多处理能力且不得含内核线程局部存储。Axvisor 保持标准库与 musl 位置无关可执行文件，并显式启用线程局部存储。ArceOS 默认启用线程局部存储；`uspace + tls` 按 `uspace` 选择寄存器所有权，内部 `kernel_tls` cfg 关闭。
 - **处理器局部执行上下文二进制接口**：`cpu-local` 独占当前来源选择、上下文绑定、切换事务和体系结构选定的抢占状态；`ax-percpu` 只负责类型化布局与存储。不得创建第二个逐处理器当前上下文指针。最终映像模式决定寄存器分配；精确初始化后的 `CpuAreaRef` 地址就是区域身份，不增加映像内二进制接口版本、代数、标记、提供者特征外部函数接口或原始线程指针访问。
 
   | 体系结构 | 处理器区域 | `LinuxCurrent` | `UnikernelTls` |
@@ -99,6 +99,7 @@ description: 为 ArceOS、StarryOS、Axvisor、someboot、动态统一可扩展�
 - x86_64 直接位置无关可执行启动在进入 Rust 前，由裸函数和相对指令指针入口应用受支持的 `R_X86_64_RELATIVE`。统一可扩展固件接口头可以共用头部节，但原始入口符号仍是直接加载入口，加载偏移后其物理地址保持有效。
 - AArch64 需要在 Rust 全局保存异常级转换状态时，把它传入重定位后入口，不能在重定位前写可重定位静态变量。统一可扩展固件接口入口按通用固件重定位契约适配 `relocate::apply`，在公共异常级设置前初始化统一可扩展固件接口、扁平设备树和高级配置与电源接口，不能重进会清理未初始化数据段或覆盖已取得设备树地址的直接启动路径。
 - 未初始化数据段只清理一次，且先保存其中的入口数据。
+- `tls` 与 `uspace` 同时启用时采用 `uspace` 的寄存器所有权，不启用内核 TLS。相关软件包在 `build.rs` 由 `CARGO_FEATURE_TLS` 存在且 `CARGO_FEATURE_USPACE` 不存在派生内部 `kernel_tls` cfg；Cargo feature 必须完整转发到 `cpu-local` 和启动层，自定义 cfg 不跨包传播。`someboot::Build::kernel_tls` 与源码 cfg 消费同一次计算结果，不能使用 AArch64 启动调整后的 `Build::uspace` 反推内核 TLS。
 - 线程局部存储与无线程局部存储使用不同链接布局。后者拒绝 `.tdata` 和 `.tbss` 并省略 `PT_TLS`；前者保留线程局部存储程序头和启动数据。
 - LoongArch 开放虚拟机固件同时取得固件设备树配置表和高级配置与电源接口根系统描述指针，但不由 someboot 或 somehal 再从这些表探测实时时钟。动态路径先使用统一可扩展固件接口运行服务 `GetTime`；固件时钟不可用时，由 `ax-driver` 处理 `loongson,ls7a-rtc` 或 `LOON0001`。
 - 启用对称多处理前分配并对齐启动栈、逐处理器区域、次处理器栈、启动参数和页表；启用中断、定时中断、内存管理单元错误或次处理器前安装陷阱向量。

--- a/.agents/skills/arch-platform-porting/references/boot-debugging.md
+++ b/.agents/skills/arch-platform-porting/references/boot-debugging.md
@@ -69,7 +69,7 @@ AArch64 宿主替换中，把不可变固件计划中的每个 GICR 区域和步
 
 - Starry 使用原裸机目标，以 `build-std=core,alloc` 构建 `no_std`、`no_main` 位置无关可执行文件；对称多处理是构建能力，运行时处理器上限另行配置。最终文件必须为 `ET_DYN`，且没有 `PT_TLS`、`.tdata` 或 `.tbss`。
 - Axvisor 保持标准库与 musl 位置无关可执行文件，并从 axruntime、axhal、`cpu-local`、axvm、axplat-dyn、somehal 到 someboot 显式选择完整线程局部存储链。AxVM 在每次客户机转换前后保存宿主内核线程局部存储值，并验证精确处理器区域。
-- ArceOS 默认保留线程局部存储。用户空间构建使用同一体系结构寄存器保存 Linux 当前上下文，因此 `uspace + tls` 是配置错误。
+- ArceOS 默认保留线程局部存储。用户空间构建使用同一体系结构寄存器保存 Linux 当前上下文，因此 `uspace + tls` 按 `uspace` 处理，`build.rs` 不输出 `kernel_tls` cfg，链接脚本也不启用内核 TLS。
 - someboot 分别生成线程局部存储与无线程局部存储链接布局。可重定位直接映像应在多个加载偏移检查最终文件，只接受体系结构支持的相对重定位类型。
 
 ## AArch64 Axvisor 异常级 2 检查

--- a/.github/ci/checks/starry.toml
+++ b/.github/ci/checks/starry.toml
@@ -16,6 +16,7 @@ download_xtask_bin_artifact = true
 command = '''
 target/debug/tg-xtask starry test qemu --arch riscv64
 target/debug/tg-xtask ktest qemu -p starry-kernel --arch riscv64
+FEATURES=ax-runtime/tls target/debug/tg-xtask starry test qemu --arch riscv64 --test-case qemu/system/syscall-test-clone-tls
 '''
 
 [[check.suite]]
@@ -36,6 +37,7 @@ target/debug/tg-xtask starry qemu --arch aarch64 --smp 4 \
 echo "==> starry aarch64 test suites"
 target/debug/tg-xtask starry test qemu --arch aarch64
 target/debug/tg-xtask ktest qemu -p starry-kernel --arch aarch64
+FEATURES=ax-runtime/tls target/debug/tg-xtask starry test qemu --arch aarch64 --test-case qemu/system/syscall-test-clone-tls
 '''
 
 [[check.suite]]
@@ -52,6 +54,7 @@ download_xtask_bin_artifact = true
 command = '''
 target/debug/tg-xtask starry test qemu --arch loongarch64
 target/debug/tg-xtask ktest qemu -p starry-kernel --arch loongarch64
+FEATURES=ax-runtime/tls target/debug/tg-xtask starry test qemu --arch loongarch64 --test-case qemu/system/syscall-test-clone-tls
 '''
 
 [[check.suite]]
@@ -68,6 +71,7 @@ download_xtask_bin_artifact = true
 command = '''
 target/debug/tg-xtask starry test qemu --arch x86_64
 target/debug/tg-xtask ktest qemu -p starry-kernel --arch x86_64
+FEATURES=ax-runtime/tls target/debug/tg-xtask starry test qemu --arch x86_64 --test-case qemu/system/syscall-test-clone-tls
 '''
 
 [[check.suite]]

--- a/.github/ci/checks/static.toml
+++ b/.github/ci/checks/static.toml
@@ -10,6 +10,7 @@ command = '''
 cargo fmt --all -- --check
 cargo publish --workspace --dry-run --no-verify
 python3 scripts/test/check_posix_bindings.py
+python3 scripts/test/check_kernel_tls_modes.py
 '''
 
 [[check]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "ax-cpu"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "aarch64-cpu 11.2.0",
  "ax-lazyinit",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "ax-hal"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "ax-alloc",
  "ax-cpu",
@@ -1147,7 +1147,7 @@ dependencies = [
 
 [[package]]
 name = "ax-runtime"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "ax-alloc",
  "ax-crate-interface",
@@ -1197,7 +1197,7 @@ dependencies = [
 
 [[package]]
 name = "ax-std"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "ax-alloc",
  "ax-api",
@@ -1421,7 +1421,7 @@ version = "0.1.1"
 
 [[package]]
 name = "axplat-dyn"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "ax-cpu",
@@ -2352,7 +2352,7 @@ dependencies = [
 
 [[package]]
 name = "cpu-local"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "thiserror 2.0.20",
 ]
@@ -7703,7 +7703,7 @@ dependencies = [
 
 [[package]]
 name = "someboot"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "aarch64-cpu 11.2.0",
  "aarch64-cpu-ext",
@@ -7746,7 +7746,7 @@ dependencies = [
 
 [[package]]
 name = "somehal"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "aarch64-cpu 11.2.0",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,8 +134,8 @@ arm_vgic = { version = "0.6", path = "virtualization/arm_vgic" }
 ax-alloc = { version = "0.9", path = "memory/ax-alloc", default-features = false }
 ax-api = { version = "0.8", path = "os/arceos/api/arceos_api" }
 ax-arm-pl031 = { version = "0.4", path = "drivers/rtc/arm_pl031" }
-cpu-local = { version = "0.2", path = "components/cpu-local" }
-ax-cpu = { version = "0.9", path = "components/axcpu" }
+cpu-local = { version = "0.3.0", path = "components/cpu-local" }
+ax-cpu = { version = "0.9.1", path = "components/axcpu" }
 ax-cpumask = { version = "0.4", path = "components/cpumask" }
 ax-crate-interface = { version = "0.5", path = "components/crate_interface" }
 ax-cgroup = { version = "0.3", path = "components/ax-cgroup" }
@@ -145,7 +145,7 @@ ax-display = { version = "0.6", path = "os/arceos/modules/axdisplay" }
 ax-driver = { version = "0.14", path = "drivers/ax-driver" }
 virtio-drivers = { version = "0.13.0", default-features = false }
 ax-fs-ng = { version = "0.10", path = "fs/ax-fs-ng" }
-ax-hal = { version = "0.7", path = "os/arceos/modules/axhal" }
+ax-hal = { version = "0.7.1", path = "os/arceos/modules/axhal" }
 irq-framework = { version = "0.5", path = "components/irq-framework" }
 ax-input = { version = "0.6", path = "os/arceos/modules/axinput" }
 ax-io = { version = "0.7", path = "components/axio" }
@@ -166,8 +166,8 @@ ax-plat = { version = "0.14", path = "platforms/ax-plat" }
 ax-plat-macros = { version = "0.3", path = "platforms/ax-plat-macros" }
 ax-posix-api = { version = "0.6.1", path = "os/arceos/api/arceos_posix_api" }
 ax-riscv-plic = { version = "0.4", path = "drivers/intc/riscv_plic" }
-ax-runtime = { version = "0.12", path = "os/arceos/modules/axruntime" }
-ax-std = { version = "0.6", path = "os/arceos/ulib/axstd", default-features = false }
+ax-runtime = { version = "0.12.1", path = "os/arceos/modules/axruntime" }
+ax-std = { version = "0.6.1", path = "os/arceos/ulib/axstd", default-features = false }
 ax-sync = { version = "0.6", path = "os/arceos/modules/axsync" }
 ax-task = { version = "0.7", path = "components/ax-task" }
 ax-tracepoint = { version = "0.6", path = "components/ax-tracepoint" }
@@ -183,7 +183,7 @@ axfs-ng-vfs = { version = "0.7", path = "fs/axfs-ng-vfs" }
 axhvc = { version = "0.5", path = "virtualization/axhvc" }
 axivc = { version = "0.1", path = "virtualization/axivc" }
 axklib = { version = "0.9", path = "components/axklib" }
-axplat-dyn = { version = "0.9", path = "platforms/axplat-dyn", default-features = false }
+axplat-dyn = { version = "0.9.1", path = "platforms/axplat-dyn", default-features = false }
 axpoll = { version = "0.7", path = "components/axpoll" }
 axvirtio-blk = { version = "0.2", path = "virtualization/axvirtio-blk" }
 axvirtio-common = { version = "0.2", path = "virtualization/axvirtio-common" }
@@ -259,13 +259,13 @@ httpboot-protocol = { version = "0.1.0", default-features = false }
 x86_vcpu = { version = "0.7.1", path = "virtualization/x86_vcpu", default-features = false }
 x86_vlapic = { version = "0.5", path = "virtualization/x86_vlapic" }
 page-table-generic = { version = "0.9", path = "memory/page-table-generic" }
-someboot = { version = "0.5", path = "platforms/someboot" }
+someboot = { version = "0.5.1", path = "platforms/someboot" }
 some-serial = { version = "0.7", path = "drivers/serial/some-serial" }
 kernutil = { path = "components/kernutil", version = "0.3" }
 ranges-ext = { version = "0.6", path = "memory/ranges-ext" }
 somehal-macros = { path = "platforms/somehal-macros", version = "0.1" }
 kasm-aarch64 = { path = "components/kasm-aarch64", version = "0.2" }
-somehal = { version = "0.10", path = "platforms/somehal" }
+somehal = { version = "0.10.1", path = "platforms/somehal" }
 
 # External crates
 acpi_tables = "0.2.1"

--- a/components/axcpu/Cargo.toml
+++ b/components/axcpu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ax-cpu"
-version = "0.9.0"
+version = "0.9.1"
 repository = "https://github.com/rcore-os/tgoskits"
 edition.workspace = true
 authors = [
@@ -26,8 +26,11 @@ exception-table = []
 fp-simd = []
 # Use unprivileged host-safe register fallbacks in scheduler tests.
 host-test = []
+# Request kernel TLS; `uspace` takes precedence and disables kernel TLS.
 tls = ["cpu-local/tls"]
-uspace = ["exception-table"]
+# Enable userspace support without kernel TLS, including when `tls` is enabled.
+# User-space TLS remains available through the userspace context APIs.
+uspace = ["exception-table", "cpu-local/uspace"]
 arm-el2 = []
 xuantie-c9xx = []
 

--- a/components/axcpu/README.md
+++ b/components/axcpu/README.md
@@ -20,6 +20,17 @@ English | [中文](README_CN.md)
 
 > ax-cpu was derived from https://github.com/arceos-org/axcpu
 
+## TLS and userspace features
+
+`tls` requests kernel thread-local storage. `uspace` takes precedence over
+`tls`: enabling both selects the same register ownership and context-switch
+path as `uspace` alone, without kernel TLS. User-space TLS is still saved and
+restored by the user-context APIs. Kernel thread-pointer accessors are available
+only when `tls` is enabled and `uspace` is disabled. `build.rs` derives the
+internal `kernel_tls` cfg; callers should select Cargo features instead of
+setting this cfg themselves. Existing single-feature modes keep their behavior
+and task-context layout.
+
 ## Quick Start
 
 ### Installation

--- a/components/axcpu/build.rs
+++ b/components/axcpu/build.rs
@@ -1,0 +1,8 @@
+fn main() {
+    let kernel_tls = std::env::var_os("CARGO_FEATURE_TLS").is_some()
+        && std::env::var_os("CARGO_FEATURE_USPACE").is_none();
+    println!("cargo::rustc-check-cfg=cfg(kernel_tls)");
+    if kernel_tls {
+        println!("cargo::rustc-cfg=kernel_tls");
+    }
+}

--- a/components/axcpu/src/aarch64/asm.rs
+++ b/components/axcpu/src/aarch64/asm.rs
@@ -7,7 +7,7 @@ use ax_memory_addr::{PhysAddr, VirtAddr};
 
 #[cfg(not(feature = "arm-el2"))]
 use super::asid::configured_tag_capacity;
-#[cfg(feature = "tls")]
+#[cfg(kernel_tls)]
 use crate::KernelTlsBase;
 #[cfg(feature = "uspace")]
 use crate::{InstalledAddressSpace, InstalledAddressSpaceMode};
@@ -339,7 +339,7 @@ pub unsafe fn write_exception_vector_base(vbar: usize) {
 ///
 /// It is used to implement TLS (Thread Local Storage).
 #[inline]
-#[cfg(feature = "tls")]
+#[cfg(kernel_tls)]
 pub fn read_thread_pointer() -> KernelTlsBase {
     KernelTlsBase::new(TPIDR_EL0.get() as usize)
 }
@@ -352,7 +352,7 @@ pub fn read_thread_pointer() -> KernelTlsBase {
 ///
 /// This function is unsafe as it changes the current CPU states.
 #[inline]
-#[cfg(feature = "tls")]
+#[cfg(kernel_tls)]
 pub unsafe fn write_thread_pointer(kernel_tls: KernelTlsBase) {
     TPIDR_EL0.set(kernel_tls.as_usize() as _)
 }

--- a/components/axcpu/src/aarch64/context.rs
+++ b/components/axcpu/src/aarch64/context.rs
@@ -286,7 +286,7 @@ impl TaskContext {
     }
 }
 
-#[cfg(feature = "tls")]
+#[cfg(kernel_tls)]
 #[unsafe(naked)]
 unsafe extern "C" fn context_switch_raw(_current_task: &mut TaskContext, _next_task: &TaskContext) {
     naked_asm!(
@@ -332,7 +332,7 @@ unsafe extern "C" fn context_switch_raw(_current_task: &mut TaskContext, _next_t
     )
 }
 
-#[cfg(not(feature = "tls"))]
+#[cfg(not(kernel_tls))]
 #[unsafe(naked)]
 unsafe extern "C" fn context_switch_raw(_current_task: &mut TaskContext, _next_task: &TaskContext) {
     naked_asm!(

--- a/components/axcpu/src/lib.rs
+++ b/components/axcpu/src/lib.rs
@@ -6,9 +6,6 @@
 #[cfg(all(feature = "host-test", not(target_os = "none")))]
 extern crate std;
 
-#[cfg(all(feature = "uspace", feature = "tls"))]
-compile_error!("ax-cpu userspace requires LinuxCurrent and cannot enable kernel TLS mode");
-
 #[macro_use]
 extern crate log;
 
@@ -47,7 +44,7 @@ impl KernelTlsBase {
     }
 
     pub(crate) fn for_task_context(requested: Self) -> Self {
-        if cfg!(feature = "tls") {
+        if cfg!(kernel_tls) {
             requested
         } else {
             assert!(

--- a/components/axcpu/src/loongarch64/asm.rs
+++ b/components/axcpu/src/loongarch64/asm.rs
@@ -12,7 +12,7 @@ use loongArch64::register::{
 const INVTLB_ADDR_GTRUE_OR_ASID: usize = 0x06;
 const TLB_PAIR_SIZE: usize = PAGE_SIZE_4K * 2;
 
-#[cfg(feature = "tls")]
+#[cfg(kernel_tls)]
 use crate::KernelTlsBase;
 #[cfg(feature = "uspace")]
 use crate::{InstalledAddressSpace, InstalledAddressSpaceMode};
@@ -291,7 +291,7 @@ pub unsafe fn write_pwc(pwcl: u32, pwch: u32) {
 /// This register follows the execution context across CPUs. It is distinct
 /// from the CPU-local base kept in `$r21`.
 #[inline]
-#[cfg(feature = "tls")]
+#[cfg(kernel_tls)]
 pub fn read_thread_pointer() -> KernelTlsBase {
     let address;
     unsafe { asm!("move {}, $tp", out(reg) address) };
@@ -309,7 +309,7 @@ pub fn read_thread_pointer() -> KernelTlsBase {
 /// is becoming current and that no Rust code observes a half-completed context
 /// switch.
 #[inline]
-#[cfg(feature = "tls")]
+#[cfg(kernel_tls)]
 pub unsafe fn write_thread_pointer(kernel_tls: KernelTlsBase) {
     unsafe { asm!("move $tp, {}", in(reg) kernel_tls.as_usize()) }
 }

--- a/components/axcpu/src/loongarch64/context.rs
+++ b/components/axcpu/src/loongarch64/context.rs
@@ -414,7 +414,7 @@ unsafe extern "C" fn restore_fp_registers(fpu: &FpuState) {
     )
 }
 
-#[cfg(feature = "tls")]
+#[cfg(kernel_tls)]
 #[unsafe(naked)]
 unsafe extern "C" fn context_switch_raw(_current_task: &mut TaskContext, _next_task: &TaskContext) {
     naked_asm!(
@@ -470,7 +470,7 @@ unsafe extern "C" fn context_switch_raw(_current_task: &mut TaskContext, _next_t
     )
 }
 
-#[cfg(not(feature = "tls"))]
+#[cfg(not(kernel_tls))]
 #[unsafe(naked)]
 unsafe extern "C" fn context_switch_raw(_current_task: &mut TaskContext, _next_task: &TaskContext) {
     naked_asm!(

--- a/components/axcpu/src/riscv/asm.rs
+++ b/components/axcpu/src/riscv/asm.rs
@@ -6,7 +6,7 @@ use riscv::{
     register::{satp, sstatus, stvec},
 };
 
-#[cfg(feature = "tls")]
+#[cfg(kernel_tls)]
 use crate::KernelTlsBase;
 #[cfg(feature = "uspace")]
 use crate::{InstalledAddressSpace, InstalledAddressSpaceMode};
@@ -243,7 +243,7 @@ pub unsafe fn write_trap_vector_base(stvec: usize) {
 /// The value is task-owned kernel TLS. CPU-local state is anchored by
 /// `sscratch` and must not be inferred from this register.
 #[inline]
-#[cfg(feature = "tls")]
+#[cfg(kernel_tls)]
 pub fn read_thread_pointer() -> KernelTlsBase {
     let tp;
     unsafe { core::arch::asm!("mv {}, tp", out(reg) tp) };
@@ -260,7 +260,7 @@ pub fn read_thread_pointer() -> KernelTlsBase {
 /// The caller must ensure that `tls_base` belongs to the execution context
 /// currently being installed and remains valid while that context can run.
 #[inline]
-#[cfg(feature = "tls")]
+#[cfg(kernel_tls)]
 pub unsafe fn write_thread_pointer(tls_base: KernelTlsBase) {
     unsafe { core::arch::asm!("mv tp, {}", in(reg) tls_base.as_usize()) }
 }

--- a/components/axcpu/src/riscv/context.rs
+++ b/components/axcpu/src/riscv/context.rs
@@ -418,7 +418,7 @@ unsafe extern "C" fn clear_fp_registers() {
     )
 }
 
-#[cfg(feature = "tls")]
+#[cfg(kernel_tls)]
 #[unsafe(naked)]
 unsafe extern "C" fn context_switch_raw(_current_task: &mut TaskContext, _next_task: &TaskContext) {
     naked_asm!(
@@ -478,7 +478,7 @@ unsafe extern "C" fn context_switch_raw(_current_task: &mut TaskContext, _next_t
     )
 }
 
-#[cfg(not(feature = "tls"))]
+#[cfg(not(kernel_tls))]
 #[unsafe(naked)]
 unsafe extern "C" fn context_switch_raw(_current_task: &mut TaskContext, _next_task: &TaskContext) {
     naked_asm!(

--- a/components/axcpu/src/riscv/local_state.rs
+++ b/components/axcpu/src/riscv/local_state.rs
@@ -2,7 +2,7 @@
 
 use core::mem::{offset_of, size_of};
 
-#[cfg(not(feature = "tls"))]
+#[cfg(not(kernel_tls))]
 use cpu_local::EXECUTION_CONTEXT_ARCH_STATE_OFFSET;
 use cpu_local::{
     CPU_AREA_ARCH_STATE_OFFSET, CPU_AREA_ARCH_STATE_SIZE, EXECUTION_CONTEXT_ARCH_STATE_SIZE,
@@ -28,16 +28,16 @@ pub(super) const CPU_KERNEL_STACK_POINTER_OFFSET: usize =
     CPU_AREA_ARCH_STATE_OFFSET + offset_of!(CpuTrapState, kernel_stack_pointer);
 pub(super) const CPU_USER_TRAP_FRAME_OFFSET: usize =
     CPU_AREA_ARCH_STATE_OFFSET + offset_of!(CpuTrapState, user_trap_frame);
-#[cfg(feature = "tls")]
+#[cfg(kernel_tls)]
 pub(super) const CPU_ENTRY_SCRATCH0_OFFSET: usize =
     CPU_AREA_ARCH_STATE_OFFSET + offset_of!(CpuTrapState, entry_scratch0);
-#[cfg(feature = "tls")]
+#[cfg(kernel_tls)]
 pub(super) const CPU_ENTRY_SCRATCH1_OFFSET: usize =
     CPU_AREA_ARCH_STATE_OFFSET + offset_of!(CpuTrapState, entry_scratch1);
-#[cfg(not(feature = "tls"))]
+#[cfg(not(kernel_tls))]
 pub(super) const THREAD_SCRATCH0_OFFSET: usize =
     EXECUTION_CONTEXT_ARCH_STATE_OFFSET + offset_of!(ThreadTrapState, scratch0);
-#[cfg(not(feature = "tls"))]
+#[cfg(not(kernel_tls))]
 pub(super) const THREAD_SCRATCH1_OFFSET: usize =
     EXECUTION_CONTEXT_ARCH_STATE_OFFSET + offset_of!(ThreadTrapState, scratch1);
 

--- a/components/axcpu/src/riscv/trap.rs
+++ b/components/axcpu/src/riscv/trap.rs
@@ -1,6 +1,6 @@
 use core::mem::size_of;
 
-#[cfg(not(feature = "tls"))]
+#[cfg(not(kernel_tls))]
 use cpu_local::EXECUTION_CONTEXT_CPU_BASE_OFFSET;
 #[cfg(feature = "fp-simd")]
 use riscv::register::sstatus;
@@ -12,9 +12,9 @@ use riscv::{
     register::{scause, stval},
 };
 
-#[cfg(feature = "tls")]
+#[cfg(kernel_tls)]
 use super::local_state::{CPU_ENTRY_SCRATCH0_OFFSET, CPU_ENTRY_SCRATCH1_OFFSET};
-#[cfg(not(feature = "tls"))]
+#[cfg(not(kernel_tls))]
 use super::local_state::{THREAD_SCRATCH0_OFFSET, THREAD_SCRATCH1_OFFSET};
 use super::{
     TrapFrame,
@@ -95,7 +95,7 @@ impl core::fmt::Debug for KernelTrapFrame<'_> {
     }
 }
 
-#[cfg(not(feature = "tls"))]
+#[cfg(not(kernel_tls))]
 core::arch::global_asm!(
     include_asm_macros!(),
     include_str!("trap.S"),
@@ -107,7 +107,7 @@ core::arch::global_asm!(
     thread_scratch1_index = const THREAD_SCRATCH1_OFFSET / size_of::<usize>(),
 );
 
-#[cfg(feature = "tls")]
+#[cfg(kernel_tls)]
 core::arch::global_asm!(
     include_asm_macros!(),
     include_str!("trap_tls.S"),

--- a/components/axcpu/src/x86_64/asm.rs
+++ b/components/axcpu/src/x86_64/asm.rs
@@ -11,7 +11,7 @@ use core::sync::atomic::{AtomicUsize, Ordering};
 #[cfg(not(feature = "host-test"))]
 use ax_memory_addr::MemoryAddr;
 use ax_memory_addr::{PhysAddr, VirtAddr};
-#[cfg(feature = "tls")]
+#[cfg(kernel_tls)]
 use x86::msr;
 #[cfg(not(feature = "host-test"))]
 use x86::{controlregs, tlb};
@@ -26,7 +26,7 @@ use x86_64::instructions::tlb::{InvPcidCommand, flush_pcid};
 use crate::InstalledAddressSpace;
 #[cfg(all(feature = "uspace", not(feature = "host-test")))]
 use crate::InstalledAddressSpaceMode;
-#[cfg(feature = "tls")]
+#[cfg(kernel_tls)]
 use crate::KernelTlsBase;
 
 #[cfg(not(feature = "host-test"))]
@@ -303,7 +303,7 @@ pub fn update_mmu_cache(_vaddr: VirtAddr) {}
 ///
 /// It is used to implement TLS (Thread Local Storage).
 #[inline]
-#[cfg(feature = "tls")]
+#[cfg(kernel_tls)]
 pub fn read_thread_pointer() -> KernelTlsBase {
     KernelTlsBase::new(unsafe { msr::rdmsr(msr::IA32_FS_BASE) as usize })
 }
@@ -316,7 +316,7 @@ pub fn read_thread_pointer() -> KernelTlsBase {
 ///
 /// This function is unsafe as it changes the CPU states.
 #[inline]
-#[cfg(feature = "tls")]
+#[cfg(kernel_tls)]
 pub unsafe fn write_thread_pointer(kernel_tls: KernelTlsBase) {
     unsafe { msr::wrmsr(msr::IA32_FS_BASE, kernel_tls.as_usize() as u64) }
 }

--- a/components/axcpu/src/x86_64/context.rs
+++ b/components/axcpu/src/x86_64/context.rs
@@ -816,7 +816,7 @@ impl TaskContext {
     }
 }
 
-#[cfg(feature = "tls")]
+#[cfg(kernel_tls)]
 #[unsafe(naked)]
 unsafe extern "C" fn context_switch_raw(_current_task: &mut TaskContext, _next_task: &TaskContext) {
     naked_asm!(
@@ -878,7 +878,7 @@ mod tests {
     }
 }
 
-#[cfg(not(feature = "tls"))]
+#[cfg(not(kernel_tls))]
 #[unsafe(naked)]
 unsafe extern "C" fn context_switch_raw(_current_task: &mut TaskContext, _next_task: &TaskContext) {
     naked_asm!(

--- a/components/axcpu/tests/image_register_mode_contract.rs
+++ b/components/axcpu/tests/image_register_mode_contract.rs
@@ -22,7 +22,7 @@ fn tls_feature_selects_register_semantics_without_changing_context_layout() {
             .0;
         assert!(task_context.contains("task_local: TaskLocalState"));
         assert!(
-            !task_context.contains("cfg(feature = \"tls\")"),
+            !task_context.contains("cfg(kernel_tls)"),
             "image mode must not change TaskContext ABI"
         );
     }
@@ -30,7 +30,6 @@ fn tls_feature_selects_register_semantics_without_changing_context_layout() {
     assert!(TASK_LOCAL.contains("kernel_tls: KernelTlsBase"));
     assert!(LIB.contains("fn for_task_context"));
     assert!(LIB.contains("requested.0 == 0"));
-    assert!(LIB.contains("cfg(all(feature = \"uspace\", feature = \"tls\"))"));
 }
 
 #[test]
@@ -67,8 +66,8 @@ fn riscv_linux_current_trap_uses_the_user_tp_sscratch_handshake() {
 #[test]
 fn context_switches_select_tls_only_for_unikernel_images() {
     for source in [RISCV_CONTEXT, AARCH_CONTEXT, X86_CONTEXT, LOONGARCH_CONTEXT] {
-        assert!(source.contains("#[cfg(feature = \"tls\")]"));
-        assert!(source.contains("#[cfg(not(feature = \"tls\"))]"));
+        assert!(source.contains("#[cfg(kernel_tls)]"));
+        assert!(source.contains("#[cfg(not(kernel_tls))]"));
         assert!(source.contains("pub fn prepare_switch_to("));
         assert!(source.contains("pub unsafe fn switch_to_prepared("));
         assert!(source.contains("prepared.commit()"));

--- a/components/cpu-local/Cargo.toml
+++ b/components/cpu-local/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cpu-local"
-version = "0.2.1"
+version = "0.3.0"
 description = "Architecture CPU-local register capability for TGOSKits"
 repository.workspace = true
 edition.workspace = true
@@ -14,7 +14,12 @@ license.workspace = true
 # retain Linux current semantics; TP-aliased backends publish current through
 # the CPU runtime anchor while TP carries the TLS base, and their HAL adapter
 # excludes local IRQs across each unpinned current/preemption operation.
+# Request kernel TLS; `uspace` takes precedence and disables kernel TLS.
 tls = []
+
+# Select userspace register ownership, overriding `tls` when both are enabled.
+# User-space TLS itself is managed by the architecture user-context APIs.
+uspace = []
 
 # Use a thread-local register model for host-side tests.
 host-test = []

--- a/components/cpu-local/README.md
+++ b/components/cpu-local/README.md
@@ -25,9 +25,14 @@ userspace, so its user-transition assembly spills the current header in the
 pinned kernel stack and restores it before returning to Rust. LoongArch KS4 and
 KS5 remain outside this contract for vCPU scratch state.
 
-The `tls` feature selects the final-image register assignment. `host-test`
-provides a thread-local register model. These are the crate's only features;
-there is no runtime ABI mode inside one final image.
+The `tls` feature requests kernel TLS. The `uspace` feature takes precedence:
+when both are enabled, the image uses the same register ownership as `uspace`
+alone and does not provide kernel TLS. User-space TLS remains the responsibility
+of the user-context APIs. `build.rs` derives the internal `kernel_tls` cfg from
+these features; it is not a user-configurable feature. `kernel_tls` and
+`install_kernel_tls` are available only in the effective kernel TLS mode.
+`host-test` provides a thread-local register model; there is no runtime ABI mode
+inside one final image.
 
 Context publication follows a strict transaction: validate the outgoing
 binding, bind the next `ExecutionContextHeader`, prepare fallible architecture

--- a/components/cpu-local/build.rs
+++ b/components/cpu-local/build.rs
@@ -1,0 +1,8 @@
+fn main() {
+    let kernel_tls = std::env::var_os("CARGO_FEATURE_TLS").is_some()
+        && std::env::var_os("CARGO_FEATURE_USPACE").is_none();
+    println!("cargo::rustc-check-cfg=cfg(kernel_tls)");
+    if kernel_tls {
+        println!("cargo::rustc-cfg=kernel_tls");
+    }
+}

--- a/components/cpu-local/src/area.rs
+++ b/components/cpu-local/src/area.rs
@@ -25,7 +25,7 @@ impl CpuRuntimeAnchor {
     const fn for_boot_context(boot_context: usize) -> Self {
         let current_context = if cfg!(all(target_arch = "x86_64", not(feature = "host-test")))
             || cfg!(all(
-                feature = "tls",
+                kernel_tls,
                 not(all(target_arch = "aarch64", not(feature = "host-test")))
             )) {
             boot_context

--- a/components/cpu-local/src/lib.rs
+++ b/components/cpu-local/src/lib.rs
@@ -24,10 +24,10 @@ pub use preempt::*;
 pub use register::current_context;
 #[doc(hidden)]
 pub use register::current_cpu_index;
-#[cfg(feature = "tls")]
+#[cfg(kernel_tls)]
 #[doc(hidden)]
 pub use register::install_kernel_tls;
-#[cfg(feature = "tls")]
+#[cfg(kernel_tls)]
 pub use register::kernel_tls;
 #[doc(hidden)]
 pub use register::{

--- a/components/cpu-local/src/register/aarch64.rs
+++ b/components/cpu-local/src/register/aarch64.rs
@@ -53,14 +53,14 @@ pub(super) unsafe fn write_current_context(value: usize) {
     unsafe { core::arch::asm!("msr SP_EL0, {value}", value = in(reg) value) };
 }
 
-#[cfg(feature = "tls")]
+#[cfg(kernel_tls)]
 pub(super) unsafe fn read_kernel_tls() -> usize {
     let value: usize;
     unsafe { core::arch::asm!("mrs {value}, TPIDR_EL0", value = out(reg) value) };
     value
 }
 
-#[cfg(feature = "tls")]
+#[cfg(kernel_tls)]
 pub(super) unsafe fn write_kernel_tls(value: usize) {
     unsafe { core::arch::asm!("msr TPIDR_EL0, {value}", value = in(reg) value) };
 }

--- a/components/cpu-local/src/register/host.rs
+++ b/components/cpu-local/src/register/host.rs
@@ -29,11 +29,7 @@ pub(super) fn validate_environment() -> Result<(), CpuLocalError> {
 
 pub(super) unsafe fn install_cpu_base(area_base: usize, boot_context: usize) {
     CPU_BASE.set(area_base);
-    ARCHITECTURE_CURRENT.set(if cfg!(feature = "tls") {
-        0
-    } else {
-        boot_context
-    });
+    ARCHITECTURE_CURRENT.set(if cfg!(kernel_tls) { 0 } else { boot_context });
 }
 
 pub(super) unsafe fn read_cpu_base() -> Result<usize, CpuLocalError> {
@@ -50,7 +46,7 @@ pub(super) unsafe fn read_current_context(area_base: usize) -> usize {
             CPU_BASE.set(target);
         }
     });
-    if cfg!(feature = "tls") {
+    if cfg!(kernel_tls) {
         // SAFETY: the shared caller validated the sampled shutdown-lifetime
         // CPU area before asking the host backend for its selected source.
         return unsafe { area_runtime_anchor(area_base) }.current_context_raw();
@@ -67,12 +63,12 @@ pub(super) unsafe fn write_current_context(value: usize) {
     ARCHITECTURE_CURRENT.set(value);
 }
 
-#[cfg(feature = "tls")]
+#[cfg(kernel_tls)]
 pub(super) unsafe fn read_kernel_tls() -> usize {
     KERNEL_TLS.get()
 }
 
-#[cfg(feature = "tls")]
+#[cfg(kernel_tls)]
 pub(super) unsafe fn write_kernel_tls(value: usize) {
     KERNEL_TLS.set(value);
 }
@@ -106,7 +102,7 @@ pub(super) fn migrate_on_next_current_read(area_base: usize) {
     MIGRATION_TARGET.set(area_base);
 }
 
-#[cfg(all(test, not(feature = "tls")))]
+#[cfg(all(test, not(kernel_tls)))]
 pub(super) fn set_architecture_current(current: usize) {
     ARCHITECTURE_CURRENT.set(current);
 }

--- a/components/cpu-local/src/register/loongarch64.rs
+++ b/components/cpu-local/src/register/loongarch64.rs
@@ -23,7 +23,7 @@ pub(super) unsafe fn install_cpu_base(area_base: usize, boot_context: usize) {
         );
         core::arch::asm!("move $r21, {base}", base = in(reg) area_base, options(nostack));
     }
-    if !cfg!(feature = "tls") {
+    if !cfg!(kernel_tls) {
         unsafe {
             core::arch::asm!("move $tp, {current}", current = in(reg) boot_context, options(nostack))
         };
@@ -49,7 +49,7 @@ pub(super) unsafe fn read_cpu_base() -> Result<usize, CpuLocalError> {
 }
 
 pub(super) unsafe fn read_current_context(area_base: usize) -> usize {
-    if cfg!(feature = "tls") {
+    if cfg!(kernel_tls) {
         unsafe { area_runtime_anchor(area_base) }.current_context_raw()
     } else {
         let current: usize;
@@ -59,19 +59,19 @@ pub(super) unsafe fn read_current_context(area_base: usize) -> usize {
 }
 
 pub(super) unsafe fn write_current_context(value: usize) {
-    if !cfg!(feature = "tls") {
+    if !cfg!(kernel_tls) {
         unsafe { core::arch::asm!("move $tp, {value}", value = in(reg) value) };
     }
 }
 
-#[cfg(feature = "tls")]
+#[cfg(kernel_tls)]
 pub(super) unsafe fn read_kernel_tls() -> usize {
     let value: usize;
     unsafe { core::arch::asm!("move {value}, $tp", value = out(reg) value) };
     value
 }
 
-#[cfg(feature = "tls")]
+#[cfg(kernel_tls)]
 pub(super) unsafe fn write_kernel_tls(value: usize) {
     unsafe { core::arch::asm!("move $tp, {value}", value = in(reg) value) };
 }

--- a/components/cpu-local/src/register/mod.rs
+++ b/components/cpu-local/src/register/mod.rs
@@ -174,7 +174,7 @@ fn default_current_preemption_snapshot() -> Result<PreemptionSnapshot, CpuLocalE
 /// The caller must own the final IRQ-disabled context-switch boundary. `value`
 /// must identify the prepared pinned header and remain alive while current.
 pub(crate) unsafe fn commit_current_context(_area: CpuAreaRef, _value: usize) {
-    match imp::CURRENT_MODEL.current_context_source(cfg!(feature = "tls")) {
+    match imp::CURRENT_MODEL.current_context_source(cfg!(kernel_tls)) {
         #[cfg(not(all(target_arch = "aarch64", not(feature = "host-test"))))]
         CurrentContextSource::RuntimeAnchor => _area
             .runtime_anchor()
@@ -198,7 +198,7 @@ pub(crate) unsafe fn commit_current_context(_area: CpuAreaRef, _value: usize) {
 /// that published invariant while the caller's pin prevents migration.
 pub fn current_context(pin: &CpuPin<'_>) -> Result<NonNull<ExecutionContextHeader>, CpuLocalError> {
     let area = pin.area();
-    let raw = match imp::CURRENT_MODEL.current_context_source(cfg!(feature = "tls")) {
+    let raw = match imp::CURRENT_MODEL.current_context_source(cfg!(kernel_tls)) {
         #[cfg(any(not(target_arch = "x86_64"), feature = "host-test"))]
         CurrentContextSource::ArchitectureRegister => unsafe {
             imp::read_current_context(area.base())
@@ -217,7 +217,7 @@ pub fn current_context(pin: &CpuPin<'_>) -> Result<NonNull<ExecutionContextHeade
 /// dereference the result after a context switch.
 #[doc(hidden)]
 pub unsafe fn current_context_unpinned() -> Result<NonNull<ExecutionContextHeader>, CpuLocalError> {
-    match imp::CURRENT_MODEL.current_context_source(cfg!(feature = "tls")) {
+    match imp::CURRENT_MODEL.current_context_source(cfg!(kernel_tls)) {
         #[cfg(any(not(target_arch = "x86_64"), feature = "host-test"))]
         CurrentContextSource::ArchitectureRegister => {
             // The architecture current source does not require a sampled CPU
@@ -367,7 +367,7 @@ mod tests {
         assert_eq!(
             // SAFETY: both boot headers have process-lifetime storage.
             unsafe { current_context_unpinned() },
-            if cfg!(feature = "tls") {
+            if cfg!(kernel_tls) {
                 Ok(NonNull::from(second.prefix().boot_context().header()))
             } else {
                 Ok(NonNull::from(first_boot))
@@ -472,7 +472,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(feature = "tls"))]
+    #[cfg(not(kernel_tls))]
     fn architecture_current_is_authoritative_when_anchor_is_stale() {
         let area = modeled_area(0);
         let boot = area.prefix().boot_context().header();
@@ -509,7 +509,7 @@ pub unsafe fn install_bootstrap_context(
 ) -> Result<(), ContextSwitchError> {
     let epoch = unsafe { header.bind_cpu(pin.area()) }?;
     let pointer = header.as_non_null().as_ptr() as usize;
-    match imp::CURRENT_MODEL.current_context_source(cfg!(feature = "tls")) {
+    match imp::CURRENT_MODEL.current_context_source(cfg!(kernel_tls)) {
         #[cfg(not(all(target_arch = "aarch64", not(feature = "host-test"))))]
         CurrentContextSource::RuntimeAnchor => unsafe {
             commit_current_context(pin.area(), pointer)
@@ -529,7 +529,7 @@ pub unsafe fn install_bootstrap_context(
 }
 
 /// Reads execution-context-owned kernel TLS under an explicit CPU pin.
-#[cfg(feature = "tls")]
+#[cfg(kernel_tls)]
 pub fn kernel_tls(_pin: &CpuPin<'_>) -> usize {
     unsafe { imp::read_kernel_tls() }
 }
@@ -540,7 +540,7 @@ pub fn kernel_tls(_pin: &CpuPin<'_>) -> usize {
 ///
 /// The caller must own the offline CPU or IRQ-disabled final context switch, and
 /// `value` must remain a valid TLS base for the installed execution context.
-#[cfg(feature = "tls")]
+#[cfg(kernel_tls)]
 #[doc(hidden)]
 pub unsafe fn install_kernel_tls(_pin: &CpuPin<'_>, value: usize) {
     unsafe { imp::write_kernel_tls(value) };

--- a/components/cpu-local/src/register/riscv.rs
+++ b/components/cpu-local/src/register/riscv.rs
@@ -14,7 +14,7 @@ pub(super) fn validate_environment() -> Result<(), CpuLocalError> {
 }
 
 pub(super) unsafe fn install_cpu_base(area_base: usize, boot_context: usize) {
-    if cfg!(feature = "tls") {
+    if cfg!(kernel_tls) {
         unsafe { core::arch::asm!("csrw sscratch, {base}", base = in(reg) area_base) };
     } else {
         unsafe {
@@ -28,7 +28,7 @@ pub(super) unsafe fn install_cpu_base(area_base: usize, boot_context: usize) {
 }
 
 pub(super) unsafe fn read_cpu_base() -> Result<usize, CpuLocalError> {
-    if cfg!(feature = "tls") {
+    if cfg!(kernel_tls) {
         let area_base: usize;
         unsafe { core::arch::asm!("csrr {base}, sscratch", base = out(reg) area_base) };
         Ok(area_base)
@@ -46,7 +46,7 @@ pub(super) unsafe fn read_cpu_base() -> Result<usize, CpuLocalError> {
 }
 
 pub(super) unsafe fn read_current_context(area_base: usize) -> usize {
-    if cfg!(feature = "tls") {
+    if cfg!(kernel_tls) {
         unsafe { area_runtime_anchor(area_base) }.current_context_raw()
     } else {
         let current: usize;
@@ -56,19 +56,19 @@ pub(super) unsafe fn read_current_context(area_base: usize) -> usize {
 }
 
 pub(super) unsafe fn write_current_context(value: usize) {
-    if !cfg!(feature = "tls") {
+    if !cfg!(kernel_tls) {
         unsafe { core::arch::asm!("mv tp, {value}", value = in(reg) value) };
     }
 }
 
-#[cfg(feature = "tls")]
+#[cfg(kernel_tls)]
 pub(super) unsafe fn read_kernel_tls() -> usize {
     let value: usize;
     unsafe { core::arch::asm!("mv {value}, tp", value = out(reg) value) };
     value
 }
 
-#[cfg(feature = "tls")]
+#[cfg(kernel_tls)]
 pub(super) unsafe fn write_kernel_tls(value: usize) {
     unsafe { core::arch::asm!("mv tp, {value}", value = in(reg) value) };
 }

--- a/components/cpu-local/src/register/x86_64.rs
+++ b/components/cpu-local/src/register/x86_64.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 
 const IA32_GS_BASE: u32 = 0xc000_0101;
-#[cfg(feature = "tls")]
+#[cfg(kernel_tls)]
 const IA32_FS_BASE: u32 = 0xc000_0100;
 
 pub(super) const CURRENT_MODEL: ArchitectureCurrentModel = ArchitectureCurrentModel {
@@ -213,7 +213,7 @@ pub(super) unsafe fn compare_exchange_preemption_state(
     observed == current
 }
 
-#[cfg(feature = "tls")]
+#[cfg(kernel_tls)]
 pub(super) unsafe fn read_kernel_tls() -> usize {
     let low: u32;
     let high: u32;
@@ -229,7 +229,7 @@ pub(super) unsafe fn read_kernel_tls() -> usize {
     ((high as usize) << 32) | low as usize
 }
 
-#[cfg(feature = "tls")]
+#[cfg(kernel_tls)]
 pub(super) unsafe fn write_kernel_tls(value: usize) {
     let value = value as u64;
     unsafe {

--- a/components/cpu-local/tests/register_mode_contract.rs
+++ b/components/cpu-local/tests/register_mode_contract.rs
@@ -53,7 +53,7 @@ fn image_mode_is_additive_but_the_prefix_layout_is_not() {
             .unwrap_or_else(|| panic!("{type_name} must have a bounded definition"))
             .0;
         assert!(
-            !definition.contains("cfg(feature = \"tls\")"),
+            !definition.contains("cfg(kernel_tls)"),
             "Cargo image mode must never alter {type_name} layout"
         );
     }
@@ -137,7 +137,7 @@ fn each_image_mode_selects_one_current_context_source() {
 
 #[test]
 fn register_backends_implement_both_compile_time_image_modes() {
-    assert!(REGISTER.contains("cfg(feature = \"tls\")"));
+    assert!(REGISTER.contains("cfg(kernel_tls)"));
 
     assert!(X86_64.contains("IA32_GS_BASE"));
 

--- a/docs/design/kernel-tls-mode.md
+++ b/docs/design/kernel-tls-mode.md
@@ -1,0 +1,38 @@
+# 内核 TLS 与用户态模式
+
+## 1. 模式与兼容性
+
+最终映像只能采用一种内核寄存器所有权。Cargo 的 feature 合并可能同时启用 `tls` 和 `uspace`；此时采用用户态模式，避免内核 TLS 与当前任务指针争用寄存器。
+
+### 1.1 功能选择
+
+`ax-cpu`、`cpu-local`、`ax-hal`、`ax-runtime` 和 `someboot` 的 `build.rs` 从 Cargo 传入的 feature 派生 `kernel_tls` cfg。只有 `tls` 开启且 `uspace` 关闭时输出该 cfg；源码使用 `cfg(kernel_tls)` 或其补集选择已有实现。此 cfg 是包内实现细节，不是用户配置入口。
+
+| Cargo features | 内核 TLS | 当前任务与用户态行为 |
+| --- | --- | --- |
+| 均关闭 | 关闭 | 保持原有模式 |
+| 仅 `tls` | 开启 | 保持原有内核 TLS 模式 |
+| 仅 `uspace` | 关闭 | 保持原有用户态模式 |
+| `tls,uspace` | 关闭 | 与仅 `uspace` 相同 |
+
+Cargo cfg 不跨包传播，因此依赖边必须转发 feature。`ax-cpu/uspace` 转发到 `cpu-local/uspace`；HAL 和动态平台同时向自身直接依赖转发，`somehal` 继续转发到 `someboot`。
+
+### 1.2 所有权与接口
+
+RISC-V 用户态模式在内核使用 `tp` 保存当前执行上下文，并令 `sscratch` 为零；内核 TLS 模式使用 `tp` 保存 TLS，`sscratch` 保存 CPU 区域。LoongArch 用户态模式同样以 `tp` 保存当前上下文。x86_64 与 AArch64 保留既有独立当前上下文寄存器，双开时也不安装内核 TLS。
+
+`KernelTlsBase::for_task_context` 在无内核 TLS 模式拒绝非零基址。任务上下文布局、事务提交、抢占及迁移顺序不变。内核线程指针接口仅在 `kernel_tls` 下可用；用户态 TLS 仍由用户上下文保存和恢复。原有合法 feature 组合保持行为；要求内核 TLS 的调用方不能在开启 `uspace` 后继续假定其可用。
+
+## 2. 启动与验证
+
+同一映像的 bootstrap、SMP、上下文切换和链接布局必须采用相同模式，否则编译通过仍可能产生寄存器破坏。
+
+### 2.1 资源与链接
+
+`ax-runtime` 双开时采用原有无内核 TLS 的分配、零标识和 `Unsupported` 返回路径，不创建或安装内核 TLS 资源。`someboot::Build::kernel_tls` 保存 build.rs 的同一次计算结果，用于 `render_linker_script`；不能使用随后为 AArch64 启动调整的 `Build::uspace` 反推 TLS 模式。无 TLS 链接布局继续拒绝意外的 `.tdata` 和 `.tbss`。
+
+### 2.2 回归与发布
+
+`scripts/test/check_kernel_tls_modes.py` 编译真实 `ax-cpu`，检查依赖 feature 传播和两个底层包的 rustc cfg，并在同一构建目录切换四种组合。QEMU 验证独立保留 ArceOS 多任务 TLS、Starry 用户态 clone/TLS 和 Axvisor 宿主 TLS 路径，不能用宿主配置检查替代。
+
+旧注册表基线仍含互斥报错。先发布能够接受双开的新版本，再验证真实注册表基线并恢复相关 semver 检查。回滚通过撤销模式改动和依赖版本更新完成；已采用双开的调用方需要同时恢复为单独 `uspace`。合入前应由启动与调度领域审查人核对寄存器所有权及真实运行证据。

--- a/os/arceos/modules/axhal/Cargo.toml
+++ b/os/arceos/modules/axhal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ax-hal"
-version = "0.7.0"
+version = "0.7.1"
 repository = "https://github.com/rcore-os/tgoskits"
 edition.workspace = true
 authors = ["Yuekai Jia <equation618@gmail.com>"]
@@ -22,8 +22,11 @@ paging = [
     "dep:ax-alloc",
     "dep:page-table-generic",
 ]
+# Request kernel TLS; `uspace` takes precedence and disables kernel TLS.
 tls = ["ax-cpu/tls", "cpu-local/tls", "axplat-dyn/tls"]
-uspace = ["paging", "ax-cpu/uspace", "axplat-dyn/uspace"]
+# Enable userspace support without kernel TLS, including when `tls` is enabled.
+# User-space TLS remains available through the userspace context APIs.
+uspace = ["paging", "ax-cpu/uspace", "cpu-local/uspace", "axplat-dyn/uspace"]
 hv = [
   "paging",
   "ax-cpu/exception-table",

--- a/os/arceos/modules/axhal/build.rs
+++ b/os/arceos/modules/axhal/build.rs
@@ -13,6 +13,13 @@ const DEFAULT_PLATFORM_CRATE: &str = "axplat_dyn";
 const DEFAULT_CPU_CAPACITY: usize = 16;
 
 fn main() {
+    let kernel_tls = std::env::var_os("CARGO_FEATURE_TLS").is_some()
+        && std::env::var_os("CARGO_FEATURE_USPACE").is_none();
+    println!("cargo::rustc-check-cfg=cfg(kernel_tls)");
+    if kernel_tls {
+        println!("cargo::rustc-cfg=kernel_tls");
+    }
+
     println!("cargo:rerun-if-env-changed=SMP");
     println!("cargo:rerun-if-env-changed={PLATFORM_CRATE_ENV}");
 

--- a/os/arceos/modules/axhal/src/lib.rs
+++ b/os/arceos/modules/axhal/src/lib.rs
@@ -18,17 +18,14 @@
 //! - `smp`: Enable SMP (symmetric multiprocessing) support.
 //! - `fp-simd`: Enable floating-point and SIMD support.
 //! - `paging`: Enable page table manipulation.
-//! - `tls`: Enable kernel space thread-local storage support.
+//! - `tls`: Request kernel TLS; `uspace` takes precedence and disables it.
 //! - `rtc`: Enable real-time clock support.
-//! - `uspace`: Enable user space support.
+//! - `uspace`: Enable user space support, including user TLS, without kernel TLS.
 //!
 //! [ArceOS]: https://github.com/arceos-org/arceos
 //! [cargo test]: https://doc.rust-lang.org/cargo/guide/tests.html
 
 #![no_std]
-
-#[cfg(all(feature = "uspace", feature = "tls"))]
-compile_error!("ax-hal features `uspace` and `tls` select incompatible register ownership modes");
 
 #[allow(unused_imports)]
 #[macro_use]
@@ -54,7 +51,7 @@ pub mod percpu;
 pub mod pmu;
 pub mod time;
 
-#[cfg(feature = "tls")]
+#[cfg(kernel_tls)]
 pub mod tls;
 
 pub mod irq;
@@ -183,5 +180,5 @@ macro_rules! addr_of_sym {
         $e as *const () as usize
     };
 }
-#[cfg(feature = "tls")]
+#[cfg(kernel_tls)]
 pub(crate) use addr_of_sym;

--- a/os/arceos/modules/axhal/src/percpu.rs
+++ b/os/arceos/modules/axhal/src/percpu.rs
@@ -56,7 +56,7 @@ pub unsafe fn install_bootstrap_context(
 }
 
 /// Reads the current task-owned kernel TLS base.
-#[cfg(feature = "tls")]
+#[cfg(kernel_tls)]
 pub fn kernel_tls(pin: &CpuPin<'_>) -> crate::context::KernelTlsBase {
     crate::context::KernelTlsBase::new(cpu_local::kernel_tls(pin))
 }
@@ -67,7 +67,7 @@ pub fn kernel_tls(pin: &CpuPin<'_>) -> crate::context::KernelTlsBase {
 ///
 /// The CPU must remain offline, and `kernel_tls` must remain valid while the
 /// bootstrap context executes.
-#[cfg(feature = "tls")]
+#[cfg(kernel_tls)]
 pub unsafe fn install_bootstrap_kernel_tls(
     pin: &CpuPin<'_>,
     kernel_tls: crate::context::KernelTlsBase,

--- a/os/arceos/modules/axruntime/Cargo.toml
+++ b/os/arceos/modules/axruntime/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 license.workspace = true
 name = "ax-runtime"
 repository = "https://github.com/rcore-os/tgoskits"
-version = "0.12.0"
+version = "0.12.1"
 
 [features]
 default = []
@@ -30,11 +30,14 @@ fp-simd = ["ax-hal/fp-simd"]
 paging = ["ax-hal/paging", "dep:ax-mm"]
 rtc = ["ax-hal/rtc", "ax-driver/rtc"]
 smp = ["ax-hal/smp", "ax-task/smp", "wake-ipi"]
+# Enable userspace support without kernel TLS, including when `tls` is enabled.
+# User-space TLS remains available through the userspace context APIs.
 uspace = ["ax-hal/uspace"]
 lockdep = ["ax-task/lockdep", "ax-fs-ng?/lockdep"]
 stack-guard-page = ["ipi", "paging"]
 vmap-task-stack = ["ipi", "paging"]
 stack-protector = []
+# Request kernel TLS; `uspace` takes precedence and disables kernel TLS.
 tls = ["ax-hal/tls"]
 
 display = ["paging", "dep:ax-display", "ax-driver/display"]

--- a/os/arceos/modules/axruntime/build.rs
+++ b/os/arceos/modules/axruntime/build.rs
@@ -19,6 +19,13 @@ const DEFAULT_SCHEDULER_TICK_MS: u64 = 10;
 const NANOS_PER_MILLISECOND: u64 = 1_000_000;
 
 fn main() -> Result<()> {
+    let kernel_tls = std::env::var_os("CARGO_FEATURE_TLS").is_some()
+        && std::env::var_os("CARGO_FEATURE_USPACE").is_none();
+    println!("cargo::rustc-check-cfg=cfg(kernel_tls)");
+    if kernel_tls {
+        println!("cargo::rustc-cfg=kernel_tls");
+    }
+
     println!("cargo:rerun-if-changed={LINKER_TEMPLATE_NAME}");
     println!("cargo:rerun-if-env-changed=CARGO_FEATURE_EXT_LD");
     println!("cargo:rerun-if-env-changed=SMP");

--- a/os/arceos/modules/axruntime/src/bootstrap.rs
+++ b/os/arceos/modules/axruntime/src/bootstrap.rs
@@ -114,7 +114,7 @@ pub fn rust_main(cpu_id: usize, arg: usize) -> ! {
     #[cfg(feature = "std-compat")]
     crate::panic_output::install_std_hook();
 
-    #[cfg(feature = "tls")]
+    #[cfg(kernel_tls)]
     crate::thread::initialize_early_bootstrap_tls()
         .expect("failed to initialize primary bootstrap TLS");
 

--- a/os/arceos/modules/axruntime/src/mp.rs
+++ b/os/arceos/modules/axruntime/src/mp.rs
@@ -63,7 +63,7 @@ pub fn rust_main_secondary(cpu_id: usize) -> ! {
     ax_alloc::init_percpu_slab(cpu_id);
     ax_hal::init_early_secondary(cpu_id);
 
-    #[cfg(feature = "tls")]
+    #[cfg(kernel_tls)]
     crate::thread::initialize_early_bootstrap_tls()
         .expect("failed to initialize secondary bootstrap TLS");
 

--- a/os/arceos/modules/axruntime/src/thread/bootstrap.rs
+++ b/os/arceos/modules/axruntime/src/thread/bootstrap.rs
@@ -31,7 +31,7 @@ static CPU_REMOTE_HANDLE: LazyInit<usize> = LazyInit::new();
 #[ax_percpu::def_percpu]
 static CPU_LOCAL_OWNER_HANDLE: usize = 0;
 
-#[cfg(feature = "tls")]
+#[cfg(kernel_tls)]
 #[ax_percpu::def_percpu]
 static EARLY_BOOTSTRAP_TLS: usize = 0;
 
@@ -75,7 +75,7 @@ pub(crate) fn initialize_primary(cpu_id: usize) -> Result<(), TaskError> {
 
 /// Installs temporary TLS before platform late-init can enter Rust code that
 /// uses thread-local storage.
-#[cfg(feature = "tls")]
+#[cfg(kernel_tls)]
 pub(crate) fn initialize_early_bootstrap_tls() -> Result<(), TaskError> {
     // SAFETY: early runtime entry owns this offline CPU until publication.
     let existing = unsafe { with_current_cpu_pin(|pin| EARLY_BOOTSTRAP_TLS.read_current(pin)) };
@@ -200,7 +200,7 @@ fn initialize_current_cpu(cpu_id: usize) -> Result<ThreadId, TaskError> {
     }
     let bootstrap_resources = create_bootstrap_resources()?;
     let bootstrap_context = bootstrap_resources.context();
-    #[cfg(feature = "tls")]
+    #[cfg(kernel_tls)]
     let bootstrap_tls = bootstrap_resources.tls();
     let bootstrap = system.install_bootstrap_thread(cpu.as_mut(), unsafe {
         // SAFETY: bootstrap_resources is a fresh unique runtime bundle.
@@ -210,9 +210,9 @@ fn initialize_current_cpu(cpu_id: usize) -> Result<ThreadId, TaskError> {
     })?;
     let bootstrap_thread = bootstrap.id();
     drop(bootstrap);
-    #[cfg(feature = "tls")]
+    #[cfg(kernel_tls)]
     let bootstrap_kernel_tls = runtime_tls_pointer(bootstrap_tls);
-    #[cfg(not(feature = "tls"))]
+    #[cfg(not(kernel_tls))]
     let bootstrap_kernel_tls = 0;
     // Publish the physical bootstrap resources only after their scheduler
     // record owns them. A failed installation must not leave this CPU using a
@@ -225,7 +225,7 @@ fn initialize_current_cpu(cpu_id: usize) -> Result<ThreadId, TaskError> {
         })
     }
     .unwrap_or_else(|error| panic!("failed to publish bootstrap runtime context: {error}"));
-    #[cfg(feature = "tls")]
+    #[cfg(kernel_tls)]
     {
         // SAFETY: bootstrap still owns this offline CPU-local slot.
         let early_tls = unsafe {

--- a/os/arceos/modules/axruntime/src/thread/context.rs
+++ b/os/arceos/modules/axruntime/src/thread/context.rs
@@ -266,7 +266,7 @@ pub(super) fn bind_bootstrap_runtime_context(
     // record keeps this pinned header alive until its switch tail withdraws it.
     unsafe { ax_hal::percpu::install_bootstrap_context(cpu_pin, context.header()) }
         .map_err(|_| TaskError::InvalidConfiguration)?;
-    #[cfg(feature = "tls")]
+    #[cfg(kernel_tls)]
     // SAFETY: the same offline bootstrap boundary owns the task TLS register.
     unsafe {
         ax_hal::percpu::install_bootstrap_kernel_tls(
@@ -274,7 +274,7 @@ pub(super) fn bind_bootstrap_runtime_context(
             ax_hal::context::KernelTlsBase::new(kernel_tls),
         );
     }
-    #[cfg(not(feature = "tls"))]
+    #[cfg(not(kernel_tls))]
     assert_eq!(
         kernel_tls, 0,
         "TLS-disabled bootstrap must retain a zero TLS identity"

--- a/os/arceos/modules/axruntime/src/thread/mod.rs
+++ b/os/arceos/modules/axruntime/src/thread/mod.rs
@@ -68,7 +68,7 @@ use address_space::{
 };
 #[cfg(feature = "uspace")]
 use bootstrap::current_cpu_remote;
-#[cfg(feature = "tls")]
+#[cfg(kernel_tls)]
 pub(crate) use bootstrap::initialize_early_bootstrap_tls;
 #[cfg(test)]
 use bootstrap::{IdleEntryAction, idle_entry_action};
@@ -118,7 +118,7 @@ pub(crate) fn current_cpu_needs_reschedule_pinned(cpu_pin: &CpuPin) -> Result<bo
         .needs_reschedule())
 }
 
-#[cfg(feature = "tls")]
+#[cfg(kernel_tls)]
 use resources::runtime_tls_pointer;
 use resources::{
     allocate_runtime_stack, allocate_runtime_tls, deallocate_runtime_stack, deallocate_runtime_tls,
@@ -194,7 +194,7 @@ pub use spawn::{
     spawn_raw_with_extension_in_address_space_and_fp_state,
     spawn_raw_with_extension_in_address_space_and_fp_state_and_policy,
 };
-#[cfg(all(test, feature = "tls"))]
+#[cfg(all(test, kernel_tls))]
 use thread_resources::assemble_bootstrap_resources;
 use thread_resources::{
     InitialContextState, create_bootstrap_resources, create_idle_resources, create_thread_resources,

--- a/os/arceos/modules/axruntime/src/thread/resources.rs
+++ b/os/arceos/modules/axruntime/src/thread/resources.rs
@@ -26,7 +26,7 @@ pub(super) enum StackBacking {
     VirtualPages(ax_mm::KernelVirtualAllocation),
 }
 
-#[cfg(feature = "tls")]
+#[cfg(kernel_tls)]
 struct RuntimeTls {
     area: ax_hal::tls::TlsArea,
 }
@@ -136,14 +136,14 @@ pub(super) fn deallocate_runtime_stack(handle: StackHandle) -> RuntimeStatus {
 }
 
 pub(super) fn allocate_runtime_tls() -> RuntimeHandleResult {
-    #[cfg(feature = "tls")]
+    #[cfg(kernel_tls)]
     {
         let tls = Box::new(RuntimeTls {
             area: ax_hal::tls::TlsArea::alloc(),
         });
         RuntimeHandleResult::success(Box::into_raw(tls).expose_provenance())
     }
-    #[cfg(not(feature = "tls"))]
+    #[cfg(not(kernel_tls))]
     {
         RuntimeHandleResult::failure(RuntimeStatus::Unsupported)
     }
@@ -153,7 +153,7 @@ pub(super) fn deallocate_runtime_tls(handle: TlsHandle) -> RuntimeStatus {
     if handle.is_none() {
         return RuntimeStatus::Success;
     }
-    #[cfg(feature = "tls")]
+    #[cfg(kernel_tls)]
     {
         // SAFETY: the scheduler consumes a live runtime TLS handle once.
         drop(unsafe {
@@ -163,13 +163,13 @@ pub(super) fn deallocate_runtime_tls(handle: TlsHandle) -> RuntimeStatus {
         });
         RuntimeStatus::Success
     }
-    #[cfg(not(feature = "tls"))]
+    #[cfg(not(kernel_tls))]
     {
         RuntimeStatus::Unsupported
     }
 }
 
-#[cfg(feature = "tls")]
+#[cfg(kernel_tls)]
 pub(super) fn runtime_tls_pointer(handle: TlsHandle) -> usize {
     if handle.is_none() {
         return 0;
@@ -183,7 +183,7 @@ pub(super) fn runtime_tls_pointer(handle: TlsHandle) -> usize {
     }
 }
 
-#[cfg(not(feature = "tls"))]
+#[cfg(not(kernel_tls))]
 pub(super) fn runtime_tls_pointer(_handle: TlsHandle) -> usize {
     0
 }

--- a/os/arceos/modules/axruntime/src/thread/tests.rs
+++ b/os/arceos/modules/axruntime/src/thread/tests.rs
@@ -493,7 +493,7 @@ fn entry_extension_lookup_does_not_pin_exited_thread() {
     .expect("modeled CPU fixture must finish without a current-register mismatch");
 }
 
-#[cfg(feature = "tls")]
+#[cfg(kernel_tls)]
 #[test]
 fn bootstrap_thread_rejects_a_missing_tls_resource() {
     // SAFETY: this inert non-zero identity is never dereferenced because

--- a/os/arceos/modules/axruntime/src/thread/thread_resources.rs
+++ b/os/arceos/modules/axruntime/src/thread/thread_resources.rs
@@ -134,7 +134,7 @@ pub(super) fn assemble_bootstrap_resources(
     if context.is_none() {
         return Err(TaskError::InvalidRuntimeHandle);
     }
-    #[cfg(feature = "tls")]
+    #[cfg(kernel_tls)]
     if tls.is_none() {
         return Err(TaskError::InvalidRuntimeHandle);
     }

--- a/os/arceos/ulib/axstd/Cargo.toml
+++ b/os/arceos/ulib/axstd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ax-std"
-version = "0.6.0"
+version = "0.6.1"
 repository = "https://github.com/rcore-os/tgoskits"
 edition.workspace = true
 authors = [
@@ -43,6 +43,8 @@ smp = ["ax-runtime/smp", "ax-posix-api/smp"]
 fp-simd = ["ax-hal/fp-simd", "ax-runtime/fp-simd"]
 
 # User space support
+# Enable userspace support without kernel TLS, including when `tls` is enabled.
+# User-space TLS remains available through the userspace context APIs.
 uspace = ["ax-runtime/uspace"]
 
 # Hypervisor support
@@ -57,6 +59,7 @@ ext-ld = ["ax-runtime/ext-ld"]
 # Memory
 alloc = ["ax-api/alloc", "ax-io/alloc", "ax-posix-api/alloc"]
 paging = ["alloc", "ax-runtime/paging"]
+# Request kernel TLS; `uspace` takes precedence and disables kernel TLS.
 tls = ["ax-runtime/tls"]
 
 # Scheduler configuration

--- a/platforms/axplat-dyn/Cargo.toml
+++ b/platforms/axplat-dyn/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axplat-dyn"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["周睿 <zrufo747@outlook.com>"]
 categories.workspace = true
 description = "A dynamic platform module for ArceOS, providing runtime platform detection and configuration"
@@ -15,8 +15,11 @@ smp = ["ax-plat/smp"]
 rtc = []
 efi = ["somehal/efi"]
 fp-simd = ["ax-cpu/fp-simd"]
+# Request kernel TLS; `uspace` takes precedence and disables kernel TLS.
 tls = ["somehal/tls", "ax-cpu/tls", "cpu-local/tls"]
-uspace = ["somehal/uspace"]
+# Enable userspace support without kernel TLS, including when `tls` is enabled.
+# User-space TLS remains available through the userspace context APIs.
+uspace = ["somehal/uspace", "ax-cpu/uspace", "cpu-local/uspace"]
 hv = ["somehal/hv"]
 thead-mae = ["somehal/thead-mae", "ax-cpu/xuantie-c9xx"]
 

--- a/platforms/axplat-dyn/src/lib.rs
+++ b/platforms/axplat-dyn/src/lib.rs
@@ -1,8 +1,5 @@
 #![no_std]
 
-#[cfg(all(feature = "uspace", feature = "tls"))]
-compile_error!("axplat-dyn userspace requires LinuxCurrent and cannot enable kernel TLS mode");
-
 extern crate alloc;
 extern crate ax_driver as _;
 extern crate somehal;

--- a/platforms/someboot/Cargo.toml
+++ b/platforms/someboot/Cargo.toml
@@ -7,14 +7,17 @@ keywords = ["os"]
 license = "MPL-2.0"
 name = "someboot"
 repository.workspace = true
-version = "0.5.0"
+version = "0.5.1"
 
 [features]
 efi = []
 hv = []
 mmu = []
 thead-mae = []
+# Request kernel TLS; `uspace` takes precedence and disables kernel TLS.
 tls = []
+# Enable userspace support without kernel TLS, including when `tls` is enabled.
+# User-space TLS remains available through the userspace context APIs.
 uspace = ["mmu"]
 
 [lints.rust]

--- a/platforms/someboot/build.rs
+++ b/platforms/someboot/build.rs
@@ -6,12 +6,18 @@ mod linker;
 use linker::{LinkerArch, LinkerConfig, render_linker_script, source_paths};
 
 fn main() {
+    let kernel_tls = std::env::var_os("CARGO_FEATURE_TLS").is_some()
+        && std::env::var_os("CARGO_FEATURE_USPACE").is_none();
+    println!("cargo::rustc-check-cfg=cfg(kernel_tls)");
+    if kernel_tls {
+        println!("cargo::rustc-cfg=kernel_tls");
+    }
+
     println!("cargo::rustc-check-cfg=cfg(efi)");
     println!("cargo::rustc-check-cfg=cfg(page_size_4k)");
     println!("cargo::rustc-check-cfg=cfg(page_size_16k)");
     println!("cargo::rustc-check-cfg=cfg(uspace)");
     println!("cargo::rustc-check-cfg=cfg(hv)");
-    println!("cargo:rerun-if-env-changed=CARGO_FEATURE_TLS");
 
     let out_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap());
     println!("cargo:rustc-link-search={}", out_dir.display());
@@ -31,6 +37,7 @@ fn main() {
         kernel_paddr: 0x200000,
         efi_image_base: 0,
         uspace,
+        kernel_tls,
         hv,
         page_size: 4096,
     };
@@ -78,6 +85,7 @@ struct Build {
     kernel_paddr: u64,
     efi_image_base: u64,
     uspace: bool,
+    kernel_tls: bool,
     hv: bool,
     page_size: usize,
 }
@@ -154,7 +162,7 @@ impl Build {
             LinkerConfig {
                 kernel_load_vaddr: self.kernel_vaddr,
                 kernel_load_paddr: self.kernel_paddr,
-                kernel_tls: std::env::var_os("CARGO_FEATURE_TLS").is_some(),
+                kernel_tls: self.kernel_tls,
             },
         );
         let ld_dst = self.out_dir.join(Self::LD_NAME);

--- a/platforms/someboot/src/arch/loongarch64/mod.rs
+++ b/platforms/someboot/src/arch/loongarch64/mod.rs
@@ -28,16 +28,16 @@ pub use relocate::relocate;
 
 use crate::{ArchTrait, DCacheOp, SystimerArch, efi_stub, irq::IrqId, power::CpuOnError};
 
-#[cfg(feature = "tls")]
+#[cfg(kernel_tls)]
 const BOOT_TLS_SIZE: usize = 64 * 1024;
 
-#[cfg(feature = "tls")]
+#[cfg(kernel_tls)]
 #[repr(C, align(16))]
 struct BootTls {
     bytes: [u8; BOOT_TLS_SIZE],
 }
 
-#[cfg(feature = "tls")]
+#[cfg(kernel_tls)]
 static mut BOOT_TLS: BootTls = BootTls {
     bytes: [0; BOOT_TLS_SIZE],
 };
@@ -71,7 +71,7 @@ impl ArchTrait for Arch {
     fn post_allocator() {}
 
     fn init_boot_tls() {
-        #[cfg(feature = "tls")]
+        #[cfg(kernel_tls)]
         {
             unsafe extern "C" {
                 fn _stdata();
@@ -383,13 +383,13 @@ impl SystimerArch for Arch {
     }
 }
 
-#[cfg(feature = "tls")]
+#[cfg(kernel_tls)]
 #[cold]
 fn boot_tls_layout_fatal() -> ! {
     panic!("invalid or oversized LoongArch bootstrap TLS image")
 }
 
-#[cfg(feature = "tls")]
+#[cfg(kernel_tls)]
 const fn align_up(value: usize, align: usize) -> usize {
     (value + align - 1) & !(align - 1)
 }

--- a/platforms/somehal/Cargo.toml
+++ b/platforms/somehal/Cargo.toml
@@ -7,14 +7,17 @@ keywords.workspace = true
 license.workspace = true
 name = "somehal"
 repository.workspace = true
-version = "0.10.0"
+version = "0.10.1"
 
 [features]
 efi = ["someboot/efi"]
 hv = ["mmu", "someboot/hv", "dep:ax-cpu"]
 mmu = ["someboot/mmu"]
 thead-mae = ["someboot/thead-mae"]
+# Request kernel TLS; `uspace` takes precedence and disables kernel TLS.
 tls = ["someboot/tls"]
+# Enable userspace support without kernel TLS, including when `tls` is enabled.
+# User-space TLS remains available through the userspace context APIs.
 uspace = ["mmu", "someboot/uspace"]
 
 [dependencies]

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -5,10 +5,9 @@ publish_no_verify = true
 # PR, rather than publishing new crates before their dependencies are released.
 release_always = false
 
-# These crates expose mutually exclusive kernel TLS and Linux userspace modes.
-# release-plz does not expose cargo-semver-checks feature selection, so its
-# default feature union is not a supported build. Check valid modes separately
-# and use set-version for breaking releases; keep the compile-time guard intact.
+# Published baselines still reject the tls/uspace feature union. Current sources
+# select userspace ownership when both are enabled. Re-enable these checks after
+# the new baselines are published and validated against the registry.
 [[package]]
 name = "ax-cpu"
 semver_check = false
@@ -27,10 +26,4 @@ semver_check = false
 
 [[package]]
 name = "ax-std"
-semver_check = false
-
-# The published axvisor 0.7.0 omits linker.ld, which build.rs embeds.
-# Re-enable after the complete 0.7.1 package is published and checked.
-[[package]]
-name = "axvisor"
 semver_check = false

--- a/scripts/test/check_kernel_tls_modes.py
+++ b/scripts/test/check_kernel_tls_modes.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Verify the compiled TLS mode and feature propagation through ax-cpu.
+
+Cargo's resolved features and build-script output must agree: adding uspace to
+an existing TLS build must stop selecting kernel TLS in both ax-cpu and cpu-local.
+The same target directory is reused to exercise feature transitions.
+"""
+
+from pathlib import Path
+import subprocess
+
+
+def main():
+    root = Path(__file__).resolve().parents[2]
+    # Start with the formerly rejected combination, then toggle the TLS mode.
+    for features, expected in [("tls,uspace", False), ("tls", True),
+                               ("uspace", False), ("", False), ("tls", True)]:
+        args = ["--locked", "-p", "ax-cpu", "--lib", "--no-default-features"]
+        if features:
+            args += ["--features", features]
+        subprocess.run(["cargo", "check", *args], cwd=root, check=True)
+        tree_args = [arg for arg in args if arg != "--lib"]
+        tree = subprocess.check_output(
+            ["cargo", "tree", *tree_args, "--prefix", "none", "--format", "{p}|{f}"],
+            cwd=root, text=True,
+        )
+        dependency = next(line for line in tree.splitlines() if line.startswith("cpu-local "))
+        resolved = set(dependency.split("|", 1)[1].removesuffix(" (*)").split(","))
+        assert set(filter(None, features.split(","))) <= resolved, dependency
+        for package in ["ax-cpu", "cpu-local"]:
+            # Inspect each package's build-script output for the same image mode.
+            command = ["cargo", "rustc", "--locked", "-p", package, "--lib",
+                       "--no-default-features"]
+            if features:
+                command += ["--features", features]
+            cfg = subprocess.check_output(command + ["--", "--print", "cfg"],
+                                          cwd=root, text=True)
+            assert ("kernel_tls" in cfg.splitlines()) == expected, (package, features, cfg)
+        print(f"KERNEL_TLS_MODE_PASSED features={features or 'none'}", flush=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 问题与行为

Cargo feature 合并可能同时启用 `tls` 与 `uspace`。旧实现直接拒绝这一组合，阻塞 release-plz 默认 feature 集的 rustdoc，也让启用默认 TLS 的上层包不能选择用户态模式。

本次规定 `uspace` 优先：双开时使用原有用户态寄存器所有权，不分配或安装内核 TLS，用户态 TLS 仍正常保存恢复。原有仅 `tls`、仅 `uspace`、均关闭的行为和任务上下文布局保持不变。要求内核 TLS 的调用方不能在启用 `uspace` 后继续假定其可用。

## 实现

- 在 `ax-cpu`、`cpu-local`、`ax-hal`、`ax-runtime`、`someboot` 的 build.rs 中，根据 `TLS && !USPACE` 输出内部 `kernel_tls` cfg，并通过 `rustc-check-cfg` 声明；源码统一使用该 cfg 及其补集。
- `cpu-local` 增加 `uspace` feature；补齐 ax-cpu、HAL 和动态平台的转发。构建脚本保持各包自包含，不新增共享构建依赖。
- 同步四架构寄存器访问、上下文切换、RISC-V trap 选择、bootstrap/SMP 和 runtime TLS 资源路径；someboot 的 cfg 与链接脚本使用同一次计算结果。
- 更新 feature 注释、公开文档及平台技能，设计与所有权说明见 `docs/design/kernel-tls-mode.md`。
- 提升相关版本及工作区最低依赖要求，保证消费新 feature 的包不会解析到旧实现。`cpu-local` 升级到 0.3.0，覆盖新增优先级下内核 TLS 接口的条件可用性；其余相关包升级补丁版本。
- 恢复已发布 `axvisor 0.7.1` 的 semver 检查。其余 5 项仍保留：旧注册表基线自身拒绝双开，要等本次版本发布后再验证恢复。

## 验证

- 新增的 `check_kernel_tls_modes.py` 在旧实现上因双开编译错误确定性失败，修复后四种配置及同目录切换全部通过；检查真实 Cargo 编译、依赖 feature 传播和 rustc cfg，并接入 CI。
- cpu-local 四种配置的现有测试、7 项链接模板测试通过。
- axvisor 0.7.1 真实注册表基线检查通过；其余 5 包的源码基线 rustdoc/semver 全部通过，后者只证明工具链可执行，不替代未发布的注册表基线。
- 首轮四架构 ArceOS 多任务 TLS、RISC-V Starry 双开 clone/TLS、Axvisor SVM 冒烟、标准库增量测试、同步检查和工作区发布 dry-run 均通过。未运行本地 clippy，也未执行实际发布。
- 变基后四架构 ArceOS TLS、标准库增量测试、Axvisor SVM 冒烟已全部通过；四架构 Starry 单开/双开 clone/TLS（8 组）和 x86_64 arch_prctl TLS（2 组）均已通过。四架构 Starry ELF 均为 PIE，且无 PT_TLS、.tdata 和 .tbss。
- 远端 NUC Linux guest 曾在启动时停滞并超时；同一提交、同一配置本地板卡测试通过（约 56 秒），没有改动超时或放宽断言。远端当前尚未全绿。
- 四架构现有 Starry CI 后增加双开 clone/TLS 用例，持续验证新增模式。

依据：[Cargo build-script cfg](https://doc.rust-lang.org/cargo/reference/build-scripts.html#rustc-cfg)、[Cargo feature 冲突处理](https://doc.rust-lang.org/cargo/reference/features.html#mutually-exclusive-features)。
