### PR TITLE
fix(ci): install libudev for release-plz semver checks

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -62,6 +62,12 @@ jobs:
       pull-requests: write
     steps:
       - *checkout
+      - name: Install semver-check system dependencies
+        # All-feature rustdoc builds include host tooling that links to libudev.
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes pkg-config libudev-dev
+
       - name: Install workspace Rust toolchain
         run: |
           toolchain="$(rustup show active-toolchain)"

--- a/scripts/test/test_ci_routing.py
+++ b/scripts/test/test_ci_routing.py
@@ -19,6 +19,23 @@ REUSABLE_CHECK_MATRIX = (
 PR_CLEANUP_WORKFLOW = WORKSPACE_ROOT / ".github/workflows/ci-pr-cleanup.yml"
 
 
+class ReleasePrerequisiteTests(unittest.TestCase):
+    def test_semver_checks_install_libudev_before_release_plz(self) -> None:
+        workflow = (
+            WORKSPACE_ROOT / ".github/workflows/release-plz.yml"
+        ).read_text(encoding="utf-8")
+        job = mapping_block(workflow, "release-plz-pr", 2)
+        setup = named_step_block(job, "Install semver-check system dependencies")
+
+        self.assertTrue(setup, "semver checks require the libudev development files")
+        self.assertIn("sudo apt-get update", setup)
+        self.assertRegex(
+            setup,
+            r"sudo apt-get install --yes (?:pkg-config libudev-dev|libudev-dev pkg-config)",
+        )
+        self.assertLess(job.index(setup), job.index("- name: Run release-plz"))
+
+
 class RunnerTrustTests(unittest.TestCase):
     def test_cleanup_reuses_planning_runner(self) -> None:
         self.assertFalse(


### PR DESCRIPTION
修复 [Release-plz PR 失败任务](https://github.com/rcore-os/tgoskits/actions/runs/34332659524/job/102404656657)。为 `axvisor v0.7.1` 生成 semver 检查所需的 rustdoc 时，宿主工具依赖引入 `libudev-sys`，但 runner 没有安装 `libudev` 开发文件，导致 `pkg-config` 找不到 `libudev.pc`，发布 PR 流程因此中断。

改动：

- 在 `release-plz-pr` 运行 release-plz 前更新 apt 索引并安装 `pkg-config`、`libudev-dev`，提供依赖构建所需的库发现工具和开发文件。
- 在现有 CI 路由测试中加入回归检查，约束依赖安装必须发生在 release-plz 之前；该测试由现有 CI 配置验证步骤自动执行。

验证：

- 先添加回归测试，在原工作流上确认失败；修复后通过。
- CI 配置验证命令通过：`python3 scripts/test/check_ci_routing.py` 及现有三个 Python 测试模块（64 项）。
- 干净 `ubuntu:24.04` 容器中确认安装前 `pkg-config --exists libudev` 失败，安装后 `pkg-config --libs --cflags libudev` 成功并返回 `-ludev`。
- 使用 CI 相同的 `cargo-semver-checks 0.50.0` 和仓库 `nightly-2026-09-04` 运行 `cargo semver-checks check-release -p axvisor --baseline-version 0.7.1`：当前源码及 registry 基线文档均构建成功，196 项通过、58 项跳过。
- `cargo fmt --all`、`git diff --check` 通过。
- actionlint 1.7.12 对修改前后均仅报告不识别已有 `concurrency.queue` 字段；过滤这一条既有兼容性错误后检查通过。

本次仅修改工作流和 Python 回归测试，没有修改 Rust crate，因此未运行 crate clippy 或 OS 构建。未执行完整的远端 release-plz 发布流程；本地验证覆盖日志中的失败构建和对应 semver 检查。
