### PR TITLE
feat(axvisor): add control-plane manifest and explicit router roots

### DIFF
--- a/os/axvisor/Cargo.toml
+++ b/os/axvisor/Cargo.toml
@@ -72,6 +72,13 @@ browser-console = [
   "dep:serde_json",
   "dep:tokio",
 ]
+# React dashboard served from the same listener. Assets are compiled in with
+# `include_bytes!` and served from memory — cargo never invokes npm, so
+# `os/axvisor/web-ui/dist` must be produced by hand before enabling this.
+# Enabling `web-ui` alone selects the dashboard URL ownership (the console page
+# yields `/` and `/assets/*`); the UI router itself stays empty until the
+# dashboard assets land.
+web-ui = ["http-axum"]
 # Do not auto-boot the default VMs at startup; the HTTP control plane starts
 # and stops them on demand (VMs are created and stay in `Ready`).
 no-auto-start = []

--- a/os/axvisor/src/http/browser_console/mod.rs
+++ b/os/axvisor/src/http/browser_console/mod.rs
@@ -18,10 +18,23 @@ mod page;
 const BROWSER_INPUT_CAPACITY: usize = 4096;
 /// Browser-console routes served by Axvisor's optional HTTP listener.
 pub(super) fn router() -> Router {
+    // The React dashboard owns `/` and `/assets/*` once `web-ui` is enabled, so
+    // this whole subtree — page and its bundled xterm assets — moves under
+    // `/console/`. Discovery and stream routes are absolute inside the page and
+    // stay where they are.
+    #[cfg(not(feature = "web-ui"))]
+    let (index_path, script_path, style_path) = ("/", "/assets/xterm.js", "/assets/xterm.css");
+    #[cfg(feature = "web-ui")]
+    let (index_path, script_path, style_path) = (
+        "/console/",
+        "/console/assets/xterm.js",
+        "/console/assets/xterm.css",
+    );
+
     Router::new()
-        .route("/", get(index))
-        .route("/assets/xterm.js", get(xterm_javascript))
-        .route("/assets/xterm.css", get(xterm_stylesheet))
+        .route(index_path, get(index))
+        .route(script_path, get(xterm_javascript))
+        .route(style_path, get(xterm_stylesheet))
         .route("/api/consoles", get(console_descriptions))
         .route("/ws/{endpoint}", get(upgrade_console))
 }

--- a/os/axvisor/src/http/browser_console/mod.rs
+++ b/os/axvisor/src/http/browser_console/mod.rs
@@ -16,23 +16,31 @@ use serde_json::{Value, json};
 mod page;
 
 const BROWSER_INPUT_CAPACITY: usize = 4096;
+
+/// Path the console page is mounted at.
+///
+/// `web-ui` reserves `/` and `/assets/*` for the React dashboard, so with that
+/// feature the whole console subtree serves under `/console/`; without it this
+/// page is the only UI and keeps `/`. The startup access banner
+/// ([`crate::network_status`]) prints this same path, so the advertised URL
+/// stays in sync with [`router()`] by construction.
+#[cfg(feature = "web-ui")]
+pub(crate) const PAGE_PATH: &str = "/console/";
+#[cfg(not(feature = "web-ui"))]
+pub(crate) const PAGE_PATH: &str = "/";
+
 /// Browser-console routes served by Axvisor's optional HTTP listener.
 pub(super) fn router() -> Router {
-    // The React dashboard owns `/` and `/assets/*` once `web-ui` is enabled, so
-    // this whole subtree — page and its bundled xterm assets — moves under
-    // `/console/`. Discovery and stream routes are absolute inside the page and
-    // stay where they are.
+    // The xterm assets follow the page — the page addresses them relatively, so
+    // they carry the same mount prefix. Discovery and stream routes are
+    // absolute inside the page and stay where they are.
     #[cfg(not(feature = "web-ui"))]
-    let (index_path, script_path, style_path) = ("/", "/assets/xterm.js", "/assets/xterm.css");
+    let (script_path, style_path) = ("/assets/xterm.js", "/assets/xterm.css");
     #[cfg(feature = "web-ui")]
-    let (index_path, script_path, style_path) = (
-        "/console/",
-        "/console/assets/xterm.js",
-        "/console/assets/xterm.css",
-    );
+    let (script_path, style_path) = ("/console/assets/xterm.js", "/console/assets/xterm.css");
 
     Router::new()
-        .route(index_path, get(index))
+        .route(PAGE_PATH, get(index))
         .route(script_path, get(xterm_javascript))
         .route(style_path, get(xterm_stylesheet))
         .route("/api/consoles", get(console_descriptions))

--- a/os/axvisor/src/http/browser_console/page.rs
+++ b/os/axvisor/src/http/browser_console/page.rs
@@ -1,4 +1,7 @@
 //! Self-contained single-page frontend served directly by Axvisor.
+//!
+//! The page refers to its own assets relatively so that the same HTML works at
+//! `/` and, once the React dashboard takes `/` over, at `/console/`.
 
 pub(super) const XTERM_JAVASCRIPT: &str = include_str!("assets/xterm-6.0.0/xterm.js");
 pub(super) const XTERM_STYLESHEET: &str = include_str!("assets/xterm-6.0.0/xterm.css");
@@ -9,7 +12,7 @@ pub(super) const INDEX_HTML: &str = r##"<!doctype html>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Axvisor board console</title>
-  <link rel="stylesheet" href="/assets/xterm.css">
+  <link rel="stylesheet" href="assets/xterm.css">
   <style>
     :root { color-scheme: dark; font-family: system-ui, sans-serif; background: #080c14; color: #e8edf7; }
     * { box-sizing: border-box; }
@@ -44,7 +47,7 @@ pub(super) const INDEX_HTML: &str = r##"<!doctype html>
       <div class="terminal"></div>
     </section>
   </template>
-  <script src="/assets/xterm.js"></script>
+  <script src="assets/xterm.js"></script>
   <script>
     (() => {
       const encoder = new TextEncoder();

--- a/os/axvisor/src/http/manifest.rs
+++ b/os/axvisor/src/http/manifest.rs
@@ -1,0 +1,31 @@
+//! Top-level control-plane manifest.
+//!
+//! The manifest is the runtime contract the dashboard shell navigates by: it
+//! lists the resource families this build exposes, what each of them supports,
+//! and where it hangs. The shell never hardcodes routes — it follows `href`,
+//! and degrades to a JSON view for kinds it does not know.
+
+use axum::Json;
+use serde_json::{Value, json};
+
+/// Contract version.
+///
+/// Bump only for shape changes an older client cannot degrade on; new fields
+/// and new resource nodes are additive and keep the current version.
+const PROTO: u32 = 1;
+
+/// `GET /api/` — top-level capability manifest.
+///
+/// Read-only and unauthenticated like every other GET route; mutating routes
+/// are the ones gated by the build-time bearer token (see [`crate::http::auth`]).
+pub async fn get_manifest() -> Json<Value> {
+    Json(json!({
+        "proto": PROTO,
+        "resources": [{
+            "kind": "vms",
+            "title": "虚拟机",
+            "href": "/api/vms",
+            "verbs": ["read", "write"],
+        }],
+    }))
+}

--- a/os/axvisor/src/http/mod.rs
+++ b/os/axvisor/src/http/mod.rs
@@ -15,6 +15,8 @@
 pub mod auth;
 #[cfg(feature = "browser-console")]
 pub mod browser_console;
+#[cfg(feature = "http-axum")]
+pub mod manifest;
 pub mod server;
 #[cfg(feature = "http-axum")]
 pub mod vm;

--- a/os/axvisor/src/http/server.rs
+++ b/os/axvisor/src/http/server.rs
@@ -74,20 +74,20 @@ impl Drop for ListeningGuard {
 }
 
 /// Assemble only the HTTP services selected by build features.
+///
+/// Three roots keep the ownership of every URL namespace visible in one place:
+/// `/api/*` is the resource surface, the console group owns its page and
+/// streams, and `/` together with its page assets belongs to exactly one UI.
 pub fn router() -> Router {
-    let router = Router::new();
-
-    #[cfg(feature = "http-axum")]
-    let router = router.merge(management_router());
-
-    #[cfg(feature = "browser-console")]
-    let router = router.merge(crate::http::browser_console::router());
-
-    router
+    Router::new()
+        .merge(api_router())
+        .merge(console_router())
+        .merge(ui_router())
 }
 
+/// `/api/*`: the resource surface plus the top-level manifest.
 #[cfg(feature = "http-axum")]
-fn management_router() -> Router {
+fn api_router() -> Router {
     Router::new()
         .route("/api/vms", get(vm::list_vms))
         .route("/api/vms/{id}", get(vm::vm_detail).delete(vm::vm_delete))
@@ -96,6 +96,31 @@ fn management_router() -> Router {
         .route("/api/vms/{id}/stop", post(vm::vm_stop))
         .route("/api/vms/{id}/pause", post(vm::vm_pause))
         .route("/api/vms/{id}/resume", post(vm::vm_resume))
+}
+
+#[cfg(not(feature = "http-axum"))]
+fn api_router() -> Router {
+    Router::new()
+}
+
+/// The console page, console discovery, and console streams.
+#[cfg(feature = "browser-console")]
+fn console_router() -> Router {
+    crate::http::browser_console::router()
+}
+
+#[cfg(not(feature = "browser-console"))]
+fn console_router() -> Router {
+    Router::new()
+}
+
+/// `/` and its page assets.
+///
+/// The React dashboard takes this root over once the `web-ui` feature lands,
+/// and the legacy console page moves under `/console/`; until then the console
+/// group is the only UI and this root stays empty.
+fn ui_router() -> Router {
+    Router::new()
 }
 
 /// Bind address for the management HTTP server.

--- a/os/axvisor/src/http/server.rs
+++ b/os/axvisor/src/http/server.rs
@@ -5,6 +5,7 @@
 //! but dispatch and JSON construction are delegated to axum + serde_json.
 //!
 //! ```text
+//! GET    /api/               → 200, JSON control-plane manifest (capability list)
 //! GET    /api/vms            → 200, JSON array (summary form)
 //! GET    /api/vms/{id}       → 200, JSON detail (with vcpu_states) | 404
 //! POST   /api/vms/create     → 200 {"id":N} | 400 | 409 | 500 (body {"toml": "..."})
@@ -56,6 +57,8 @@ use anyhow::Context;
 use axum::Router;
 
 #[cfg(feature = "http-axum")]
+use crate::http::manifest;
+#[cfg(feature = "http-axum")]
 use crate::http::vm;
 #[cfg(feature = "http-axum")]
 use axum::{routing::get, routing::post};
@@ -89,6 +92,7 @@ pub fn router() -> Router {
 #[cfg(feature = "http-axum")]
 fn api_router() -> Router {
     Router::new()
+        .route("/api/", get(manifest::get_manifest))
         .route("/api/vms", get(vm::list_vms))
         .route("/api/vms/{id}", get(vm::vm_detail).delete(vm::vm_delete))
         .route("/api/vms/create", post(vm::vm_create))

--- a/os/axvisor/src/network_status.rs
+++ b/os/axvisor/src/network_status.rs
@@ -93,5 +93,11 @@ fn append_web_console_endpoint(
         IpAddr::V4(ip) if ip.is_unspecified() => assigned_address.to_string(),
         ip => ip.to_string(),
     };
-    let _ = write!(banner, "  web_console = http://{host}:{}/\r\n", bind.port());
+    let _ = write!(
+        banner,
+        "  web_console = http://{}:{}{}\r\n",
+        host,
+        bind.port(),
+        crate::http::browser_console::PAGE_PATH
+    );
 }

--- a/test-suit/axvisor/normal/qemu-browser-console/browser-console/http_probe.py
+++ b/test-suit/axvisor/normal/qemu-browser-console/browser-console/http_probe.py
@@ -180,8 +180,11 @@ def check_page():
     expect_status("GET /", status, 200)
     for marker in (
         b"/api/consoles",
-        b"/assets/xterm.js",
-        b"/assets/xterm.css",
+        # The page references its xterm assets relatively, so the same HTML
+        # resolves them wherever the page is mounted (/ or /console/).
+        b'href="assets/xterm.css"',
+        b'src="assets/xterm.js"',
+
         b"new Terminal",
         b"terminal.onData",
         b"catch(() => document.execCommand('copy'))",

--- a/test-suit/axvisor/normal/qemu-http-control-plane/http-control-plane/http_probe.py
+++ b/test-suit/axvisor/normal/qemu-http-control-plane/http-control-plane/http_probe.py
@@ -27,6 +27,7 @@ auth/error mapping, start/stop, pause/resume, and the destroy-then-recreate
 resource re-acquire regression — mirroring
 `os/axvisor/doc/http-control-plane-quickstart.md`:
 
+    GET    /api/               -> 200            (control-plane manifest; vms node)
     GET    /api/vms            -> 200            (list; id=1 present)
     GET    /api/vms/1          -> 200 ready      (detail; id/name/cpu_num/vcpu_states/guest_entry_count)
     GET    /api/vms/not-an-id  -> 404            (non-numeric id)
@@ -387,6 +388,29 @@ def main():
     #    request briefly in case the axum router is still binding.
     poll_ready()
     print("  http probe: guest management server reachable")
+
+    # 1b. Control-plane manifest: the capability list a dashboard shell
+    #     navigates by. The shape is asserted, not just the status, because the
+    #     shell follows `href` instead of hardcoding routes.
+    status, body = request("GET", "/api/")
+    check("GET /api/", status, 200)
+    if body.get("proto") != 1:
+        raise AssertionError("GET /api/ reported proto=%r" % (body.get("proto"),))
+    resources = body.get("resources")
+    if not isinstance(resources, list):
+        raise AssertionError("GET /api/ reported no resources array: %r" % (body,))
+    vms_nodes = [node for node in resources if node.get("kind") == "vms"]
+    if len(vms_nodes) != 1:
+        raise AssertionError(
+            "GET /api/ did not report exactly one vms node: %r" % (body,)
+        )
+    vms_node = vms_nodes[0]
+    if vms_node.get("href") != "/api/vms":
+        raise AssertionError("GET /api/ vms node href=%r" % (vms_node.get("href"),))
+    if "read" not in vms_node.get("verbs", []) or "write" not in vms_node.get(
+        "verbs", []
+    ):
+        raise AssertionError("GET /api/ vms node verbs=%r" % (vms_node.get("verbs"),))
 
     # 2. List: the default VM (id 1) is registered and `Ready`.
     status, body = request("GET", "/api/vms")


### PR DESCRIPTION
## 背景与目标

axvisor 目前的 VM 管理只有两种入口：串口 shell，和 curl 直达的 HTTP 管理 API（`/api/vms*` 共 8 条路由，写操作需要 Bearer token）。我们正在做一件事：让浏览器里有一个 React 管理页，能完成与 curl 完全一致的 VM 生命周期操作，后端 API 语义零改动。

这个目标分三步，每步一个 PR：

1. **本 PR**：先定后端契约——新增「能力发现」端点，把 HTTP 路由装配点整理成职责明确的几组，把将来要被页面占用的 URL 归属先定死。
2. **下一个 PR（React 页面）**：前端源码放进 `os/axvisor/web-ui/`，构建产物 `include_bytes!` 编译期内嵌、运行时纯内存直服（cargo 不调用 npm），VM 面板接真实 API 完成完整生命周期。
3. **再下一个（终端面板）**：把现有 `/ws/*` 终端流接进同一个页面。

## 本 PR 的三个改动

1. **新增 `GET /api/` 能力清单**。页面不应硬编码「后端有哪些功能」，而是启动时拉一份清单：`{"proto":1,"resources":[{"kind":"vms","href":"/api/vms","verbs":["read","write"]}]}`，跟着 `href` 导航；遇到不认识的 kind 显示降级视图而不崩。这样以后后端加新资源，老页面自动多一项、无需改前端。端点只读、免 token（与其余 GET 路由一致），挂在 `http-axum` 下，curl 即可访问，不依赖任何 UI。
2. **装配点整理为三个命名根**（纯重构，路由集合零变化）：`api_router()`（`/api/*` 资源面）、`console_router()`（现有板载终端页与流）、`ui_router()`（`/` 与页面静态资产）。
3. **声明 `web-ui` feature 并定下旧终端页的让位规则**。React 页面将占用 `/` 与 `/assets/*`，而现有终端页已注册 `/assets/xterm.{js,css}`——两个 feature 声明同一命名空间会让 axum 路由合并直接 panic（与历史上两个页面争 `/` 是同一类问题）。故现在定死：`web-ui` 开启时旧终端页整棵子树（页面 + 自带 xterm 资源）挪到 `/console/`；关闭时路由与今天完全一致。

## 为什么有些改动「暂时什么也不做」

- `ui_router()` 返回空 Router：这是给 React 资产路由预留的插槽，先把 `/` 的归属在装配点立起来，下个 PR 直接往里填。
- `web-ui` 开启后暂不改变任何路由：它当前的作用是给「旧页让位」提供真实 feature 门控、锁定 `web-ui = ["http-axum"]` 的依赖关系；页面资产落地后才真正接管 `/`。

## 验证

- 三种 feature 组合构建通过：仅 `http-axum` / 仅 `browser-console` / 三者全开（含 `web-ui`）。
- `cargo xtask axvisor test qemu --test-case http-control-plane` PASS：既有 8 条 `/api/vms*` 路由与生命周期契约零回归，并新增 `GET /api/` 形状断言（proto / 唯一 vms 节点 / href / verbs）。
- `cargo fmt --check`。
