### PR TITLE
fix(ax-driver): keep PCI INTx unmasked for virtio input probe

### DIFF
--- a/drivers/ax-driver/src/virtio/input.rs
+++ b/drivers/ax-driver/src/virtio/input.rs
@@ -28,8 +28,7 @@ crate::model_register!(
 
 #[cfg(feature = "pci")]
 fn probe_pci(mut probe: rdrive::probe::pci::ProbePci<'_>) -> Result<(), OnProbeError> {
-    let transport =
-        crate::pci::take_virtio_transport_masked(probe.endpoint_mut(), DeviceType::Input)?;
+    let transport = crate::pci::take_virtio_transport(probe.endpoint_mut(), DeviceType::Input)?;
     let info = binding_info_from_pci(probe.info(), PciIrqRequirement::Optional)?;
     register_transport_with_info(probe.into_platform_device(), transport, info)
 }


### PR DESCRIPTION
## 要解决的问题

上游 issue #2352：virtio input 的 PCI probe 走 `take_virtio_transport_masked`，probe 即把 PCI command 寄存器的 `INTERRUPT_DISABLE` 置位，而全树没有任何路径解除它：

- input 的 IRQ 绑定链路（`binding_info_from_pci`）只产出 INTx，从不分配 MSI；
- 驱动的 `enable_irq()/disable_irq()` 仅翻转软件标志 `irq_enabled`，不回写 PCI command；
- `unmask_intx_passthrough` 只服务于 passthrough handoff，不在此路径。

结果：INTx 绑定解析成功、`request_irq` 成功、`evdev-irq-service` 正常 park，但设备物理上无法断言中断——阻塞读者（libinput、dd）无限等待，桌面上表现为鼠标事件整体丢失（光标不动、点击无反应）。掩 INTx 是 #1228 轮询时代的假设，#2313 起 evdev 改为 IRQ 驱动后失效。

## 实际改动

`drivers/ax-driver/src/virtio/input.rs` 的 PCI probe 与 virtio-net 对齐，改用不掩 INTx 的 `take_virtio_transport`（单行改动）。

## 每步逻辑

INTx 绑定场景下设备必须保持 INTx 使能；掩码的设计场景是 MSI-X（掩 INTx 防误触发），但该调用路径从不分配 MSI，掩码因此成为永久性。probe 阶段无法预知是否会转 MSI，直接沿用 unmasked 路径最直接；masked 语义应与真实 MSI 租约绑定，原则性方向（驱动开关回写 PCI command、GICv2m provider 等）已在 #2352 中讨论。

## 验证

QEMU virt aarch64（HVF，`-smp 4`，`virtio-keyboard-pci` + `virtio-mouse-pci`）：

- 内核层：先启动阻塞 `dd if=/dev/input/event0|event1` 再经 HMP 注入事件——修复前 0 字节 + Terminated；修复后键盘/鼠标各 144B、dd Done（阻塞读者被唤醒）。
- 桌面层：libinput 枚举 event0/event1；合成器光标任意定位、点击关闭面板、拖拽拉出 Dashboard 面板。
- `cargo xtask starry build -c os/StarryOS/configs/board/qemu-aarch64.toml --smp 4` 构建通过；starry-kernel aarch64 目标 clippy 全部通过。ax-driver clippy 矩阵在 macOS 宿主因 `model_register` 宏的 section 名在 Mach-O 下非法而失败，属既有环境限制（上游 CI 在 Linux ELF），aarch64 目标实际编译通过。

Fixes #2352