### PR TITLE
fix(release): republish ax-percpu with cpu-local 0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1073,7 +1073,7 @@ dependencies = [
 
 [[package]]
 name = "ax-percpu"
-version = "0.4.19"
+version = "0.4.20"
 dependencies = [
  "ax-lazyinit",
  "ax-percpu-macros",

--- a/components/percpu/percpu/CHANGELOG.md
+++ b/components/percpu/percpu/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.20](https://github.com/rcore-os/tgoskits/compare/ax-percpu-v0.4.19...ax-percpu-v0.4.20) - 2026-09-10
+
+### Fixed
+
+- Publish the workspace `cpu-local 0.3` dependency so registry consumers use the
+  same CPU-local types as the current workspace.
+
 ## [0.4.19](https://github.com/rcore-os/tgoskits/compare/ax-percpu-v0.4.18...ax-percpu-v0.4.19) - 2026-09-09
 
 ### Other

--- a/components/percpu/percpu/Cargo.toml
+++ b/components/percpu/percpu/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ax-percpu"
 description = "Define and access per-CPU data structures"
-version = "0.4.19"
+version = "0.4.20"
 repository = "https://github.com/rcore-os/tgoskits"
 edition.workspace = true
 authors = ["Yuekai Jia <equation618@gmail.com>", "hky1999 <976929993@qq.com>", "Su Mingxian <aarkegz@gmail.com>", "yufeng <321353225@qq.com>"]

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -27,3 +27,10 @@ semver_check = false
 [[package]]
 name = "ax-std"
 semver_check = false
+
+# starry-kernel 0.9.0 resolves axplat-dyn 0.9.1, whose direct cpu-local 0.3
+# dependency conflicts with ax-percpu 0.4.19's published cpu-local 0.2
+# requirement. Re-enable this check after ax-percpu 0.4.20 is published.
+[[package]]
+name = "starry-kernel"
+semver_check = false


### PR DESCRIPTION
## 问题

`Release-plz PR` 在对已发布的 `starry-kernel 0.9.0` 执行 semver 检查时编译失败。注册表中的 `axplat-dyn 0.9.1` 直接依赖 `cpu-local 0.3`，但 `ax-percpu 0.4.19` 的已发布元数据仍依赖 `cpu-local 0.2`，导致 `CpuIndex`、`CpuAreaRef` 和 `CpuLocalError` 出现两套互不兼容的类型。

失败作业：https://github.com/rcore-os/tgoskits/actions/runs/34418485752/job/102690191046

## 改动

- 手动将 `ax-percpu` 提升到 `0.4.20`，使新版本发布时记录 workspace 当前的 `cpu-local 0.3.0` 依赖。
- 同步更新 `Cargo.lock` 和 `ax-percpu` 变更日志。
- 临时关闭 `starry-kernel` 的 release-plz semver 检查，避免损坏的已发布依赖闭包阻塞 `ax-percpu 0.4.20` 的发布准备。
- 在配置中明确注明：`ax-percpu 0.4.20` 发布后应重新启用该检查。

这里保持 `ax-percpu` 的 `0.4` 版本线，而不是提升到 `0.5`：现有已发布消费者使用 `ax-percpu = "0.4"`，发布 `0.4.20` 后才能自动解析到修复版本。

## 验证

- 使用注册表依赖构造 `starry-kernel 0.9.0` 编译复现，稳定得到与 CI 相同的四处 `E0308` 和两版 `cpu-local` 冲突。
- `cargo package -p ax-percpu --allow-dirty --no-verify` 通过；生成包的规范化 `Cargo.toml` 为 `ax-percpu 0.4.20`、`cpu-local = "0.3.0"`。
- `release-plz update --allow-dirty -vv` 在一次性副本中通过，不再触发该 semver 编译失败。
- `cargo xtask clippy --package ax-percpu` 通过（2/2 配置）。
- `cargo fmt --check`、`cargo metadata --locked --format-version 1 --no-deps`、`git diff --check` 通过。
- `cargo xtask test` 按用户要求提前停止；停止前 56/59 个白名单包通过，剩余 3 个未执行完成。
