### PR TITLE
fix(starry-kernel): allow completed block request IDs to be reused

### DIFF
--- a/os/StarryOS/kernel/src/block_runtime_axtest.rs
+++ b/os/StarryOS/kernel/src/block_runtime_axtest.rs
@@ -1,6 +1,6 @@
 //! Starry axtests for the asynchronous block runtime boundary.
 
-use alloc::sync::Arc;
+use alloc::{sync::Arc, vec::Vec};
 use ax_fs_ng::{BlockDeviceHandle, BlockError};
 use core::{
     future::{Future, poll_fn},
@@ -37,6 +37,12 @@ fn block_runtime_async_double_read() {
         .first()
         .cloned()
         .expect("block axtest requires an installed block device");
+    let serial = read_two(Arc::clone(&device), true);
+    let concurrent = read_two(device, false);
+    assert_eq!(concurrent, serial, "each completion must contain its requested block");
+}
+
+fn read_two(device: Arc<BlockDeviceHandle>, finish_first: bool) -> (Vec<u8>, Vec<u8>) {
     let info = device.device_info();
     assert!(info.num_blocks >= 2, "block axtest requires at least two blocks");
     let block_size = info.logical_block_size;
@@ -57,7 +63,7 @@ fn block_runtime_async_double_read() {
         } else {
             false
         };
-        let second_polled = if second_result.is_none() {
+        let second_polled = if second_result.is_none() && (!finish_first || first_result.is_some()) {
             match second.as_mut().poll(cx) {
                 Poll::Ready(result) => {
                     second_result = Some(result);
@@ -82,7 +88,7 @@ fn block_runtime_async_double_read() {
     }));
 
     assert!(
-        first_pending_before_second,
+        finish_first || first_pending_before_second,
         "second request was not polled while the first completion was pending"
     );
     let first = first_result.expect("first block request result");
@@ -91,5 +97,10 @@ fn block_runtime_async_double_read() {
     assert_eq!(second.result, Ok(()));
     assert_eq!(first.data.as_ref().map(|dma| dma.len().get()), Some(block_size));
     assert_eq!(second.data.as_ref().map(|dma| dma.len().get()), Some(block_size));
-    assert_ne!(usize::from(first.id), usize::from(second.id));
+    let first = first.data.expect("first read DMA backing").into_cpu_buffer();
+    let second = second.data.expect("second read DMA backing").into_cpu_buffer();
+    // Hardware queue tags can be reused as soon as a request completes, even
+    // while its consumer still owns the completed DMA buffer.
+    assert_ne!(first.cpu_ptr(), second.cpu_ptr());
+    (first.as_slice_cpu().to_vec(), second.as_slice_cpu().to_vec())
 }


### PR DESCRIPTION
`dev` CI 34428429562 的 Starry 块设备 axtest 在两笔读请求都完成后断言请求 ID 不同，出现 `left: 1 / right: 1` panic。NVMe 完成处理先回收 CID，再交付完成缓冲区；后续请求合法复用 CID，因此该断言取决于完成时序。

测试现在覆盖第一笔完成后再推进第二笔，以及两个 future 交错推进的顺序。检查两次读取均成功、长度正确、DMA 缓冲区所有权独立，并比较两种顺序的读回内容。这保留了并发读的验证，同时允许完成后的请求 ID 复用。

验证：

- `cargo xtask ktest qemu -p starry-kernel --arch aarch64`：受控顺序在旧断言上确定性失败；同一用例修复后通过，汇总 `pass=175 fail=0 skip=0`。
- `cargo xtask test --since origin/dev`：通过。
- `cargo xtask clippy --package axbuild --package starry-kernel`：93/93 组合通过，内核代码与当前提交相同。
- `cargo fmt`、`git diff --check`：通过。

按当前范围，Apps 测试改动已移出本 PR。最新提交的完整主 CI：[34437274401](https://github.com/rcore-os/tgoskits/actions/runs/34437274401) 已结束。除机器人 Linux guest 失败、StarryOS guest 被取消外，其余全部成功（包括所有 QEMU 套件、标准库测试和增量 Clippy）。机器人首轮平均 27.98 FPS，第二轮停在第 509 帧无帧超时，最终触发原有 900 秒超时。

本 PR 暂为草稿：机器人 Linux guest 测试另有掉帧故障，尚未完成根因修复。guest ftrace 已确认 xHCI event type 37 的完成码为 `Event Ring Full Error`；相同 VM 配置换用 Linux 6.1.99 后仍出现该错误。未降低 28 FPS 门槛、增加重试或延长超时。
