### PR TITLE
fix(some-serial): clear PL011 IRQ status before draining the RX FIFO

### DIFF
--- a/drivers/serial/some-serial/src/pl011/irq.rs
+++ b/drivers/serial/some-serial/src/pl011/irq.rs
@@ -28,6 +28,16 @@ impl UartIrq for Pl011Irq {
         if active == 0 {
             return None;
         }
+        // Clear the sampled status before draining, mirroring Linux
+        // pl011_int(). The host console refills the RX FIFO as soon as this
+        // handler frees space, and a PL011 implementation may assert the
+        // receive interrupt only on a new arrival edge instead of
+        // re-evaluating the FIFO level. Clearing after the drain would wipe
+        // an interrupt asserted by bytes that arrived while the handler was
+        // running, leaving them stranded in the FIFO with no way to signal
+        // again. Clearing first keeps every later arrival latched as a new
+        // interrupt.
+        self.registers().uarticr.set(active);
 
         let mut events = events_from_mis(mis);
         let mut rx = IrqRxBatch::new();
@@ -59,7 +69,6 @@ impl UartIrq for Pl011Irq {
         } else if !rearm.is_empty() {
             self.mask(rearm);
         }
-        self.registers().uarticr.set(active);
 
         Some(SerialIrqReport::new(
             SerialIrqEvent {


### PR DESCRIPTION
## 问题

QEMU aarch64（SMP2、MTTCG）下约三分之一的启动会出现控制台永久无响应：注入的 shell 命令只被回显一半，之后两个 CPU 都停在 WFI 空闲循环，`wakeup-latency-bench` 等任何交互任务都无法继续；偶发伴随 bench `not_parked` 计数。该问题在未修改的 dev 基线上同样复现（约 1/3），是既有缺陷，也大概率与 #2308 历史中未解释的 exp105 `not_parked=1`、SG2002 "RX 停滞" 同源。

## 根因

`Pl011Irq::handle()` 的顺序是"先排空 RX FIFO，最后写 UARTICR 清中断"。排查证据链：

1. gdb 快照：挂死时两 CPU 均在 `wait_for_interrupt`，说明不是死锁而是无人被唤醒；
2. QMP 物理内存转储：PL011 处于 `FR=0xC0`（RX FIFO 满 16 字节）+ `IMSC.RX` 使能 + `RIS.RX=0` 的矛盾状态；
3. QEMU 设备 trace（`-trace enable=pl011*`）钉死时序：排空循环以 RXFE 退出后、驱动写 ICR 之前，主机控制台恰好送入新字节（`pl011_fifo_rx_put ... 1/16` 重新置位 INT_RX），随后的 `ICR=0x10` 把这个刚置位的中断又清掉。

QEMU 的 PL011 模型只在"到达沿"置位接收中断（`read_trigger` 被硬编码为 1），且其寄存器图中声明的 INT_RT 接收超时没有实现定时器，不会按 FIFO 电平重新评估。被误清后，滞留在满 FIFO 中的字节永远无法再触发中断：tty 整行永不完整，shell 的阻塞 read 永久睡眠。真实硬件 RXINTR 是电平语义且有真实 RT 定时器兜底，任一都能恢复，因此只在 QEMU 暴露。

## 修复

将 UARTICR 清除移到采样 `UARTMIS` 之后、排空 FIFO 之前，对齐 Linux `pl011_int()` 的顺序：

- 清除之后到达的每个字节都会锁存为新中断；
- 已被本次清除覆盖的字节由紧随的排空循环读走（读到 RXFE 为止）；
- 批次满/overrun 时的 mask+rearm 托管路径保持不变。

该顺序在电平语义（真硬件）与边沿语义（QEMU）下都收敛。

## 回归证据

- 驱动单测（`cargo test -p some-serial`）：63/63 通过；
- 启动统计（每轮含完整注入 workload）：常规时序 20/20 通过（修复前约 1/3 挂死）；`-trace` 拉慢时序 6/6 通过（修复前 6/6 全挂）；
- `cargo xtask starry test qemu --arch aarch64` 全量系统测试通过；
- `cargo xtask clippy --package some-serial` 通过。

寄存器假体无法表达"处理中途回填 FIFO"的设备时序窗口，crate 内无法构造确定性红绿测试，故以设备 trace 证据 + 启动统计代替（原因记录在提交信息中）。

Refs #2308
