### PR TITLE
perf(ax-task): reduce same-CPU futex handoff instructions on AArch64

### DIFF
--- a/components/ax-task/src/sched/algorithm/queue/accounting.rs
+++ b/components/ax-task/src/sched/algorithm/queue/accounting.rs
@@ -21,6 +21,9 @@ impl RunQueue {
     /// The common dispatch token and RT/DL active nodes are disjoint fields
     /// of the same rq. Keeping this operation here prevents callers from
     /// temporarily clearing `rq->curr` merely to obtain two mutable borrows.
+    /// Only small copyable accounting facts cross this boundary, like Linux
+    /// `update_curr()` returning to its callers; the running entity stays in
+    /// the rq and is re-read where a consumer actually needs it.
     pub(crate) fn charge_current(
         &mut self,
         runtime_ns: u64,
@@ -29,37 +32,34 @@ impl RunQueue {
         extra_bw_scaled: u64,
         max_bw_scaled: u64,
         reclaimed_ns: u64,
-    ) -> Result<(DispatchCharge, SchedulePolicy, SchedulingEntity, bool), TaskError> {
+    ) -> Result<(DispatchCharge, SchedulePolicy, bool), TaskError> {
         let current = self.current.as_ref().ok_or(TaskError::NoRunnableThread)?;
         let id = current.thread();
         let policy = current.schedule_policy();
         let rt_quota_exempt = current.rt_quota_exempt();
         let membership = self.membership_class(id);
-        let current_entity = match membership {
-            Some(QueueMembershipClass::Deadline(key)) => self
-                .deadline
-                .get(key)
-                .map(QueuedThread::entity_snapshot)
-                .ok_or(TaskError::InvalidConfiguration)?,
-            Some(QueueMembershipClass::Realtime(key)) => self
-                .rt
-                .get(key)
-                .map(QueuedThread::entity_snapshot)
-                .ok_or(TaskError::InvalidConfiguration)?,
-            _ => current
-                .owned_scheduling_entity_ref()
-                .cloned()
-                .ok_or(TaskError::InvalidConfiguration)?,
+        // GRUB reclaim consults only a Deadline entity's server flags and the
+        // task's bandwidth metadata; every other class pays the full runtime
+        // charge, so the pre-charge entity snapshot exists only for Deadline.
+        let grub_reclaimed_ns = match membership {
+            Some(QueueMembershipClass::Deadline(key)) => {
+                let entity = self
+                    .deadline
+                    .get(key)
+                    .map(QueuedThread::entity_snapshot)
+                    .ok_or(TaskError::InvalidConfiguration)?;
+                current.grub_reclaimed_ns(
+                    &entity,
+                    runtime_ns,
+                    inactive_bw_scaled,
+                    extra_bw_scaled,
+                    max_bw_scaled,
+                )
+            }
+            _ => 0,
         };
-        let dispatch = self.current.as_mut().ok_or(TaskError::NoRunnableThread)?;
-        let grub_reclaimed_ns = dispatch.grub_reclaimed_ns(
-            &current_entity,
-            runtime_ns,
-            inactive_bw_scaled,
-            extra_bw_scaled,
-            max_bw_scaled,
-        );
         let reclaimed_ns = reclaimed_ns.saturating_add(grub_reclaimed_ns);
+        let dispatch = self.current.as_mut().ok_or(TaskError::NoRunnableThread)?;
         let charge = match membership {
             Some(QueueMembershipClass::Deadline(key)) => {
                 let entity = &mut self
@@ -81,25 +81,7 @@ impl RunQueue {
             }
             _ => dispatch.charge(runtime_ns, now_ns, reclaimed_ns),
         };
-        let charged_entity = match membership {
-            Some(QueueMembershipClass::Deadline(key)) => self
-                .deadline
-                .get(key)
-                .map(QueuedThread::entity_snapshot)
-                .ok_or(TaskError::InvalidConfiguration)?,
-            Some(QueueMembershipClass::Realtime(key)) => self
-                .rt
-                .get(key)
-                .map(QueuedThread::entity_snapshot)
-                .ok_or(TaskError::InvalidConfiguration)?,
-            _ => self
-                .current
-                .as_ref()
-                .and_then(CurrentDispatch::owned_scheduling_entity_ref)
-                .cloned()
-                .ok_or(TaskError::InvalidConfiguration)?,
-        };
-        Ok((charge, policy, charged_entity, rt_quota_exempt))
+        Ok((charge, policy, rt_quota_exempt))
     }
 
     /// Reserves every class index before a thread becomes externally visible.

--- a/components/ax-task/src/sched/algorithm/queue/lifecycle.rs
+++ b/components/ax-task/src/sched/algorithm/queue/lifecycle.rs
@@ -493,6 +493,28 @@ impl RunQueue {
         }
     }
 
+    /// Snapshots the current dispatch's full scheduling entity.
+    ///
+    /// Only rare consumers such as the class tick hook need the wide linked
+    /// Deadline variant; ordinary accounting settles through the Fair
+    /// contender snapshot returned by [`Self::charge_current`].
+    pub(crate) fn current_entity_snapshot(&self, id: ThreadId) -> Option<SchedulingEntity> {
+        match self.membership_class(id) {
+            Some(QueueMembershipClass::Deadline(key)) => {
+                self.deadline.get(key).map(QueuedThread::entity_snapshot)
+            }
+            Some(QueueMembershipClass::Realtime(key)) => {
+                self.rt.get(key).map(QueuedThread::entity_snapshot)
+            }
+            _ => self
+                .current
+                .as_ref()
+                .filter(|current| current.thread() == id)
+                .and_then(CurrentDispatch::owned_scheduling_entity_ref)
+                .cloned(),
+        }
+    }
+
     /// Rebuilds the active EDF key after Linux-style boosted replenishment.
     pub(crate) fn requeue_replenished_deadline_current(
         &mut self,

--- a/components/ax-task/src/sched/system/cpu/remote/run_queue/accounting.rs
+++ b/components/ax-task/src/sched/system/cpu/remote/run_queue/accounting.rs
@@ -104,7 +104,7 @@ impl CpuRunQueueState {
         }
 
         let bandwidth = self.queue.deadline_bandwidth();
-        let (mut charge, policy, current_entity, rt_quota_exempt) = self.queue.charge_current(
+        let (mut charge, policy, rt_quota_exempt) = self.queue.charge_current(
             runtime_ns,
             now_ns,
             bandwidth.inactive_bw_scaled(),
@@ -118,15 +118,22 @@ impl CpuRunQueueState {
         } else {
             false
         };
-        if let Some(current_fair) = current_entity.fair() {
+        if let Some(current_fair) = self.current_fair_contender() {
             self.queue.update_fair_virtual_time(Some(current_fair));
         }
         let class_tick = event.runs_class_tick(charge.slice_expired).then(|| {
+            // The class tick hook runs only on periodic/clock events; it
+            // re-reads the full entity itself instead of forcing every
+            // ordinary settle to carry the wide snapshot.
+            let entity = self
+                .queue
+                .current_entity_snapshot(current_thread)
+                .expect("current identity must retain its scheduling entity");
             SchedulerClass::for_policy(policy).task_tick(
                 &mut self.queue,
                 current_thread,
                 policy,
-                &current_entity,
+                &entity,
                 charge,
                 event.periodic_tick_ns(),
             )

--- a/components/ax-task/src/sched/system/cpu/remote/run_queue/preemption.rs
+++ b/components/ax-task/src/sched/system/cpu/remote/run_queue/preemption.rs
@@ -71,15 +71,16 @@ impl CpuRunQueueState {
             }
             return WakePreemptionDecision::WakeeSelected;
         }
+        // Linux's wakeup preemption compares `rq->curr` in place through its
+        // class hooks; no entity snapshot crosses this boundary.
         let current_entity = self
             .current_scheduling_entity()
-            .cloned()
             .expect("current dispatch must have one rq-owned scheduling entity");
 
         let preempts = if context.intent.is_sync() {
             crate::sched::algorithm::default_sync_wakeup_preempts(
                 current_policy,
-                &current_entity,
+                current_entity,
                 false,
                 policy,
                 entity,
@@ -88,7 +89,7 @@ impl CpuRunQueueState {
         } else {
             crate::sched::algorithm::wakeup_preempts(
                 current_policy,
-                &current_entity,
+                current_entity,
                 false,
                 policy,
                 entity,
@@ -109,7 +110,7 @@ impl CpuRunQueueState {
             _ => WakePreemptionDecision::WakeeSelected,
         };
         if decision == WakePreemptionDecision::WakeeSelected
-            && fair_preemption_cancels_protection(current_policy, &current_entity, policy, entity)
+            && fair_preemption_cancels_protection(current_policy, current_entity, policy, entity)
             && let Some(SchedulingEntity::Fair(current)) = self.current_scheduling_entity_mut()
         {
             current.cancel_slice_protection();

--- a/os/arceos/ulib/axstd/src/os.rs
+++ b/os/arceos/ulib/axstd/src/os.rs
@@ -93,5 +93,13 @@ pub mod arceos {
 #[cfg(feature = "std-compat")]
 pub mod libc_compat;
 
+/// Kernel-image memory operations that replace the portable
+/// `compiler_builtins` versions on targets whose default codegen cannot use
+/// wide accesses. See the module documentation for the AArch64 rationale.
+/// Host-test builds compile the module for its exhaustive unit tests without
+/// exporting the kernel symbol.
+#[cfg(any(target_arch = "aarch64", all(test, feature = "host-test")))]
+pub mod arch_mem;
+
 #[cfg(any(feature = "std-compat", all(test, feature = "host-test")))]
 mod futex;

--- a/os/arceos/ulib/axstd/src/os/arch_mem.rs
+++ b/os/arceos/ulib/axstd/src/os/arch_mem.rs
@@ -1,0 +1,202 @@
+//! Compiler-ABI memory operations for AArch64 kernel images.
+//!
+//! `aarch64-unknown-none-softfloat` enables `strict-align`, so every
+//! struct-sized copy whose field offsets cannot prove 8-byte alignment
+//! compiles to a call into `compiler_builtins`, whose portable `memcpy`
+//! walks both ranges one byte at a time. Scheduler wake, park, and switch
+//! paths move dozens of such records per context switch, which made that
+//! byte loop a top instruction consumer in wakeup-latency profiles.
+//!
+//! This module provides the kernel image's `memcpy` instead. Wide accesses
+//! are used whenever they stay naturally aligned: both ranges aligned copies
+//! word-by-word, and an aligned destination with an unaligned source copies
+//! through aligned loads combined by shifts. All other shapes keep the
+//! portable byte loop. Naturally aligned accesses are permitted on every
+//! memory type, including the MMU-off Device memory that early boot code
+//! executes on, so no fast path can fault before page tables are enabled.
+
+#[cfg(not(any(test, feature = "host-test")))]
+use core::ffi::c_void;
+
+/// # Safety
+///
+/// Callers must uphold the C/libc ABI contract: `src` must be readable and
+/// `dst` writable for `n` bytes, and the ranges must not overlap.
+#[cfg(not(any(test, feature = "host-test")))]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn memcpy(dst: *mut c_void, src: *const c_void, n: usize) -> *mut c_void {
+    unsafe { dispatch_memcpy(dst.cast::<u8>(), src.cast::<u8>(), n) };
+    dst
+}
+
+/// Same dispatch as the exported [`memcpy`], callable from tests on any host.
+unsafe fn dispatch_memcpy(dst: *mut u8, src: *const u8, n: usize) {
+    unsafe {
+        let dst_aligned = (dst as usize) & 0x7 == 0;
+        let src_aligned = (src as usize) & 0x7 == 0;
+        if src_aligned {
+            if dst_aligned {
+                copy_aligned_words(dst.cast(), src.cast(), n);
+            } else {
+                copy_bytes(dst, src, n);
+            }
+        } else if dst_aligned && n >= 16 {
+            copy_shifted_words(dst.cast(), src, n);
+        } else {
+            copy_bytes(dst, src, n);
+        }
+    }
+}
+
+/// # Safety
+///
+/// Both ranges must be 8-byte aligned and hold at least `n` accessible
+/// bytes.
+unsafe fn copy_aligned_words(mut dst: *mut u64, mut src: *const u64, mut n: usize) {
+    unsafe {
+        while n >= 8 {
+            *dst = *src;
+            dst = dst.add(1);
+            src = src.add(1);
+            n -= 8;
+        }
+        copy_bytes(dst.cast(), src.cast(), n);
+    }
+}
+
+/// Copies an unaligned source range into an aligned destination.
+///
+/// Loads stay on 8-byte-aligned source addresses and each stored word is
+/// assembled from the overlapping loaded pair by a funnel shift, so the
+/// destination never receives a wide unaligned store. The trailing partial
+/// word is copied first so the funnel can cover every full word.
+///
+/// Assembling the final word loads the aligned word that begins at or after
+/// the logical end, which may read up to 7 bytes past `src + n`. That load
+/// is kept only when it cannot cross a page boundary: the final in-range
+/// byte proves its page is mapped, and any smaller page size supported by
+/// the kernel (4 KiB or larger) has boundaries at 4 KiB multiples. When the
+/// load would cross, the final word falls back to the byte loop.
+///
+/// # Safety
+///
+/// `dst` must be 8-byte aligned, `src` must not be, and both ranges must
+/// hold at least `n` accessible bytes with `n >= 16`.
+unsafe fn copy_shifted_words(dst: *mut u64, src: *const u8, n: usize) {
+    /// The largest page size whose boundaries the final-load guard must
+    /// respect; actual kernel pages are never smaller.
+    const GUARD_PAGE_SIZE: usize = 4096;
+
+    unsafe {
+        let src_misalignment = (src as usize) & 0x7;
+        let shift_bits = src_misalignment * 8;
+        let words = n / 8;
+        let tail_bytes = n - words * 8;
+        copy_bytes(
+            dst.cast::<u8>().add(n - tail_bytes),
+            src.add(n - tail_bytes),
+            tail_bytes,
+        );
+        let aligned = src.map_addr(|address| address & !0x7).cast::<u64>();
+        let final_load = aligned.addr() + words * 8;
+        let final_word_page_safe = final_load % GUARD_PAGE_SIZE <= GUARD_PAGE_SIZE - 8;
+        let assembled_words = words - usize::from(!final_word_page_safe);
+        let mut previous = *aligned;
+        for i in 0..assembled_words {
+            let next = *aligned.add(i + 1);
+            *dst.add(i) = rotate_word_pair(previous, next, shift_bits);
+            previous = next;
+        }
+        if !final_word_page_safe {
+            let final_word = assembled_words * 8;
+            copy_bytes(
+                dst.cast::<u8>().add(final_word),
+                src.add(final_word),
+                words * 8 - final_word,
+            );
+        }
+    }
+}
+
+/// Returns the `shift_bits/8`-byte-shifted window of the `[low, high]` pair.
+const fn rotate_word_pair(low: u64, high: u64, shift_bits: usize) -> u64 {
+    if shift_bits == 0 {
+        low
+    } else {
+        (low >> shift_bits) | (high << (64 - shift_bits))
+    }
+}
+
+/// # Safety
+///
+/// Both ranges must hold at least `n` accessible bytes.
+unsafe fn copy_bytes(mut dst: *mut u8, mut src: *const u8, mut n: usize) {
+    unsafe {
+        while n > 0 {
+            *dst = *src;
+            dst = dst.add(1);
+            src = src.add(1);
+            n -= 1;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec;
+
+    use super::dispatch_memcpy;
+
+    fn run_copy(arena: &mut [u8], src_base: usize, dst_base: usize, n: usize) {
+        let src_pattern = |i: usize| (src_base.wrapping_mul(31).wrapping_add(i * 7 + 3)) as u8;
+        for i in 0..n {
+            arena[src_base + i] = src_pattern(i);
+        }
+        for i in 0..n {
+            arena[dst_base + i] = 0xA5;
+        }
+        unsafe {
+            dispatch_memcpy(
+                arena.as_mut_ptr().add(dst_base),
+                arena.as_ptr().add(src_base),
+                n,
+            );
+        }
+        for i in 0..n {
+            assert_eq!(
+                arena[dst_base + i],
+                src_pattern(i),
+                "copy mismatch src={src_base} dst={dst_base} n={n} at {i}"
+            );
+        }
+    }
+
+    #[test]
+    fn every_alignment_and_size_combination_copies_exactly() {
+        let mut arena = vec![0u8; 512];
+        for src_off in 0..16usize {
+            for dst_off in 0..16usize {
+                for n in 0..96usize {
+                    run_copy(&mut arena, 128 + src_off, 256 + dst_off, n);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn page_boundary_sources_copy_exactly() {
+        let mut arena = vec![0u8; 131072];
+        let dst_base = 98304;
+        for edge in (4096..61440).step_by(4096) {
+            for delta in [
+                0usize, 1, 4, 7, 8, 9, 4080, 4084, 4087, 4088, 4089, 4090, 4095, 4100, 4200,
+            ] {
+                for misalignment in 1..8usize {
+                    for n in [24usize, 64, 72] {
+                        run_copy(&mut arena, edge + delta + misalignment, dst_base, n);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/os/arceos/ulib/axstd/src/os/libc_compat.rs
+++ b/os/arceos/ulib/axstd/src/os/libc_compat.rs
@@ -480,6 +480,7 @@ pub unsafe extern "C" fn free(ptr: *mut c_void) {
 ///
 /// Callers must uphold the Linux/musl ABI contract for this libc symbol.
 #[unsafe(no_mangle)]
+#[cfg(not(target_arch = "aarch64"))]
 pub unsafe extern "C" fn memcpy(dst: *mut c_void, src: *const c_void, n: SizeT) -> *mut c_void {
     let dst_u8 = dst.cast::<u8>();
     let src_u8 = src.cast::<u8>();


### PR DESCRIPTION
> **状态：Draft。** 按 #2308 冻结协议，性能候选需 OrangePi 板上 B-A-B2 原始数据后方可请求评审；当前仅完成 QEMU 指令级 A/B 与功能回归，板上验证为下一步。

## 问题

#2308 的 aarch64 QEMU 指令剖析（MTTCG + qperf count 模式，20000 次同核 futex 交接窗口）显示：

- `memcpy` 占窗口内全部内核指令的 26%（91.8M/350.6M，约 69.4 次调用/交接）；
- `charge_current` 每次结算前后各做一次完整 `SchedulingEntity`（Deadline 变体约 120 字节）快照，其中充电前快照只服务于 GRUB（仅 Deadline 实体非零）；
- `wakeup_preempt_with_intent` 克隆 `rq->curr` 实体仅用于按引用比较。

根因：内核链接的 `memcpy` 来自 compiler-builtins 为 `aarch64-unknown-none-softfloat`（`+strict-align`）编译的逐字节可移植版本，每次 8 字节约 15 条指令；无法证明对齐的结构体拷贝全部退化为该调用。

## 改动

**`perf(ax-task): settle wakeup accounting without entity snapshots`**
- `charge_current` 返回值收窄为 `(DispatchCharge, SchedulePolicy, bool)`，充电前实体快照仅保留给 Deadline 成员（GRUB 判定）；充电后快照取消，改由调用方通过 `current_fair_contender()` 获取 Fair 快照（Copy，48 字节），对应 Linux `update_curr()` 只返回记账事实的边界；
- 类 tick 钩子（仅周期事件触达）经新增的 `RunQueue::current_entity_snapshot` 惰性取全量实体；
- `wakeup_preempt_with_intent` 以借用比较替代克隆。

**`perf(axstd): add an aligned fast-path kernel memcpy for AArch64`**
- 新增 `os::arch_mem`（仅 aarch64 链接内核镜像）提供内核 `memcpy`：双对齐走 u64 字循环；dst 对齐 + src 非对齐走"对齐 ldr + 漏斗移位 + 对齐 str"，末字加载带 4KiB 页边界守卫（与页内既有字节共同证明映射）；其余形状保持字节循环；
- 所有宽访问均自然对齐，pre-MMU Device 内存下也安全（QEMU `-kernel` 直启时 someboot 早期 Rust 确实 pre-MMU 执行，这是不能改用非对齐宽访问的原因）；
- `libc_compat` 的 `memcpy` 在 aarch64 上让位，保持单一符号；
- 附 28986 组穷举单测（对齐 × 偏移 × 大小 × 页边界），随 `cargo test -p ax-std --features host-test` 运行。

## QEMU A/B 数据（每交接窗口指令回调数）

| 场景 | dev 基线 | 本分支 | 变化 |
| --- | ---: | ---: | ---: |
| OTHER thread_futex_same_cpu | 350.6M（17530/交接） | 343.1M | **−2.15%** |
| FIFO thread_futex_same_cpu | 252.7M | 251.7M | −0.43% |
| 其中 memcpy（OTHER） | 91.8M | 86.7M | −5.5% |
| update_current_for_event | 9.73M | 6.85M | −30% |
| wakeup_preempt_with_intent | 1.90M | 1.46M | −23% |

基线复测方差 ±0.1%。已知边界：剩余 memcpy 约 46% 指令来自 dst 非对齐拷贝，需非对齐宽存储（MMU 感知）或逐类型对齐标注（#2308 认可的"保留可证明的对齐信息"方向），留作后续。

## 验证

- `cargo xtask clippy --package ax-task / --package ax-std`、`cargo fmt` 通过；
- `cargo test -p ax-std --features host-test`（含 memcpy 穷举）通过；
- `cargo xtask starry test qemu --arch aarch64` 全量系统测试通过；
- `cargo xtask starry build --arch x86_64` 交叉构建通过（验证非 aarch64 路径不受影响）；
- 排查期间的偶发挂死已确认与性能改动无关，根因为 PL011 IRQ 清除顺序问题，另以 #2359 修复。

## 待办

- OrangePi-5-Plus-1 冻结协议 B-A-B2 完整 20 项矩阵（板上 strict-align 实际代价可能使收益高于 QEMU 指令比例）；
- 依据板上数据决定是否继续推进 dst 非对齐 memcpy 与 strict-align/target-JSON 议题。

Refs #2308
