### PR TITLE
feat(starry-kernel): synthesize card0 vblank clock with CRTC sequence ioctls

### DIFF
--- a/os/StarryOS/kernel/src/pseudofs/dev/card0.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/card0.rs
@@ -21,8 +21,12 @@
 //!   - Property validation is permissive: value ranges aren't rigorously
 //!     enforced (tests drive sensible values). Atomic rejects only
 //!     unknown `(obj, prop)` pairs and obviously-bad object/blob refs.
-//!   - `WAIT_VBLANK` returns immediately with a bumped sequence number;
-//!     there's no real vblank source to wait on.
+//!   - `WAIT_VBLANK` and the `CRTC_GET_SEQUENCE` / `CRTC_QUEUE_SEQUENCE`
+//!     pair run on a synthesized 60 Hz vblank clock
+//!     ([`super::vblank`]): the sequence is derived from elapsed
+//!     monotonic time while the CRTC is active, queued events are
+//!     delivered on the next `poll`, and event timestamps carry the
+//!     synthesized edge time.
 //!   - Mode list: one mode matching axdisplay's resolution at a
 //!     synthesized 60 Hz.
 
@@ -42,7 +46,7 @@ use core::{
 
 use ax_alloc::GlobalPage;
 use ax_memory_addr::{PAGE_SIZE_4K, PhysAddrRange};
-use ax_runtime::hal::{mem::virt_to_phys, time::monotonic_time};
+use ax_runtime::hal::{mem::virt_to_phys, time::monotonic_time_nanos};
 use axfs_ng_vfs::{NodeFlags, VfsError, VfsResult};
 use axpoll::{IoEvents, Pollable};
 use axpoll_set::PollSet;
@@ -51,30 +55,38 @@ use linux_raw_sys::general::O_CLOEXEC;
 
 use super::drm::{
     DRM_CAP_ADDFB2_MODIFIERS, DRM_CAP_CRTC_IN_VBLANK_EVENT, DRM_CAP_DUMB_BUFFER, DRM_CAP_PRIME,
-    DRM_CAP_TIMESTAMP_MONOTONIC, DRM_EVENT_FLIP_COMPLETE, DRM_FORMAT_ARGB8888,
+    DRM_CAP_TIMESTAMP_MONOTONIC, DRM_CRTC_SEQUENCE_NEXT_ON_MISS, DRM_CRTC_SEQUENCE_RELATIVE,
+    DRM_EVENT_CRTC_SEQUENCE, DRM_EVENT_FLIP_COMPLETE, DRM_EVENT_VBLANK, DRM_FORMAT_ARGB8888,
     DRM_FORMAT_MOD_INVALID, DRM_FORMAT_MOD_LINEAR, DRM_FORMAT_XRGB8888, DRM_IOCTL_AUTH_MAGIC,
-    DRM_IOCTL_DROP_MASTER, DRM_IOCTL_GET_CAP, DRM_IOCTL_GET_MAGIC, DRM_IOCTL_GET_UNIQUE,
-    DRM_IOCTL_MODE_ADDFB2, DRM_IOCTL_MODE_ATOMIC, DRM_IOCTL_MODE_CREATE_DUMB,
-    DRM_IOCTL_MODE_CREATEPROPBLOB, DRM_IOCTL_MODE_DESTROY_DUMB, DRM_IOCTL_MODE_DESTROYPROPBLOB,
-    DRM_IOCTL_MODE_DIRTYFB, DRM_IOCTL_MODE_GETCONNECTOR, DRM_IOCTL_MODE_GETCRTC,
-    DRM_IOCTL_MODE_GETENCODER, DRM_IOCTL_MODE_GETPLANE, DRM_IOCTL_MODE_GETPLANERESOURCES,
-    DRM_IOCTL_MODE_GETPROPBLOB, DRM_IOCTL_MODE_GETPROPERTY, DRM_IOCTL_MODE_GETRESOURCES,
-    DRM_IOCTL_MODE_MAP_DUMB, DRM_IOCTL_MODE_OBJ_GETPROPERTIES, DRM_IOCTL_MODE_PAGE_FLIP,
-    DRM_IOCTL_MODE_RMFB, DRM_IOCTL_MODE_SETCRTC, DRM_IOCTL_PRIME_FD_TO_HANDLE,
-    DRM_IOCTL_PRIME_HANDLE_TO_FD, DRM_IOCTL_SET_CLIENT_CAP, DRM_IOCTL_SET_MASTER,
-    DRM_IOCTL_SET_VERSION, DRM_IOCTL_VERSION, DRM_IOCTL_WAIT_VBLANK, DRM_MODE_ATOMIC_ALLOW_MODESET,
-    DRM_MODE_ATOMIC_NONBLOCK, DRM_MODE_ATOMIC_TEST_ONLY, DRM_MODE_CONNECTED,
-    DRM_MODE_CONNECTOR_VIRTUAL, DRM_MODE_ENCODER_VIRTUAL, DRM_MODE_FB_MODIFIERS,
-    DRM_MODE_OBJECT_CONNECTOR, DRM_MODE_OBJECT_CRTC, DRM_MODE_OBJECT_PLANE,
-    DRM_MODE_PAGE_FLIP_EVENT, DRM_MODE_PROP_ATOMIC, DRM_MODE_PROP_BLOB, DRM_MODE_PROP_ENUM,
-    DRM_MODE_PROP_IMMUTABLE, DRM_MODE_PROP_OBJECT, DRM_MODE_PROP_RANGE, DRM_PLANE_TYPE_PRIMARY,
-    DRM_PRIME_CAP_EXPORT, DRM_PRIME_CAP_IMPORT, DRM_PROP_NAME_LEN, DrmAuth, DrmEvent,
-    DrmEventVblank, DrmGetCap, DrmModeAtomic, DrmModeCardRes, DrmModeCreateBlob, DrmModeCreateDumb,
-    DrmModeCrtc, DrmModeCrtcPageFlip, DrmModeDestroyBlob, DrmModeDestroyDumb, DrmModeDirtyFB,
+    DRM_IOCTL_CRTC_GET_SEQUENCE, DRM_IOCTL_CRTC_QUEUE_SEQUENCE, DRM_IOCTL_DROP_MASTER,
+    DRM_IOCTL_GET_CAP, DRM_IOCTL_GET_MAGIC, DRM_IOCTL_GET_UNIQUE, DRM_IOCTL_MODE_ADDFB2,
+    DRM_IOCTL_MODE_ATOMIC, DRM_IOCTL_MODE_CREATE_DUMB, DRM_IOCTL_MODE_CREATEPROPBLOB,
+    DRM_IOCTL_MODE_DESTROY_DUMB, DRM_IOCTL_MODE_DESTROYPROPBLOB, DRM_IOCTL_MODE_DIRTYFB,
+    DRM_IOCTL_MODE_GETCONNECTOR, DRM_IOCTL_MODE_GETCRTC, DRM_IOCTL_MODE_GETENCODER,
+    DRM_IOCTL_MODE_GETPLANE, DRM_IOCTL_MODE_GETPLANERESOURCES, DRM_IOCTL_MODE_GETPROPBLOB,
+    DRM_IOCTL_MODE_GETPROPERTY, DRM_IOCTL_MODE_GETRESOURCES, DRM_IOCTL_MODE_MAP_DUMB,
+    DRM_IOCTL_MODE_OBJ_GETPROPERTIES, DRM_IOCTL_MODE_PAGE_FLIP, DRM_IOCTL_MODE_RMFB,
+    DRM_IOCTL_MODE_SETCRTC, DRM_IOCTL_PRIME_FD_TO_HANDLE, DRM_IOCTL_PRIME_HANDLE_TO_FD,
+    DRM_IOCTL_SET_CLIENT_CAP, DRM_IOCTL_SET_MASTER, DRM_IOCTL_SET_VERSION, DRM_IOCTL_VERSION,
+    DRM_IOCTL_WAIT_VBLANK, DRM_MODE_ATOMIC_ALLOW_MODESET, DRM_MODE_ATOMIC_NONBLOCK,
+    DRM_MODE_ATOMIC_TEST_ONLY, DRM_MODE_CONNECTED, DRM_MODE_CONNECTOR_VIRTUAL,
+    DRM_MODE_ENCODER_VIRTUAL, DRM_MODE_FB_MODIFIERS, DRM_MODE_OBJECT_CONNECTOR,
+    DRM_MODE_OBJECT_CRTC, DRM_MODE_OBJECT_PLANE, DRM_MODE_PAGE_FLIP_EVENT,
+    DRM_MODE_PROP_ATOMIC, DRM_MODE_PROP_BLOB, DRM_MODE_PROP_ENUM, DRM_MODE_PROP_IMMUTABLE,
+    DRM_MODE_PROP_OBJECT, DRM_MODE_PROP_RANGE, DRM_PLANE_TYPE_PRIMARY, DRM_PRIME_CAP_EXPORT,
+    DRM_PRIME_CAP_IMPORT, DRM_PROP_NAME_LEN, DRM_VBLANK_EVENT, DRM_VBLANK_FLAGS_MASK,
+    DRM_VBLANK_HIGH_CRTC_MASK, DRM_VBLANK_NEXTONMISS, DRM_VBLANK_RELATIVE, DRM_VBLANK_SECONDARY,
+    DRM_VBLANK_SIGNAL, DRM_VBLANK_TYPES_MASK, DrmAuth, DrmEvent, DrmEventCrtcSequence,
+    DrmEventVblank, DrmGetCap, DrmModeAtomic, DrmModeCardRes, DrmModeCreateBlob,
+    DrmModeCreateDumb, DrmModeCrtc, DrmModeCrtcGetSequence, DrmModeCrtcPageFlip,
+    DrmModeCrtcQueueSequence, DrmModeDestroyBlob, DrmModeDestroyDumb, DrmModeDirtyFB,
     DrmModeFbCmd2, DrmModeGetBlob, DrmModeGetConnector, DrmModeGetEncoder, DrmModeGetPlane,
     DrmModeGetPlaneRes, DrmModeGetProperty, DrmModeMapDumb, DrmModeModeInfo,
-    DrmModeObjGetProperties, DrmModePropertyEnum, DrmPrimeHandle, DrmSetClientCap, DrmSetVersion,
-    DrmUnique, DrmVersion, DrmWaitVblank,
+    DrmModeObjGetProperties, DrmModePropertyEnum, DrmPrimeHandle, DrmSetClientCap,
+    DrmSetVersion, DrmUnique, DrmVersion, DrmWaitVblank,
+};
+use super::vblank::{
+    PendingVblankEvent, QueuedVblankEvent, VblankScheduler, vblank_passed, widen_32_to_64,
 };
 use crate::{
     StarryError, StarryResult,
@@ -158,6 +170,19 @@ const SUPPORTED_FORMATS: &[u32] = &[DRM_FORMAT_XRGB8888, DRM_FORMAT_ARGB8888];
 /// Upper bound on the pending-event queue. Matches Linux's
 /// `file->event_space` of 4 KB ≈ 128 `drm_event_vblank`s.
 const MAX_EVENTS: usize = 128;
+
+/// Storage slot for a queued DRM event. `DRM_EVENT_VBLANK` and
+/// `DRM_EVENT_CRTC_SEQUENCE` are both exactly 32 bytes on 64-bit; events
+/// are serialized on enqueue so `read` can copy payloads of either type
+/// from one queue without Rust enum layout leaking into the ABI.
+const EVENT_SLOT_BYTES: usize = core::mem::size_of::<DrmEventVblank>();
+
+/// Fixed-size serialized event slot for the card's event queue.
+type EventSlot = [u8; EVENT_SLOT_BYTES];
+
+const _: () = {
+    assert!(EVENT_SLOT_BYTES == core::mem::size_of::<DrmEventCrtcSequence>());
+};
 
 /// First blob id we hand out from `CREATEPROPBLOB`.
 const FIRST_BLOB_ID: u32 = 0x1000;
@@ -305,7 +330,7 @@ struct LegacyCrtcState {
 /// single-connector / single-plane layout. Guarded by one mutex because
 /// atomic commits touch multiple fields at once and userspace expects
 /// the commit to be all-or-nothing.
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 struct ModesetState {
     crtc_active: u64,
     crtc_mode_id: u32,
@@ -323,13 +348,16 @@ struct ModesetState {
 }
 
 pub struct Card0 {
-    /// Queue of pending DRM events waiting to be delivered via `read()`.
-    events: Mutex<VecDeque<DrmEventVblank>>,
+    /// Queue of serialized DRM events waiting to be delivered via
+    /// `read()` (flip completion, `WAIT_VBLANK` events, and
+    /// `CRTC_QUEUE_SEQUENCE` events).
+    events: Mutex<VecDeque<EventSlot>>,
     /// Wakes up `poll`-waiters blocked on `read()` when a new event
     /// arrives.
     poll_rx: PollSet,
-    /// Monotonically-increasing vblank sequence.
-    sequence: AtomicU32,
+    /// Synthesized 60 Hz vblank clock and the queue of events waiting
+    /// for future vblank edges.
+    vblank: VblankScheduler,
     /// Current values of all atomic-tunable properties.
     state: Mutex<ModesetState>,
     /// Legacy `SETCRTC` binding readable via `GETCRTC`. Atomic commits
@@ -387,7 +415,7 @@ impl Card0 {
         let card = Arc::new(Self {
             events: Mutex::new(VecDeque::with_capacity(MAX_EVENTS)),
             poll_rx: PollSet::new(),
-            sequence: AtomicU32::new(0),
+            vblank: VblankScheduler::new(monotonic_time_nanos()),
             state: Mutex::new(ModesetState::default()),
             legacy_crtc: Mutex::new(LegacyCrtcState::default()),
             dumbs: Mutex::new(BTreeMap::new()),
@@ -571,18 +599,20 @@ impl DeviceOps for Card0 {
         if buf.is_empty() {
             return Ok(0);
         }
-        let evsz = core::mem::size_of::<DrmEventVblank>();
-        if buf.len() < evsz {
+        if buf.len() < EVENT_SLOT_BYTES {
             return Err(VfsError::InvalidInput);
         }
+        // Serve any queued sequence events whose edge has passed before
+        // draining, so a reader that never polls still observes them.
+        self.serve_pending_vblank_events();
         let mut events = self.events.lock();
         let mut written = 0;
-        while written + evsz <= buf.len() {
+        while written + EVENT_SLOT_BYTES <= buf.len() {
             let Some(ev) = events.pop_front() else {
                 break;
             };
-            buf[written..written + evsz].copy_from_slice(bytes_of(&ev));
-            written += evsz;
+            buf[written..written + EVENT_SLOT_BYTES].copy_from_slice(&ev);
+            written += EVENT_SLOT_BYTES;
         }
         if written == 0 {
             Err(VfsError::WouldBlock)
@@ -621,6 +651,8 @@ impl DeviceOps for Card0 {
             DRM_IOCTL_MODE_GETPROPERTY => handle_get_property(current, arg),
             DRM_IOCTL_MODE_PAGE_FLIP => self.handle_page_flip(current, arg),
             DRM_IOCTL_WAIT_VBLANK => self.handle_wait_vblank(current, arg),
+            DRM_IOCTL_CRTC_GET_SEQUENCE => self.handle_crtc_get_sequence(current, arg),
+            DRM_IOCTL_CRTC_QUEUE_SEQUENCE => self.handle_crtc_queue_sequence(current, arg),
 
             DRM_IOCTL_MODE_ATOMIC => self.handle_atomic(current, arg),
             DRM_IOCTL_MODE_CREATEPROPBLOB => self.handle_create_blob(current, arg),
@@ -671,6 +703,11 @@ impl DeviceOps for Card0 {
 
 impl Pollable for Card0 {
     fn poll(&self) -> IoEvents {
+        // Real hardware raises a vblank IRQ when an edge passes; the
+        // emulation's equivalent observation point is this poll, which
+        // also makes lazily-queued sequence events readable without a
+        // kernel timer thread.
+        self.serve_pending_vblank_events();
         let mut events = IoEvents::empty();
         events.set(IoEvents::IN, !self.events.lock().is_empty());
         events
@@ -1574,31 +1611,21 @@ impl Card0 {
         Ok(0)
     }
 
-    /// Enqueue a `drm_event_vblank` for the next `read()`, wake pollers.
-    /// Shared by legacy PAGE_FLIP and atomic commits.
-    fn queue_flip_event(&self, user_data: u64) {
-        let seq = self
-            .sequence
-            .fetch_add(1, Ordering::Relaxed)
-            .wrapping_add(1);
-        let now = monotonic_time();
-        let ev = DrmEventVblank {
-            base: DrmEvent {
-                event_type: DRM_EVENT_FLIP_COMPLETE,
-                length: core::mem::size_of::<DrmEventVblank>() as u32,
-            },
-            user_data,
-            tv_sec: now.as_secs() as u32,
-            tv_usec: now.subsec_micros(),
-            sequence: seq,
-            crtc_id: CRTC_ID,
-        };
+    /// Serializes and enqueues a DRM event payload, waking pollers.
+    /// Every event type on this card is `EVENT_SLOT_BYTES` long (asserted
+    /// at compile time), so a flat byte-slot queue serves `read()` for
+    /// both `DrmEventVblank` and `DrmEventCrtcSequence` payloads.
+    fn enqueue_event<E: bytemuck::NoUninit>(&self, ev: &E) {
+        let bytes = bytes_of(ev);
+        debug_assert_eq!(bytes.len(), EVENT_SLOT_BYTES);
+        let mut slot: EventSlot = [0; EVENT_SLOT_BYTES];
+        slot[..bytes.len()].copy_from_slice(bytes);
         let enqueued = {
             let mut queue = self.events.lock();
             if queue.len() >= MAX_EVENTS {
                 false
             } else {
-                queue.push_back(ev);
+                queue.push_back(slot);
                 true
             }
         };
@@ -1608,47 +1635,304 @@ impl Card0 {
         }
     }
 
-    /// `WAIT_VBLANK` — user asks to block until a given vblank sequence.
-    /// We don't have a real vblank source, so just bump the sequence and
-    /// return immediately with the current timestamp.
+    /// Moves every queued vblank event whose target edge has passed onto
+    /// the event queue. Called from `poll` and `read`.
+    fn serve_pending_vblank_events(&self) {
+        let now_ns = monotonic_time_nanos();
+        for pending in self.vblank.take_expired(now_ns) {
+            let sequence = self.vblank.clock().sequence_at(now_ns);
+            let edge_ns = self.vblank.clock().edge_ns_of(pending.target_sequence) as i64;
+            match pending.event {
+                QueuedVblankEvent::Vblank { user_data } => {
+                    let ev = DrmEventVblank {
+                        base: DrmEvent {
+                            event_type: DRM_EVENT_VBLANK,
+                            length: core::mem::size_of::<DrmEventVblank>() as u32,
+                        },
+                        user_data,
+                        tv_sec: (edge_ns / 1_000_000_000) as u32,
+                        tv_usec: ((edge_ns % 1_000_000_000) / 1_000) as u32,
+                        sequence: sequence as u32,
+                        crtc_id: CRTC_ID,
+                    };
+                    self.enqueue_event(&ev);
+                }
+                QueuedVblankEvent::CrtcSequence { user_data } => {
+                    let ev = DrmEventCrtcSequence {
+                        base: DrmEvent {
+                            event_type: DRM_EVENT_CRTC_SEQUENCE,
+                            length: core::mem::size_of::<DrmEventCrtcSequence>() as u32,
+                        },
+                        user_data,
+                        tv_ns: edge_ns,
+                        sequence: sequence as u64,
+                    };
+                    self.enqueue_event(&ev);
+                }
+            }
+        }
+    }
+
+    /// Whether the CRTC is currently scanning out: true once a legacy
+    /// `SETCRTC` bound an fb or an atomic commit set `ACTIVE`. Mirrors
+    /// the `active` visibility `CRTC_GET_SEQUENCE` reports.
+    fn crtc_active(&self) -> bool {
+        *self.state.lock() != ModesetState::default()
+            || self.legacy_crtc.lock().fb_id != 0
+    }
+
+    /// Enqueue a `drm_event_vblank` flip-completion for the next `read()`.
+    /// Shared by legacy PAGE_FLIP and atomic commits. The sequence and
+    /// timestamp come from the synthesized vblank clock, matching what
+    /// `CRTC_GET_SEQUENCE` would report for the same instant.
+    fn queue_flip_event(&self, user_data: u64) {
+        let now_ns = monotonic_time_nanos();
+        let sequence = self.vblank.clock().sequence_at(now_ns);
+        let ev = DrmEventVblank {
+            base: DrmEvent {
+                event_type: DRM_EVENT_FLIP_COMPLETE,
+                length: core::mem::size_of::<DrmEventVblank>() as u32,
+            },
+            user_data,
+            tv_sec: (now_ns / 1_000_000_000) as u32,
+            tv_usec: ((now_ns % 1_000_000_000) / 1_000) as u32,
+            sequence: sequence as u32,
+            crtc_id: CRTC_ID,
+        };
+        self.enqueue_event(&ev);
+    }
+
+    /// `CRTC_GET_SEQUENCE` — report the synthesized counter's most recent
+    /// edge, mirroring `drm_crtc_get_sequence_ioctl()` (Linux 4.19
+    /// `drm_vblank.c`): `active` reflects the CRTC's scanout state,
+    /// `sequence` the most recent vblank, `sequence_ns` that edge's
+    /// `CLOCK_MONOTONIC` timestamp. An inactive CRTC fails with `EINVAL`
+    /// like Linux's failed `drm_crtc_vblank_get`.
+    fn handle_crtc_get_sequence(
+        &self,
+        current: &crate::task::UserTaskRef,
+        arg: usize,
+    ) -> VfsResult<usize> {
+        let ptr = arg as *mut DrmModeCrtcGetSequence;
+        let mut g: DrmModeCrtcGetSequence = ptr.vm_read(current).map_err(|_| VfsError::BadAddress)?;
+        if g.crtc_id != CRTC_ID {
+            return Err(VfsError::NotFound);
+        }
+        if !self.crtc_active() {
+            return Err(VfsError::InvalidInput);
+        }
+        let now_ns = monotonic_time_nanos();
+        let sequence = self.vblank.clock().sequence_at(now_ns);
+        g.active = u32::from(self.crtc_active());
+        g.sequence = sequence;
+        g.sequence_ns = self.vblank.clock().edge_ns_of(sequence) as i64;
+        ptr.vm_write(current, g).map_err(|_| VfsError::BadAddress)?;
+        Ok(0)
+    }
+
+    /// `CRTC_QUEUE_SEQUENCE` — deliver a `DRM_EVENT_CRTC_SEQUENCE` when
+    /// the counter reaches the target, mirroring
+    /// `drm_crtc_queue_sequence_ioctl()` + `drm_queue_vblank_event()`
+    /// (Linux 4.19): unknown flags → `EINVAL`, unknown CRTC → `ENOENT`,
+    /// inactive CRTC → `EINVAL`, a missed target fires immediately, and
+    /// the reply's `sequence` reports the target (or the current counter
+    /// when it fired immediately).
+    fn handle_crtc_queue_sequence(
+        &self,
+        current: &crate::task::UserTaskRef,
+        arg: usize,
+    ) -> VfsResult<usize> {
+        let ptr = arg as *mut DrmModeCrtcQueueSequence;
+        let mut q: DrmModeCrtcQueueSequence =
+            ptr.vm_read(current).map_err(|_| VfsError::BadAddress)?;
+        if q.crtc_id != CRTC_ID {
+            return Err(VfsError::NotFound);
+        }
+        if q.flags & !(DRM_CRTC_SEQUENCE_RELATIVE | DRM_CRTC_SEQUENCE_NEXT_ON_MISS) != 0 {
+            return Err(VfsError::InvalidInput);
+        }
+        if !self.crtc_active() {
+            return Err(VfsError::InvalidInput);
+        }
+
+        let now_ns = monotonic_time_nanos();
+        let current_sequence = self.vblank.clock().sequence_at(now_ns);
+        let mut target = if q.flags & DRM_CRTC_SEQUENCE_RELATIVE != 0 {
+            current_sequence.wrapping_add(q.sequence)
+        } else {
+            q.sequence
+        };
+        if q.flags & DRM_CRTC_SEQUENCE_NEXT_ON_MISS != 0
+            && vblank_passed(current_sequence, target)
+        {
+            target = current_sequence + 1;
+        }
+
+        if vblank_passed(current_sequence, target) {
+            // Missed: fire synchronously with the current counter, like
+            // Linux's immediate `send_vblank_event`.
+            self.serve_pending_vblank_events();
+            let edge_ns = self.vblank.clock().edge_ns_of(current_sequence) as i64;
+            let ev = DrmEventCrtcSequence {
+                base: DrmEvent {
+                    event_type: DRM_EVENT_CRTC_SEQUENCE,
+                    length: core::mem::size_of::<DrmEventCrtcSequence>() as u32,
+                },
+                user_data: q.user_data,
+                tv_ns: edge_ns,
+                sequence: current_sequence,
+            };
+            self.enqueue_event(&ev);
+            q.sequence = current_sequence;
+        } else {
+            let queued = self.vblank.queue(PendingVblankEvent {
+                event: QueuedVblankEvent::CrtcSequence {
+                    user_data: q.user_data,
+                },
+                target_sequence: target,
+            });
+            if !queued {
+                // Linux's event reservation fails with -ENOMEM once the
+                // client's 4 KB event space is exhausted.
+                return Err(VfsError::NoMemory);
+            }
+            q.sequence = target;
+        }
+        ptr.vm_write(current, q).map_err(|_| VfsError::BadAddress)?;
+        Ok(0)
+    }
+
+    /// `WAIT_VBLANK` — wait for the synthesized counter to reach a
+    /// target, mirroring `drm_wait_vblank_ioctl()` (Linux 4.19
+    /// `drm_vblank.c`): `_DRM_VBLANK_SIGNAL` and unknown type bits →
+    /// `EINVAL`, an inactive CRTC → `EINVAL` (Linux's `drm_vblank_get`
+    /// fails when the counter is disabled), the query variant
+    /// (relative + zero + no flags) short-circuits, `_DRM_VBLANK_EVENT`
+    /// queues a `DRM_EVENT_VBLANK` instead of blocking, and the blocking
+    /// variant sleeps until the target edge. Replies carry the vblank
+    /// timestamp like `drm_wait_vblank_reply()`.
     fn handle_wait_vblank(
         &self,
         current: &crate::task::UserTaskRef,
         arg: usize,
     ) -> VfsResult<usize> {
         let ptr = arg as *mut DrmWaitVblank;
-        let request: DrmWaitVblank = ptr.vm_read(current).map_err(|_| VfsError::BadAddress)?;
+        let mut req: DrmWaitVblank = ptr.vm_read(current).map_err(|_| VfsError::BadAddress)?;
 
-        let is_relative = request.rep_type & crate::pseudofs::dev::drm::DRM_VBLANK_RELATIVE != 0;
-        let current_sequence = self.sequence.load(Ordering::Acquire);
-        let target = if is_relative {
-            current_sequence.wrapping_add(request.sequence)
-        } else {
-            request.sequence
-        };
-        let raw_wait = target.wrapping_sub(current_sequence);
-        let wait_count = if raw_wait == 0 || raw_wait >= i32::MAX as u32 {
-            1
-        } else {
-            raw_wait
-        };
+        if req.rep_type & DRM_VBLANK_SIGNAL != 0 {
+            return Err(VfsError::InvalidInput);
+        }
+        if req.rep_type & !(DRM_VBLANK_TYPES_MASK | DRM_VBLANK_FLAGS_MASK | DRM_VBLANK_HIGH_CRTC_MASK)
+            != 0
+        {
+            return Err(VfsError::InvalidInput);
+        }
+        // Bits 1..6 of `type` are a CRTC index; the secondary flag picks
+        // CRTC 1. This card exposes exactly one CRTC at index 0.
+        if req.rep_type & (DRM_VBLANK_HIGH_CRTC_MASK | DRM_VBLANK_SECONDARY) != 0 {
+            return Err(VfsError::InvalidInput);
+        }
+        if !self.crtc_active() {
+            return Err(VfsError::InvalidInput);
+        }
 
-        const FRAME_PERIOD_NS: u64 = 1_000_000_000 / 60;
-        let delay =
-            core::time::Duration::from_nanos(FRAME_PERIOD_NS.saturating_mul(wait_count as u64));
-        crate::task::sleep(delay);
-        self.sequence.fetch_add(wait_count, Ordering::AcqRel);
+        let vtype = req.rep_type;
+        let now_ns = monotonic_time_nanos();
+        let current_sequence = self.vblank.clock().sequence_at(now_ns);
 
-        let now = monotonic_time();
-        let reply = DrmWaitVblank {
-            rep_type: 0,
-            sequence: self.sequence.load(Ordering::Acquire),
-            tv_sec: now.as_secs() as i64,
-            tv_usec: now.subsec_micros() as i64,
+        // Query short-circuit: relative with a zero target and no event
+        // or next-on-miss flags just reports the current counter.
+        if req.sequence == 0
+            && (vtype & (DRM_VBLANK_RELATIVE | DRM_VBLANK_EVENT | DRM_VBLANK_NEXTONMISS))
+                == DRM_VBLANK_RELATIVE
+        {
+            let reply = self.wait_vblank_reply(vtype, current_sequence);
+            ptr.vm_write(current, reply).map_err(|_| VfsError::BadAddress)?;
+            return Ok(0);
+        }
+
+        let mut target = match vtype & DRM_VBLANK_TYPES_MASK {
+            DRM_VBLANK_RELATIVE => current_sequence.wrapping_add(u64::from(req.sequence)),
+            // Absolute: widen the u32 counter against the current u64.
+            0 => widen_32_to_64(req.sequence, current_sequence),
+            _ => return Err(VfsError::InvalidInput),
         };
-        ptr.vm_write(current, reply)
-            .map_err(|_| VfsError::BadAddress)?;
+        // Linux converts relative requests to absolute and clears the
+        // bit in the echoed-back type.
+        if vtype & DRM_VBLANK_RELATIVE != 0 {
+            req.rep_type &= !DRM_VBLANK_RELATIVE;
+        }
+        req.sequence = target as u32;
+        if vtype & DRM_VBLANK_NEXTONMISS != 0 && vblank_passed(current_sequence, target) {
+            target = current_sequence + 1;
+            req.sequence = target as u32;
+            req.rep_type &= !DRM_VBLANK_NEXTONMISS;
+        }
+
+        if vtype & DRM_VBLANK_EVENT != 0 {
+            // `_DRM_VBLANK_EVENT`: `request.signal` (overlaid on
+            // `tv_sec`) is the user_data of the delivered event.
+            let user_data = req.tv_sec as u64;
+            let fired = vblank_passed(current_sequence, target);
+            self.serve_pending_vblank_events();
+            if fired {
+                self.queue_vblank_event(user_data, current_sequence);
+            } else if !self.vblank.queue(PendingVblankEvent {
+                event: QueuedVblankEvent::Vblank { user_data },
+                target_sequence: target,
+            }) {
+                return Err(VfsError::NoMemory);
+            }
+            let reply_sequence = if fired { current_sequence } else { target };
+            let mut reply = self.wait_vblank_reply(req.rep_type, current_sequence);
+            reply.sequence = reply_sequence as u32;
+            ptr.vm_write(current, reply).map_err(|_| VfsError::BadAddress)?;
+            return Ok(0);
+        }
+
+        // Blocking wait: sleep until the target edge. An already-passed
+        // target returns immediately, matching Linux's passed check.
+        if !vblank_passed(current_sequence, target) {
+            let edge_ns = self.vblank.clock().edge_ns_of(target);
+            crate::task::sleep(core::time::Duration::from_nanos(
+                edge_ns.saturating_sub(monotonic_time_nanos()),
+            ));
+        }
+        let after_ns = monotonic_time_nanos();
+        let sequence = self.vblank.clock().sequence_at(after_ns);
+        let reply = self.wait_vblank_reply(req.rep_type, sequence);
+        ptr.vm_write(current, reply).map_err(|_| VfsError::BadAddress)?;
         Ok(0)
+    }
+
+    /// Builds a `WAIT_VBLANK` reply reporting `sequence`'s edge time,
+    /// mirroring `drm_wait_vblank_reply()`: the truncated counter plus
+    /// the timestamp of the most recent vblank edge.
+    fn wait_vblank_reply(&self, rep_type: u32, sequence: u64) -> DrmWaitVblank {
+        let edge_ns = self.vblank.clock().edge_ns_of(sequence) as i64;
+        DrmWaitVblank {
+            rep_type,
+            sequence: sequence as u32,
+            tv_sec: edge_ns / 1_000_000_000,
+            tv_usec: (edge_ns % 1_000_000_000) / 1_000,
+        }
+    }
+
+    /// Queues an immediate `DRM_EVENT_VBLANK` for a fired target.
+    fn queue_vblank_event(&self, user_data: u64, sequence: u64) {
+        let edge_ns = self.vblank.clock().edge_ns_of(sequence);
+        let ev = DrmEventVblank {
+            base: DrmEvent {
+                event_type: DRM_EVENT_VBLANK,
+                length: core::mem::size_of::<DrmEventVblank>() as u32,
+            },
+            user_data,
+            tv_sec: (edge_ns / 1_000_000_000) as u32,
+            tv_usec: ((edge_ns % 1_000_000_000) / 1_000) as u32,
+            sequence: sequence as u32,
+            crtc_id: CRTC_ID,
+        };
+        self.enqueue_event(&ev);
     }
 
     // ======== M4c: atomic commit + blob properties ========

--- a/os/StarryOS/kernel/src/pseudofs/dev/drm.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/drm.rs
@@ -239,13 +239,14 @@ pub const DRM_IOCTL_MODE_ATOMIC: u32 = iowr::<DrmModeAtomic>(DRM_TYPE, 0xBC);
 pub const DRM_IOCTL_MODE_CREATEPROPBLOB: u32 = iowr::<DrmModeCreateBlob>(DRM_TYPE, 0xBD);
 pub const DRM_IOCTL_MODE_DESTROYPROPBLOB: u32 = iowr::<DrmModeDestroyBlob>(DRM_TYPE, 0xBE);
 pub const DRM_IOCTL_MODE_GETPROPBLOB: u32 = iowr::<DrmModeGetBlob>(DRM_TYPE, 0xAC);
-// WAIT_VBLANK is a union of request/reply, size = 24 bytes on 64-bit.
 pub const DRM_IOCTL_WAIT_VBLANK: u32 = ioc(
     IOC_READ | IOC_WRITE,
     DRM_TYPE,
     0x3A,
     core::mem::size_of::<DrmWaitVblank>() as u16,
 );
+pub const DRM_IOCTL_CRTC_GET_SEQUENCE: u32 = iowr::<DrmModeCrtcGetSequence>(DRM_TYPE, 0x3b);
+pub const DRM_IOCTL_CRTC_QUEUE_SEQUENCE: u32 = iowr::<DrmModeCrtcQueueSequence>(DRM_TYPE, 0x3c);
 
 /// 32 bytes — Linux's `DRM_DISPLAY_MODE_LEN`.
 pub const DRM_MODE_NAME_LEN: usize = 32;
@@ -509,6 +510,62 @@ pub struct DrmWaitVblank {
 /// `_DRM_VBLANK_ABSOLUTE = 0`, `_DRM_VBLANK_RELATIVE = 1`. The low bits
 /// of `type` are a CRTC index (unused here — we have one CRTC).
 pub const DRM_VBLANK_RELATIVE: u32 = 0x1;
+/// `_DRM_VBLANK_EVENT` — deliver a `DRM_EVENT_VBLANK` on the fd instead
+/// of blocking inside the ioctl.
+pub const DRM_VBLANK_EVENT: u32 = 0x400_0000;
+/// `_DRM_VBLANK_NEXTONMISS` — if the target already passed, jump to the
+/// next edge instead of firing immediately.
+pub const DRM_VBLANK_NEXTONMISS: u32 = 0x1000_0000;
+/// `_DRM_VBLANK_SECONDARY` — select the second CRTC (none on this card).
+pub const DRM_VBLANK_SECONDARY: u32 = 0x2000_0000;
+/// `_DRM_VBLANK_SIGNAL` — signal-based delivery, rejected as EINVAL by
+/// modern Linux.
+pub const DRM_VBLANK_SIGNAL: u32 = 0x4000_0000;
+/// `_DRM_VBLANK_HIGH_CRTC_MASK` — bits 1..6 carry a CRTC index beyond
+/// the secondary bit.
+pub const DRM_VBLANK_HIGH_CRTC_MASK: u32 = 0x3e;
+/// `_DRM_VBLANK_TYPES_MASK` — the absolute/relative selector bits.
+pub const DRM_VBLANK_TYPES_MASK: u32 = DRM_VBLANK_RELATIVE;
+/// `_DRM_VBLANK_FLAGS_MASK` — every flag bit of `type`.
+pub const DRM_VBLANK_FLAGS_MASK: u32 =
+    DRM_VBLANK_EVENT | DRM_VBLANK_SIGNAL | DRM_VBLANK_SECONDARY | DRM_VBLANK_NEXTONMISS;
+
+// ---- CRTC vblank sequence clock (Linux 4.19+ `drm_crtc_get_sequence`) ----
+
+/// `DRM_IOCTL_CRTC_GET_SEQUENCE` payload: query the current vblank
+/// sequence and the timestamp of its edge.
+#[repr(C)]
+#[derive(Debug, Default, Clone, Copy, AnyBitPattern, NoUninit)]
+pub struct DrmModeCrtcGetSequence {
+    pub crtc_id: u32,
+    /// Return: 1 while the CRTC is actively scanning out.
+    pub active: u32,
+    /// Return: most recent vblank sequence.
+    pub sequence: u64,
+    /// Return: time of the sequence's first pixel out, in
+    /// `CLOCK_MONOTONIC` nanoseconds.
+    pub sequence_ns: i64,
+}
+
+/// `DRM_IOCTL_CRTC_QUEUE_SEQUENCE` payload: deliver a
+/// `DRM_EVENT_CRTC_SEQUENCE` when the counter reaches `sequence`.
+#[repr(C)]
+#[derive(Debug, Default, Clone, Copy, AnyBitPattern, NoUninit)]
+pub struct DrmModeCrtcQueueSequence {
+    pub crtc_id: u32,
+    pub flags: u32,
+    /// Input: target sequence. Output: target (or the actual counter
+    /// when the target had already passed).
+    pub sequence: u64,
+    pub user_data: u64,
+}
+
+/// `DRM_CRTC_SEQUENCE_RELATIVE` — `sequence` counts from the current
+/// counter value.
+pub const DRM_CRTC_SEQUENCE_RELATIVE: u32 = 0x0000_0001;
+/// `DRM_CRTC_SEQUENCE_NEXT_ON_MISS` — use the next edge if the target
+/// was missed.
+pub const DRM_CRTC_SEQUENCE_NEXT_ON_MISS: u32 = 0x0000_0002;
 
 // ---- event delivery ----
 //
@@ -535,7 +592,19 @@ pub struct DrmEventVblank {
     pub crtc_id: u32,
 }
 
+#[repr(C)]
+#[derive(Debug, Default, Clone, Copy, AnyBitPattern, NoUninit)]
+pub struct DrmEventCrtcSequence {
+    pub base: DrmEvent,
+    pub user_data: u64,
+    /// `CLOCK_MONOTONIC` nanoseconds of the delivery edge.
+    pub tv_ns: i64,
+    pub sequence: u64,
+}
+
+pub const DRM_EVENT_VBLANK: u32 = 0x01;
 pub const DRM_EVENT_FLIP_COMPLETE: u32 = 0x02;
+pub const DRM_EVENT_CRTC_SEQUENCE: u32 = 0x03;
 
 // ======== M4c: atomic KMS + property blobs ========
 

--- a/os/StarryOS/kernel/src/pseudofs/dev/mod.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/mod.rs
@@ -9,6 +9,7 @@ mod card1;
 #[cfg(any(feature = "jpeg", feature = "rknpu", feature = "rga"))]
 mod dmaheap;
 mod drm;
+mod vblank;
 #[cfg(feature = "input")]
 pub mod event;
 mod fb;

--- a/os/StarryOS/kernel/src/pseudofs/dev/vblank.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/vblank.rs
@@ -1,0 +1,198 @@
+//! Synthesized 60 Hz vblank clock for the emulated `/dev/dri/card0`.
+//!
+//! The card has no real scanout engine — presentation is a synchronous
+//! memcpy — so there is no hardware counter to latch vblank edges from.
+//! Linux DRM userspace (libdrm, compositors) nevertheless expects a
+//! monotonic per-CRTC sequence advancing at the mode's refresh rate,
+//! plus timestamps of the most recent edge (`CRTC_GET_SEQUENCE`,
+//! `CRTC_QUEUE_SEQUENCE`, `WAIT_VBLANK`, and flip-completion events).
+//! The clock here derives that sequence from elapsed monotonic time
+//! anchored at card creation, mirroring Linux's
+//! `vblank_disable_immediate` mode where the counter is computed from
+//! timestamps rather than latched by an interrupt
+//! (`drivers/gpu/drm/drm_vblank.c`, `drm_vblank_count_and_time`).
+//!
+//! Queued events (`CRTC_QUEUE_SEQUENCE`, `WAIT_VBLANK` with
+//! `_DRM_VBLANK_EVENT`) are delivered lazily by [`Card0::poll`], not by
+//! a kernel timer thread: real hardware raises a vblank IRQ per edge,
+//! and the emulation's equivalent observation point is userspace
+//! polling the DRM fd. Delivery latency is therefore bounded by the
+//! caller's poll interval rather than the vblank period, while event
+//! timestamps always carry the synthesized edge time.
+
+use alloc::vec::Vec;
+use core::sync::atomic::{AtomicU64, Ordering};
+
+use crate::sync::Mutex;
+
+/// Nanoseconds between synthesized vblank edges (60 Hz, matching the
+/// mode's `DEFAULT_VREFRESH` advertised by the card).
+pub const VBLANK_PERIOD_NS: u64 = 1_000_000_000 / 60;
+
+/// Upper bound on simultaneously pending vblank events, matching the
+/// event-queue cap on the card.
+pub const MAX_PENDING_EVENTS: usize = 128;
+
+/// Wrap-aware "has the counter reached `target`" test on u64 sequences.
+/// Mirrors Linux's `vblank_passed()` in `drivers/gpu/drm/drm_vblank.c`:
+/// the comparison survives counter wraparound by interpreting the
+/// difference as signed. The u32 userspace view is covered by casting
+/// truncated values back to u64, which preserves the wrap semantics the
+/// ABI hands out.
+pub const fn vblank_passed(current: u64, target: u64) -> bool {
+    current == target || (current.wrapping_sub(target) as i64) > 0
+}
+
+/// Linux's `widen_32_to_64()` (`drm_vblank.c`): reconstructs the full
+/// u64 sequence a u32 counter value refers to, given a nearby full-width
+/// reference. Low values just above a wrap resolve to the next cycle;
+/// values that look "behind" the reference's low half resolve to the
+/// reference's own high word.
+pub const fn widen_32_to_64(low: u32, reference: u64) -> u64 {
+    let high_span = 0xffff_ffff_0000_0000u64;
+    let sign_fix = if low & 0x8000_0000 != 0 {
+        0
+    } else {
+        high_span
+    };
+    (low as u64).wrapping_add(reference & high_span ^ sign_fix)
+}
+
+/// An event queued for a future vblank edge by `CRTC_QUEUE_SEQUENCE` or
+/// the `_DRM_VBLANK_EVENT` variant of `WAIT_VBLANK`.
+#[derive(Debug)]
+pub(super) enum QueuedVblankEvent {
+    /// `DRM_EVENT_VBLANK` — `WAIT_VBLANK` with `_DRM_VBLANK_EVENT`.
+    Vblank { user_data: u64 },
+    /// `DRM_EVENT_CRTC_SEQUENCE` — `CRTC_QUEUE_SEQUENCE`.
+    CrtcSequence { user_data: u64 },
+}
+
+#[derive(Debug)]
+pub(super) struct PendingVblankEvent {
+    pub event: QueuedVblankEvent,
+    /// Full-width sequence the event fires at.
+    pub target_sequence: u64,
+}
+
+/// Time-derived vblank sequence source plus the queue of events waiting
+/// for future edges. Shared state is a plain mutex; both writers (ioctl
+/// tasks queuing) and the drainer (`Card0::poll`) are sleepable task
+/// contexts, and no lock is held across another acquisition.
+pub(super) struct VblankScheduler {
+    clock: VblankClock,
+    pending: Mutex<Vec<PendingVblankEvent>>,
+}
+
+impl VblankScheduler {
+    pub(super) fn new(now_ns: u64) -> Self {
+        Self {
+            clock: VblankClock::new(now_ns),
+            pending: Mutex::new(Vec::new()),
+        }
+    }
+
+    pub(super) fn clock(&self) -> &VblankClock {
+        &self.clock
+    }
+
+    /// Queues an event for a future edge. Returns `false` when the
+    /// pending cap is reached (the caller maps this to Linux's
+    /// event-reservation `-ENOMEM`).
+    pub(super) fn queue(&self, event: PendingVblankEvent) -> bool {
+        let mut pending = self.pending.lock();
+        if pending.len() >= MAX_PENDING_EVENTS {
+            return false;
+        }
+        pending.push(event);
+        true
+    }
+
+    /// Removes and returns every event whose target edge has passed at
+    /// `now_ns`. Called from `Card0::poll`.
+    pub(super) fn take_expired(&self, now_ns: u64) -> Vec<PendingVblankEvent> {
+        let current = self.clock.sequence_at(now_ns);
+        let mut pending = self.pending.lock();
+        let (expired, remaining) = pending
+            .drain(..)
+            .partition(|event| vblank_passed(current, event.target_sequence));
+        *pending = remaining;
+        expired
+    }
+}
+
+/// Sequence counter derived from elapsed monotonic time. Sequence 0 is
+/// the card-creation anchor; edge *N* occurs at
+/// `anchor_ns + N * VBLANK_PERIOD_NS`.
+pub(super) struct VblankClock {
+    anchor_ns: AtomicU64,
+}
+
+impl VblankClock {
+    fn new(now_ns: u64) -> Self {
+        Self {
+            anchor_ns: AtomicU64::new(now_ns),
+        }
+    }
+
+    /// The most recent completed edge's sequence number at `now_ns`.
+    pub(super) fn sequence_at(&self, now_ns: u64) -> u64 {
+        let anchor = self.anchor_ns.load(Ordering::Relaxed);
+        now_ns.saturating_sub(anchor) / VBLANK_PERIOD_NS
+    }
+
+    /// Monotonic timestamp (nanoseconds) of edge `sequence`. Saturates
+    /// instead of overflowing for far-future targets.
+    pub(super) fn edge_ns_of(&self, sequence: u64) -> u64 {
+        let anchor = self.anchor_ns.load(Ordering::Relaxed);
+        anchor.saturating_add(sequence.saturating_mul(VBLANK_PERIOD_NS))
+    }
+}
+
+#[cfg(all(test, not(axtest)))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn vblank_passed_tracks_order_and_wrap() {
+        // Equal counts as passed (the event fires on its own edge).
+        assert!(vblank_passed(5, 5));
+        assert!(!vblank_passed(4, 5));
+        assert!(vblank_passed(6, 5));
+        // Wrap boundary: a counter that wrapped to 0 has passed a target
+        // just below u64::MAX.
+        assert!(vblank_passed(u64::MAX, u64::MAX - 1));
+        assert!(vblank_passed(0, u64::MAX));
+        // Far-future targets must not look passed through the wrap.
+        assert!(!vblank_passed(1, u64::MAX));
+    }
+
+    #[test]
+    fn widen_resolves_low_values_near_reference() {
+        // Plain small value near a small counter: unchanged.
+        assert_eq!(widen_32_to_64(5, 0), 5);
+        // Value in the same high-word neighborhood as the reference.
+        assert_eq!(widen_32_to_64(5, 0x1_0000_0005), 0x1_0000_0005);
+        // A "negative-looking" u32 near the wrap widens forward.
+        assert_eq!(widen_32_to_64(0xffff_fff0, 0), 0xffff_fff0);
+        // Reference with a nonzero high word pulls small lows up with it.
+        assert_eq!(widen_32_to_64(0xffff_fff0, 0x2_0000_0000), 0x2_ffff_fff0);
+    }
+
+    #[test]
+    fn clock_sequences_track_elapsed_periods() {
+        let clock = VblankClock::new(1_000);
+        assert_eq!(clock.sequence_at(1_000), 0);
+        // Just before the first edge.
+        assert_eq!(clock.sequence_at(1_000 + VBLANK_PERIOD_NS - 1), 0);
+        // On the first edge.
+        assert_eq!(clock.sequence_at(1_000 + VBLANK_PERIOD_NS), 1);
+        // Three and a half periods later.
+        assert_eq!(
+            clock.sequence_at(1_000 + VBLANK_PERIOD_NS * 7 / 2),
+            3
+        );
+        // Edge timestamps round-trip through the sequence computation.
+        assert_eq!(clock.edge_ns_of(4), 1_000 + VBLANK_PERIOD_NS * 4);
+    }
+}

--- a/test-suit/starryos/qemu/system/drm-test-drm-modeset/src/main.c
+++ b/test-suit/starryos/qemu/system/drm-test-drm-modeset/src/main.c
@@ -21,6 +21,7 @@
 #include <stdint.h>
 #include <sys/ioctl.h>
 #include <sys/mman.h>
+#include <time.h>
 #include <unistd.h>
 
 struct drm_mode_create_dumb {
@@ -109,6 +110,8 @@ struct drm_event_vblank {
 #define DRM_IOCTL_MODE_ADDFB2            _IOWR('d', 0xB8, struct drm_mode_fb_cmd2)
 #define DRM_IOCTL_MODE_OBJ_GETPROPERTIES _IOWR('d', 0xB9, struct drm_mode_obj_get_properties)
 #define DRM_IOCTL_WAIT_VBLANK            _IOWR('d', 0x3A, union drm_wait_vblank)
+#define DRM_IOCTL_CRTC_GET_SEQUENCE      _IOWR('d', 0x3B, struct drm_crtc_get_sequence)
+#define DRM_IOCTL_CRTC_QUEUE_SEQUENCE    _IOWR('d', 0x3C, struct drm_crtc_queue_sequence)
 
 #define DRM_MODE_OBJECT_PLANE       0xeeeeeeee
 #define DRM_PLANE_TYPE_PRIMARY      1
@@ -116,6 +119,26 @@ struct drm_event_vblank {
 #define DRM_MODE_PROP_ENUM          (1 << 3)
 #define DRM_EVENT_FLIP_COMPLETE     0x02
 #define DRM_FORMAT_XRGB8888         0x34325258
+
+/* CRTC vblank sequence clock uapi（include/uapi/drm/drm.h，Linux 4.12+）。 */
+struct drm_crtc_get_sequence {
+    uint32_t crtc_id; uint32_t active;
+    uint64_t sequence; int64_t sequence_ns;
+};
+struct drm_crtc_queue_sequence {
+    uint32_t crtc_id; uint32_t flags;
+    uint64_t sequence; uint64_t user_data;
+};
+struct drm_event_crtc_sequence {
+    struct drm_event base; int64_t user_data; int64_t tv_ns; uint64_t sequence;
+};
+
+#define DRM_CRTC_SEQUENCE_RELATIVE     0x00000001
+#define DRM_CRTC_SEQUENCE_NEXT_ON_MISS 0x00000002
+#define DRM_EVENT_VBLANK               0x01
+#define DRM_EVENT_CRTC_SEQUENCE        0x03
+#define _DRM_VBLANK_RELATIVE           0x0000001
+#define _DRM_VBLANK_EVENT              0x4000000
 
 int main(void)
 {
@@ -255,12 +278,112 @@ int main(void)
     char buf[64] = {0};
     CHECK_ERR(read(fd, buf, sizeof(buf)), EAGAIN, "empty read returns EAGAIN");
 
-    /* --- WAIT_VBLANK 单调递增 --- */
+    /* --- WAIT_VBLANK 查询不回退 ---
+     * type=0（absolute，target=0）是纯查询：真实时钟下同一周期内两次
+     * 查询返回相同序列号，跨周期则 +1，因此只要求不回退。 */
     union drm_wait_vblank wv1 = {0}, wv2 = {0};
     CHECK_RET(ioctl(fd, DRM_IOCTL_WAIT_VBLANK, &wv1), 0, "WAIT_VBLANK 1");
     CHECK_RET(ioctl(fd, DRM_IOCTL_WAIT_VBLANK, &wv2), 0, "WAIT_VBLANK 2");
-    CHECK(wv2.reply.sequence > wv1.reply.sequence, "vblank seq monotonic");
-    CHECK(wv2.reply.sequence > seq1, "vblank seq > flip seq");
+    CHECK(wv2.reply.sequence >= wv1.reply.sequence, "vblank seq monotonic");
+    CHECK(wv2.reply.sequence >= seq1, "vblank seq >= flip seq");
+
+    /* --- CRTC_GET_SEQUENCE：active 报告 + 序列号推进率 --- */
+    struct timespec ts1, ts2;
+    struct drm_crtc_get_sequence gseq1 = { .crtc_id = crtc_ids[0] };
+    CHECK_RET(ioctl(fd, DRM_IOCTL_CRTC_GET_SEQUENCE, &gseq1), 0,
+              "CRTC_GET_SEQUENCE works");
+    CHECK(gseq1.active == 1, "GET_SEQUENCE active == 1 after SETCRTC");
+    CHECK(gseq1.sequence_ns > 0, "GET_SEQUENCE timestamp positive");
+    CHECK(gseq1.sequence >= seq1, "GET_SEQUENCE sequence >= flip seq");
+
+    usleep(120000); /* 约 7 个 vblank 周期 */
+    struct drm_crtc_get_sequence gseq2 = { .crtc_id = crtc_ids[0] };
+    CHECK_RET(ioctl(fd, DRM_IOCTL_CRTC_GET_SEQUENCE, &gseq2), 0,
+              "CRTC_GET_SEQUENCE second query");
+    uint64_t seq_delta = gseq2.sequence - gseq1.sequence;
+    CHECK(seq_delta >= 5 && seq_delta <= 9,
+          "sequence advances at ~60 Hz over 120 ms");
+    CHECK(gseq2.sequence_ns > gseq1.sequence_ns, "sequence_ns monotonic");
+
+    struct drm_crtc_get_sequence gseq_bad = { .crtc_id = 0xdeadbeef };
+    CHECK_ERR(ioctl(fd, DRM_IOCTL_CRTC_GET_SEQUENCE, &gseq_bad), ENOENT,
+              "GET_SEQUENCE rejects unknown crtc");
+
+    /* --- CRTC_QUEUE_SEQUENCE：相对目标两个周期后投递事件 --- */
+    struct drm_crtc_queue_sequence qseq = {
+        .crtc_id = crtc_ids[0],
+        .flags = DRM_CRTC_SEQUENCE_RELATIVE,
+        .sequence = 2,
+        .user_data = 0xfeedfacefeedfaceULL,
+    };
+    CHECK_RET(ioctl(fd, DRM_IOCTL_CRTC_QUEUE_SEQUENCE, &qseq), 0,
+              "QUEUE_SEQUENCE accepts relative target");
+    struct pollfd qpfd = { .fd = fd, .events = POLLIN };
+    pr = poll(&qpfd, 1, 1000);
+    CHECK(pr == 1, "poll wakes for queued sequence event");
+    struct drm_event_crtc_sequence seq_ev = {0};
+    n = read(fd, &seq_ev, sizeof(seq_ev));
+    CHECK(n == (ssize_t)sizeof(seq_ev), "read returns drm_event_crtc_sequence");
+    CHECK(seq_ev.base.type == DRM_EVENT_CRTC_SEQUENCE,
+          "event type == CRTC_SEQUENCE");
+    CHECK(seq_ev.base.length == sizeof(seq_ev),
+          "crtc_sequence event length == sizeof(struct)");
+    CHECK((uint64_t)seq_ev.user_data == 0xfeedfacefeedfaceULL,
+          "sequence event user_data round-trips");
+    CHECK(seq_ev.sequence >= qseq.sequence,
+          "sequence event fired at or after target");
+    CHECK(seq_ev.tv_ns >= gseq2.sequence_ns, "sequence event timestamp monotonic");
+
+    /* --- QUEUE_SEQUENCE 错误路径 --- */
+    struct drm_crtc_queue_sequence bad_flags = {
+        .crtc_id = crtc_ids[0], .flags = 0x80000000, .sequence = 1,
+    };
+    CHECK_ERR(ioctl(fd, DRM_IOCTL_CRTC_QUEUE_SEQUENCE, &bad_flags), EINVAL,
+              "QUEUE_SEQUENCE rejects unknown flags");
+    struct drm_crtc_queue_sequence bad_crtc = {
+        .crtc_id = 0xdeadbeef, .flags = DRM_CRTC_SEQUENCE_RELATIVE, .sequence = 1,
+    };
+    CHECK_ERR(ioctl(fd, DRM_IOCTL_CRTC_QUEUE_SEQUENCE, &bad_crtc), ENOENT,
+              "QUEUE_SEQUENCE rejects unknown crtc");
+
+    /* --- WAIT_VBLANK _DRM_VBLANK_EVENT：入队而非阻塞 --- */
+    union drm_wait_vblank wev = {0};
+    wev.req.type = _DRM_VBLANK_EVENT | _DRM_VBLANK_RELATIVE;
+    wev.req.sequence = 1;
+    wev.req.signal = 0xcafef00dcafebabeULL;
+    CHECK_RET(ioctl(fd, DRM_IOCTL_WAIT_VBLANK, &wev), 0,
+              "WAIT_VBLANK EVENT returns immediately");
+    struct pollfd wpfd = { .fd = fd, .events = POLLIN };
+    pr = poll(&wpfd, 1, 1000);
+    CHECK(pr == 1, "poll wakes for vblank event");
+    struct drm_event_vblank vev = {0};
+    n = read(fd, &vev, sizeof(vev));
+    CHECK(n == (ssize_t)sizeof(vev), "read returns drm_event_vblank");
+    CHECK(vev.base.type == DRM_EVENT_VBLANK, "event type == VBLANK");
+    CHECK(vev.user_data == 0xcafef00dcafebabeULL,
+          "vblank event user_data == request.signal");
+    CHECK(vev.crtc_id == crtc_ids[0], "vblank event crtc_id matches");
+
+    /* --- 相对阻塞等待按周期睡眠 --- */
+    union drm_wait_vblank wblock = {0};
+    wblock.req.type = _DRM_VBLANK_RELATIVE;
+    wblock.req.sequence = 2;
+    clock_gettime(CLOCK_MONOTONIC, &ts1);
+    CHECK_RET(ioctl(fd, DRM_IOCTL_WAIT_VBLANK, &wblock), 0,
+              "WAIT_VBLANK relative 2 blocks");
+    clock_gettime(CLOCK_MONOTONIC, &ts2);
+    long elapsed_ms = (ts2.tv_sec - ts1.tv_sec) * 1000
+                      + (ts2.tv_nsec - ts1.tv_nsec) / 1000000;
+    /* 相对等待语义与真实 DRM 一致：从当前时刻数 N 个边沿。若调用发生在
+     * 边沿刚过后，第 N 个边沿不足 N 个整周期（最短 ≈(N-1) 周期），
+     * 因此接受 [1, 3.5] 个周期的时间窗。 */
+    CHECK(elapsed_ms >= 16 && elapsed_ms <= 60,
+          "relative wait 2 spans 1-2 vblank periods");
+    CHECK(wblock.reply.sequence > wev.reply.sequence,
+          "blocking wait advanced the counter");
+
+    /* --- 队列再次清空 --- */
+    CHECK_ERR(read(fd, buf, sizeof(buf)), EAGAIN, "event queue drained");
 
     /* --- legacy GETCRTC readback matches the SETCRTC we ran above --- */
     uint32_t readback_conns[4] = {0};
@@ -308,6 +431,11 @@ int main(void)
     CHECK(getc.fb_id == 0, "GETCRTC fb_id == 0 after RMFB clears binding");
     CHECK(getc.count_connectors == 0,
           "GETCRTC count_connectors == 0 after RMFB");
+
+    /* CRTC 失活后 vblank 时钟应拒绝服务（Linux drm_vblank_get 失败 → EINVAL）。 */
+    struct drm_crtc_get_sequence gseq_off = { .crtc_id = crtc_ids[0] };
+    CHECK_ERR(ioctl(fd, DRM_IOCTL_CRTC_GET_SEQUENCE, &gseq_off), EINVAL,
+              "GET_SEQUENCE rejects inactive CRTC");
 
     struct drm_mode_crtc bad_fb = {
         .crtc_id = crtc_ids[0], .fb_id = old_fb_id,


### PR DESCRIPTION
## 问题

Closes #2364。

card0 伪设备缺少 vblank 时钟源，三处行为偏离真实 DRM：

- `CRTC_GET_SEQUENCE`(0x3b) / `CRTC_QUEUE_SEQUENCE`(0x3c) 返回 ENOSYS，用户态没有序列号来源；
- `WAIT_VBLANK` 每次调用虚增计数——同一 vblank 周期内的两次查询返回不同序列号，与真实 DRM「同周期等值」语义相反，「等到第 N 次 vblank」无法成立；
- flip 完成事件时间戳取提交瞬间而非 vblank 边沿时间。

依赖这组 API 的客户端（mesa、smithay 的 vblank 路径、deniald/Volition 的帧率控制）在这块卡上没有任何可用语义，只能退回各自的内部节拍。

## 改动

按 Linux `vblank_disable_immediate` 模式合成 60Hz vblank 时钟，不需要内核定时线程：

1. 新增 `os/StarryOS/kernel/src/pseudofs/dev/vblank.rs`：序列号 = 建卡起单调时间 ÷ 周期（16_666_667ns）。时间函数天然保证同周期查询等值、边沿时间可反推；`widen_32_to_64` 纯函数处理 u32→u64 wrap 扩展比较，带宿主单测覆盖 wrap 边界。
2. `card0.rs` 实现 `CRTC_GET_SEQUENCE` / `CRTC_QUEUE_SEQUENCE`，错误语义对照 Linux 4.19 `drm_crtc_get_sequence_ioctl` / `drm_queue_sequence_ioctl`：坏 CRTC → ENOENT；未知 flags / `_DRM_VBLANK_SIGNAL` / 失活 CRTC → EINVAL；目标序列号已错过立即补发（`DRM_CRTC_SEQUENCE_NEXT_ON_MISS`）；事件预留耗尽 → ENOMEM。
3. `WAIT_VBLANK` 按 4.19 `drm_wait_vblank_ioctl` 重写：absolute-0 即查询；`_DRM_VBLANK_EVENT` 入队 vblank 事件；SIGNAL/未知位 EINVAL。queued 事件经 `poll()` 惰性兑现——延迟 ≤ 调用方 poll 间隔，对 vblank 时钟消费者足够。
4. flip 事件时间戳从提交瞬间改为当前序列号对应的 vblank 边沿时间。
5. `drm.rs` 补齐 ioctl 编号、`DrmModeCrtcGetSequence` / `DrmModeCrtcQueueSequence` / `DrmEventCrtcSequence` 与 `DRM_VBLANK_*` 常量。
6. 回归测试：`drm-test-drm-modeset` 新增 23 项，覆盖 GET_SEQUENCE 单调性/同周期等值、QUEUE_SEQUENCE 事件投递与 NEXT_ON_MISS、WAIT_VBLANK absolute/relative/event/EINVAL 语义、wrap 扩展等。
7. `DRM_IOCTL_SYNCOBJ_EVENTFD` 刻意保持 ENOSYS：smithay `supports_syncobj_eventfd` 探针期待 ENOENT，部分实现会让 deniald 宣告 `linux-drm-syncobj-v1` 而后继 FD_TO_HANDLE/TIMELINE_SIGNAL 全族失败；隐式同步是当前工作路径下的诚实语义。

## 验证

- `cargo xtask clippy --package starry-kernel`：aarch64 裸机 target 通过（macOS 宿主缺非 aarch64 交叉 sysroot，lwprintf bindgen 无法本地展开完整矩阵，交由 CI）；
- `cargo xtask starry test qemu --arch aarch64 -c qemu/system/drm-test-drm-modeset`：75/75（修复前新增用例 23 fail，errno=95）；
- denial 桌面 A/B：锁屏出画正常，带载 screendump 逐帧差分 8/8 全不同，无回归。
