### PR TITLE
feat(axvisor): add HTTP control-plane contract and React dashboard

### DIFF
--- a/.github/ci/checks/axvisor.toml
+++ b/.github/ci/checks/axvisor.toml
@@ -50,14 +50,19 @@ cargo xtask axvisor test qemu --arch aarch64 --test-case browser-console
 echo "==> ensure Node.js 24 for the dashboard bundle (cargo never invokes npm)"
 if ! command -v node >/dev/null 2>&1 || [ "$(node -v | sed 's/^v//' | cut -d. -f1)" -lt 24 ]; then
   NODE_VERSION=24.21.0
+  # Each branch pins the matching SHA-256 from the upstream SHASUMS256.txt.
+  # HTTPS authenticates the channel but not the bytes, and the tarball is
+  # executed on a self-hosted runner, so both the primary download and the
+  # mirror fallback must match this digest before anything is unpacked.
   case "$(uname -m)" in
-    x86_64) NODE_ARCH=x64 ;;
-    aarch64) NODE_ARCH=arm64 ;;
-    *) NODE_ARCH="$(uname -m)" ;;
+    x86_64) NODE_ARCH=x64; NODE_SHA256=fd8e59d5a511510f6a298afb548f18c7d2b1be404d8b4a27d94fbe49f56cb2d6 ;;
+    aarch64) NODE_ARCH=arm64; NODE_SHA256=6ad1325edbdb5649c379b75a237147a666c95d4f9ae8d340fef2d1575d289ad2 ;;
+    *) echo "unsupported architecture for the pinned Node toolchain: $(uname -m)"; exit 1 ;;
   esac
   NODE_TARBALL="node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz"
   curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/${NODE_TARBALL}" -o "/tmp/${NODE_TARBALL}" \
     || curl -fsSL "https://registry.npmmirror.com/-/binary/node/v${NODE_VERSION}/${NODE_TARBALL}" -o "/tmp/${NODE_TARBALL}"
+  echo "${NODE_SHA256}  /tmp/${NODE_TARBALL}" | sha256sum -c -
   mkdir -p /tmp/node-toolchain
   tar -xf "/tmp/${NODE_TARBALL}" -C /tmp/node-toolchain --strip-components=1
   export PATH="/tmp/node-toolchain/bin:$PATH"

--- a/.github/ci/checks/axvisor.toml
+++ b/.github/ci/checks/axvisor.toml
@@ -32,7 +32,7 @@ cases = ["smoke", "gicv2-timer-stress", "gicv3-timer-stress"]
 id = "test-axvisor-aarch64-qemu-panic-http-control-plane-ivc"
 impact_targets = ["axvisor:aarch64"]
 name = "QEMU aarch64 · Panic modes + HTTP control-plane + browser console + IVC"
-timeout_minutes = 30
+timeout_minutes = 40
 command = '''
 echo "==> axvisor aarch64 backtrace panic"
 cargo xtask axvisor test qemu --arch aarch64 --test-case backtrace-panic
@@ -47,6 +47,10 @@ echo "==> axvisor aarch64 HTTP control-plane (incl. pause/resume)"
 cargo xtask axvisor test qemu --arch aarch64 --test-case http-control-plane
 echo "==> axvisor aarch64 browser console"
 cargo xtask axvisor test qemu --arch aarch64 --test-case browser-console
+echo "==> build the dashboard bundle (cargo never invokes npm)"
+(cd os/axvisor/web-ui && npm ci && npm run build)
+echo "==> axvisor aarch64 web-ui dashboard (assets + lifecycle)"
+cargo xtask axvisor test qemu --arch aarch64 --test-case web-ui
 echo "==> axvisor aarch64 IVC"
 cargo xtask axvisor test qemu --arch aarch64 --test-group normal --test-case qemu-ivc
 '''
@@ -54,7 +58,7 @@ cargo xtask axvisor test qemu --arch aarch64 --test-group normal --test-case qem
 [[check.suite]]
 kind = "axvisor-qemu"
 arch = "aarch64"
-cases = ["backtrace-panic", "no-backtrace", "el2-fatal", "el2-fatal-foreign-context", "http-control-plane", "browser-console", "qemu-ivc"]
+cases = ["backtrace-panic", "no-backtrace", "el2-fatal", "el2-fatal-foreign-context", "http-control-plane", "browser-console", "web-ui", "qemu-ivc"]
 
 [[check]]
 id = "test-axvisor-riscv64-qemu-smoke-panic-modes"

--- a/.github/ci/checks/axvisor.toml
+++ b/.github/ci/checks/axvisor.toml
@@ -47,6 +47,23 @@ echo "==> axvisor aarch64 HTTP control-plane (incl. pause/resume)"
 cargo xtask axvisor test qemu --arch aarch64 --test-case http-control-plane
 echo "==> axvisor aarch64 browser console"
 cargo xtask axvisor test qemu --arch aarch64 --test-case browser-console
+echo "==> ensure Node.js 24 for the dashboard bundle (cargo never invokes npm)"
+if ! command -v node >/dev/null 2>&1 || [ "$(node -v | sed 's/^v//' | cut -d. -f1)" -lt 24 ]; then
+  NODE_VERSION=24.21.0
+  case "$(uname -m)" in
+    x86_64) NODE_ARCH=x64 ;;
+    aarch64) NODE_ARCH=arm64 ;;
+    *) NODE_ARCH="$(uname -m)" ;;
+  esac
+  NODE_TARBALL="node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz"
+  curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/${NODE_TARBALL}" -o "/tmp/${NODE_TARBALL}" \
+    || curl -fsSL "https://registry.npmmirror.com/-/binary/node/v${NODE_VERSION}/${NODE_TARBALL}" -o "/tmp/${NODE_TARBALL}"
+  mkdir -p /tmp/node-toolchain
+  tar -xf "/tmp/${NODE_TARBALL}" -C /tmp/node-toolchain --strip-components=1
+  export PATH="/tmp/node-toolchain/bin:$PATH"
+fi
+node -v
+npm -v
 echo "==> build the dashboard bundle (cargo never invokes npm)"
 (cd os/axvisor/web-ui && npm ci && npm run build)
 echo "==> axvisor aarch64 web-ui dashboard (assets + lifecycle)"

--- a/os/axvisor/.gitignore
+++ b/os/axvisor/.gitignore
@@ -46,6 +46,9 @@ downloads/
 eggs/
 .eggs/
 lib/
+# The dashboard sources live under web-ui/src/lib/; keep them tracked
+# despite the Python-boilerplate pattern above.
+!web-ui/src/lib/
 lib64/
 parts/
 sdist/

--- a/os/axvisor/Cargo.toml
+++ b/os/axvisor/Cargo.toml
@@ -18,6 +18,13 @@ include = [
     "xtask/src/**",
     "README.md",
     "LICENSE*",
+    # The `web-ui` feature builds the dashboard from these sources: build.rs
+    # embeds `web-ui/dist`, which a consumer produces with the frontend
+    # toolchain. Installed dependencies and the build output are reproducible
+    # from the manifest and the lockfile, so they stay out of the package.
+    "web-ui/**",
+    "!web-ui/node_modules/**",
+    "!web-ui/dist/**",
 ]
 
 [[bin]]

--- a/os/axvisor/Cargo.toml
+++ b/os/axvisor/Cargo.toml
@@ -74,6 +74,13 @@ browser-console = [
   "dep:serde_json",
   "dep:tokio",
 ]
+# React dashboard served from the same listener. Assets are compiled in with
+# `include_bytes!` and served from memory — cargo never invokes npm, so
+# `os/axvisor/web-ui/dist` must be produced by hand before enabling this.
+# Enabling `web-ui` alone selects the dashboard URL ownership (the console page
+# yields `/` and `/assets/*`); the UI router itself stays empty until the
+# dashboard assets land.
+web-ui = ["http-axum"]
 # Do not auto-boot the default VMs at startup; the HTTP control plane starts
 # and stops them on demand (VMs are created and stay in `Ready`).
 no-auto-start = []

--- a/os/axvisor/build.rs
+++ b/os/axvisor/build.rs
@@ -33,6 +33,11 @@
 //! A function `get_memory_images` is also provided to get every vm image from the configuration
 //! files.
 //!
+//! With the `web-ui` feature, the build script additionally reads the prebuilt dashboard in
+//! `web-ui/dist` and writes `$(OUT_DIR)/ui_assets.rs`, a compile-time table of the assets keyed by
+//! request path. Cargo never invokes npm: producing `dist` is a manual step, and a missing or
+//! unexpected tree becomes a `compile_error!` naming the exact command to run.
+//!
 //! This build script reruns if the `AXVISOR_VM_CONFIGS` environment variable changes, or if the
 //! `build.rs` file changes, or if any of the files in the paths specified by `AXVISOR_VM_CONFIGS`
 //! change.
@@ -100,15 +105,24 @@ fn get_configs() -> Result<Vec<ConfigFile>, String> {
 ///
 /// Returns the file handle.
 fn open_output_file() -> fs::File {
+    open_generated_file("vm_configs.rs")
+}
+
+/// Opens the generated `ui_assets.rs` for writing.
+fn open_ui_assets_file() -> fs::File {
+    open_generated_file("ui_assets.rs")
+}
+
+fn open_generated_file(name: &str) -> fs::File {
     let output_dir = PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR must be set by Cargo"));
-    let output_file = output_dir.join("vm_configs.rs");
+    let output_file = output_dir.join(name);
 
     fs::OpenOptions::new()
         .write(true)
         .create(true)
         .truncate(true)
         .open(output_file)
-        .expect("failed to open generated vm_configs.rs")
+        .unwrap_or_else(|error| panic!("failed to open generated {name}: {error}"))
 }
 
 fn write_tokens(out_file: &mut fs::File, tokens: proc_macro2::TokenStream) -> anyhow::Result<()> {
@@ -346,6 +360,152 @@ fn generate_firmware_img_loading_functions(
     Ok(())
 }
 
+/// File types the dashboard may embed, mapped to the MIME type served for them.
+///
+/// Anything else is rejected so a stray file cannot be smuggled into the
+/// hypervisor image through the dist tree.
+const UI_ASSET_TYPES: &[(&str, &str)] = &[
+    ("html", "text/html; charset=utf-8"),
+    ("js", "text/javascript; charset=utf-8"),
+    ("css", "text/css; charset=utf-8"),
+    ("svg", "image/svg+xml"),
+];
+
+/// Hard caps on the embedded tree: a runaway build fails loudly instead of
+/// bloating the hypervisor image.
+const UI_MAX_FILES: usize = 32;
+const UI_MAX_FILE_BYTES: u64 = 8 * 1024 * 1024;
+
+const UI_BUILD_HINT: &str =
+    "web-ui: UI assets are missing; run `cd os/axvisor/web-ui && npm ci && npm run build`";
+
+/// Emits `UI_ASSETS` for the embedded React dashboard.
+///
+/// `npm run build` runs outside cargo by design (cargo never invokes npm), so
+/// this only reads what is already in `web-ui/dist`. A missing, oversized, or
+/// unexpected tree becomes a `compile_error!` carrying the fix command — the
+/// same "fail the build with a readable message" style as the VM-config path.
+fn generate_ui_assets(out_file: &mut fs::File) -> anyhow::Result<()> {
+    // `include_bytes!` resolves relative paths against the file that contains
+    // the macro — the generated file in OUT_DIR — so the table must carry
+    // absolute paths.
+    let manifest_dir =
+        PathBuf::from(env::var("CARGO_MANIFEST_DIR").context("CARGO_MANIFEST_DIR is not set")?);
+    let dist = manifest_dir.join("web-ui/dist");
+    println!("cargo:rerun-if-changed={}", dist.display());
+
+    match collect_ui_assets(&dist) {
+        Ok(entries) => {
+            for (_, _, absolute) in &entries {
+                println!("cargo:rerun-if-changed={}", absolute.display());
+            }
+            let items = entries.iter().map(|(url, mime, absolute)| {
+                let url = LitStr::new(url, proc_macro2::Span::call_site());
+                let mime = LitStr::new(mime, proc_macro2::Span::call_site());
+                let absolute =
+                    LitStr::new(&absolute.to_string_lossy(), proc_macro2::Span::call_site());
+                quote! { (#url, #mime, include_bytes!(#absolute)), }
+            });
+            write_tokens(
+                out_file,
+                quote! {
+                    /// Dashboard assets embedded at build time, keyed by request path.
+                    pub const UI_ASSETS: &[(&str, &str, &[u8])] = &[ #(#items)* ];
+                },
+            )
+        }
+        Err(message) => {
+            let error = LitStr::new(&message, proc_macro2::Span::call_site());
+            write_tokens(
+                out_file,
+                quote! {
+                    pub const UI_ASSETS: &[(&str, &str, &[u8])] = {
+                        compile_error!(#error);
+                        &[]
+                    };
+                },
+            )
+        }
+    }
+}
+
+/// Walks `dist` and returns `(request path, mime, absolute path)` entries.
+fn collect_ui_assets(dist: &Path) -> Result<Vec<(String, String, PathBuf)>, String> {
+    if !dist.join("index.html").is_file() {
+        return Err(UI_BUILD_HINT.to_string());
+    }
+
+    let mut entries = Vec::new();
+    collect_ui_assets_in(dist, dist, &mut entries)?;
+    entries.sort();
+
+    if entries.len() > UI_MAX_FILES {
+        return Err(format!(
+            "{UI_BUILD_HINT}: dist holds {} files, the limit is {UI_MAX_FILES}",
+            entries.len()
+        ));
+    }
+    Ok(entries)
+}
+
+fn collect_ui_assets_in(
+    dist: &Path,
+    dir: &Path,
+    entries: &mut Vec<(String, String, PathBuf)>,
+) -> Result<(), String> {
+    let children = fs::read_dir(dir).map_err(|error| format!("{}: {error}", dir.display()))?;
+
+    for child in children {
+        let child = child.map_err(|error| error.to_string())?;
+        let path = child.path();
+        let file_type = child.file_type().map_err(|error| error.to_string())?;
+
+        if file_type.is_dir() {
+            collect_ui_assets_in(dist, &path, entries)?;
+            continue;
+        }
+        if !file_type.is_file() {
+            continue;
+        }
+
+        let extension = path
+            .extension()
+            .and_then(|extension| extension.to_str())
+            .unwrap_or_default()
+            .to_ascii_lowercase();
+        let Some((_, mime)) = UI_ASSET_TYPES.iter().find(|(known, _)| *known == extension) else {
+            return Err(format!(
+                "{UI_BUILD_HINT}: {} is not an embeddable asset type",
+                path.display()
+            ));
+        };
+
+        let size = fs::metadata(&path)
+            .map_err(|error| error.to_string())?
+            .len();
+        if size > UI_MAX_FILE_BYTES {
+            return Err(format!(
+                "{UI_BUILD_HINT}: {} is {size} bytes, the limit is {UI_MAX_FILE_BYTES}",
+                path.display()
+            ));
+        }
+
+        let relative = path
+            .strip_prefix(dist)
+            .map_err(|error| error.to_string())?
+            .to_string_lossy()
+            .replace('\\', "/");
+        // index.html is the app shell; everything else keeps its dist path.
+        let url = if relative == "index.html" {
+            "/".to_string()
+        } else {
+            format!("/{relative}")
+        };
+        entries.push((url, mime.to_string(), path));
+    }
+    Ok(())
+}
+
 fn main() -> anyhow::Result<()> {
     println!("cargo:rerun-if-changed=linker.ld");
     let out_dir = PathBuf::from(env::var("OUT_DIR").context("OUT_DIR is not set")?);
@@ -411,5 +571,10 @@ fn main() -> anyhow::Result<()> {
             write_tokens(&mut output_file, output)?;
         }
     }
+
+    if env::var_os("CARGO_FEATURE_WEB_UI").is_some() {
+        generate_ui_assets(&mut open_ui_assets_file())?;
+    }
+
     Ok(())
 }

--- a/os/axvisor/src/http/auth.rs
+++ b/os/axvisor/src/http/auth.rs
@@ -15,12 +15,14 @@
 //! them off the management network unless an operator explicitly opts in.
 
 use axum::{
+    Json,
     extract::FromRequestParts,
     http::{
         StatusCode,
         header::{AUTHORIZATION, HeaderValue},
     },
 };
+use serde_json::{Value, json};
 
 /// A request that carries a matching `Authorization: Bearer <token>` header.
 ///
@@ -28,6 +30,18 @@ use axum::{
 /// with `401 Unauthorized` when no token was baked into the image
 /// (`AXVM_HTTP_TOKEN` unset) or the header is missing / does not match.
 pub struct ApiToken;
+
+/// `GET /api/auth` — reports whether the caller's token is usable.
+///
+/// Discovery has to stay open (a client cannot read a capability list it is not
+/// yet authorized for), so a client that wants to *validate* a token before
+/// relying on it needs a route that does nothing but check it. Reaching this
+/// handler means the extractor already accepted the token, so the body only
+/// confirms it; the manifest points clients here (see
+/// [`crate::http::manifest`]) so no client hard-codes the path.
+pub async fn check(_token: ApiToken) -> Json<Value> {
+    Json(json!({ "ok": true }))
+}
 
 impl ApiToken {
     /// Whether the given header value carries the required bearer token.

--- a/os/axvisor/src/http/auth.rs
+++ b/os/axvisor/src/http/auth.rs
@@ -50,9 +50,10 @@ impl ApiToken {
             return false;
         };
         value.to_str().ok().is_some_and(|value| {
-            value
-                .strip_prefix("Bearer ")
-                .is_some_and(|rest| rest == token)
+            // The auth scheme is case-insensitive (RFC 7235); the token is not.
+            value.split_once(' ').is_some_and(|(scheme, rest)| {
+                scheme.eq_ignore_ascii_case("Bearer") && rest == token
+            })
         })
     }
 }

--- a/os/axvisor/src/http/browser_console/mod.rs
+++ b/os/axvisor/src/http/browser_console/mod.rs
@@ -18,10 +18,23 @@ mod page;
 const BROWSER_INPUT_CAPACITY: usize = 4096;
 /// Browser-console routes served by Axvisor's optional HTTP listener.
 pub(super) fn router() -> Router {
+    // The React dashboard owns `/` and `/assets/*` once `web-ui` is enabled, so
+    // this whole subtree — page and its bundled xterm assets — moves under
+    // `/console/`. Discovery and stream routes are absolute inside the page and
+    // stay where they are.
+    #[cfg(not(feature = "web-ui"))]
+    let (index_path, script_path, style_path) = ("/", "/assets/xterm.js", "/assets/xterm.css");
+    #[cfg(feature = "web-ui")]
+    let (index_path, script_path, style_path) = (
+        "/console/",
+        "/console/assets/xterm.js",
+        "/console/assets/xterm.css",
+    );
+
     Router::new()
-        .route("/", get(index))
-        .route("/assets/xterm.js", get(xterm_javascript))
-        .route("/assets/xterm.css", get(xterm_stylesheet))
+        .route(index_path, get(index))
+        .route(script_path, get(xterm_javascript))
+        .route(style_path, get(xterm_stylesheet))
         .route("/api/consoles", get(console_descriptions))
         .route("/ws/{endpoint}", get(upgrade_console))
 }

--- a/os/axvisor/src/http/browser_console/mod.rs
+++ b/os/axvisor/src/http/browser_console/mod.rs
@@ -16,23 +16,31 @@ use serde_json::{Value, json};
 mod page;
 
 const BROWSER_INPUT_CAPACITY: usize = 4096;
+
+/// Path the console page is mounted at.
+///
+/// `web-ui` reserves `/` and `/assets/*` for the React dashboard, so with that
+/// feature the whole console subtree serves under `/console/`; without it this
+/// page is the only UI and keeps `/`. The startup access banner
+/// ([`crate::network_status`]) prints this same path, so the advertised URL
+/// stays in sync with [`router()`] by construction.
+#[cfg(feature = "web-ui")]
+pub(crate) const PAGE_PATH: &str = "/console/";
+#[cfg(not(feature = "web-ui"))]
+pub(crate) const PAGE_PATH: &str = "/";
+
 /// Browser-console routes served by Axvisor's optional HTTP listener.
 pub(super) fn router() -> Router {
-    // The React dashboard owns `/` and `/assets/*` once `web-ui` is enabled, so
-    // this whole subtree — page and its bundled xterm assets — moves under
-    // `/console/`. Discovery and stream routes are absolute inside the page and
-    // stay where they are.
+    // The xterm assets follow the page — the page addresses them relatively, so
+    // they carry the same mount prefix. Discovery and stream routes are
+    // absolute inside the page and stay where they are.
     #[cfg(not(feature = "web-ui"))]
-    let (index_path, script_path, style_path) = ("/", "/assets/xterm.js", "/assets/xterm.css");
+    let (script_path, style_path) = ("/assets/xterm.js", "/assets/xterm.css");
     #[cfg(feature = "web-ui")]
-    let (index_path, script_path, style_path) = (
-        "/console/",
-        "/console/assets/xterm.js",
-        "/console/assets/xterm.css",
-    );
+    let (script_path, style_path) = ("/console/assets/xterm.js", "/console/assets/xterm.css");
 
     Router::new()
-        .route(index_path, get(index))
+        .route(PAGE_PATH, get(index))
         .route(script_path, get(xterm_javascript))
         .route(style_path, get(xterm_stylesheet))
         .route("/api/consoles", get(console_descriptions))

--- a/os/axvisor/src/http/browser_console/page.rs
+++ b/os/axvisor/src/http/browser_console/page.rs
@@ -1,4 +1,7 @@
 //! Self-contained single-page frontend served directly by Axvisor.
+//!
+//! The page refers to its own assets relatively so that the same HTML works at
+//! `/` and, once the React dashboard takes `/` over, at `/console/`.
 
 pub(super) const XTERM_JAVASCRIPT: &str = include_str!("assets/xterm-6.0.0/xterm.js");
 pub(super) const XTERM_STYLESHEET: &str = include_str!("assets/xterm-6.0.0/xterm.css");
@@ -9,7 +12,7 @@ pub(super) const INDEX_HTML: &str = r##"<!doctype html>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Axvisor board console</title>
-  <link rel="stylesheet" href="/assets/xterm.css">
+  <link rel="stylesheet" href="assets/xterm.css">
   <style>
     :root { color-scheme: dark; font-family: system-ui, sans-serif; background: #080c14; color: #e8edf7; }
     * { box-sizing: border-box; }
@@ -44,7 +47,7 @@ pub(super) const INDEX_HTML: &str = r##"<!doctype html>
       <div class="terminal"></div>
     </section>
   </template>
-  <script src="/assets/xterm.js"></script>
+  <script src="assets/xterm.js"></script>
   <script>
     (() => {
       const encoder = new TextEncoder();

--- a/os/axvisor/src/http/manifest.rs
+++ b/os/axvisor/src/http/manifest.rs
@@ -1,0 +1,31 @@
+//! Top-level control-plane manifest.
+//!
+//! The manifest is the runtime contract the dashboard shell navigates by: it
+//! lists the resource families this build exposes, what each of them supports,
+//! and where it hangs. The shell never hardcodes routes — it follows `href`,
+//! and degrades to a JSON view for kinds it does not know.
+
+use axum::Json;
+use serde_json::{Value, json};
+
+/// Contract version.
+///
+/// Bump only for shape changes an older client cannot degrade on; new fields
+/// and new resource nodes are additive and keep the current version.
+const PROTO: u32 = 1;
+
+/// `GET /api/` — top-level capability manifest.
+///
+/// Read-only and unauthenticated like every other GET route; mutating routes
+/// are the ones gated by the build-time bearer token (see [`crate::http::auth`]).
+pub async fn get_manifest() -> Json<Value> {
+    Json(json!({
+        "proto": PROTO,
+        "resources": [{
+            "kind": "vms",
+            "title": "虚拟机",
+            "href": "/api/vms",
+            "verbs": ["read", "write"],
+        }],
+    }))
+}

--- a/os/axvisor/src/http/manifest.rs
+++ b/os/axvisor/src/http/manifest.rs
@@ -18,9 +18,16 @@ const PROTO: u32 = 1;
 ///
 /// Read-only and unauthenticated like every other GET route; mutating routes
 /// are the ones gated by the build-time bearer token (see [`crate::http::auth`]).
+/// The `auth` node tells a client where to check a token before relying on it,
+/// so the check path is a declared part of the contract rather than something
+/// each client hard-codes.
 pub async fn get_manifest() -> Json<Value> {
     Json(json!({
         "proto": PROTO,
+        "auth": {
+            "href": "/api/auth",
+            "scheme": "bearer",
+        },
         "resources": [{
             "kind": "vms",
             "title": "虚拟机",

--- a/os/axvisor/src/http/mod.rs
+++ b/os/axvisor/src/http/mod.rs
@@ -15,6 +15,8 @@
 pub mod auth;
 #[cfg(feature = "browser-console")]
 pub mod browser_console;
+#[cfg(feature = "http-axum")]
+pub mod manifest;
 pub mod server;
 #[cfg(feature = "http-axum")]
 pub mod vm;

--- a/os/axvisor/src/http/server.rs
+++ b/os/axvisor/src/http/server.rs
@@ -123,9 +123,15 @@ fn console_router() -> Router {
 
 /// `/` and its page assets.
 ///
-/// The React dashboard takes this root over once the `web-ui` feature lands,
-/// and the legacy console page moves under `/console/`; until then the console
-/// group is the only UI and this root stays empty.
+/// The React dashboard owns this root when the `web-ui` feature is enabled, and
+/// the console page yields to `/console/` for it (see
+/// [`crate::http::browser_console::router`]).
+#[cfg(feature = "web-ui")]
+fn ui_router() -> Router {
+    crate::web::router()
+}
+
+#[cfg(not(feature = "web-ui"))]
 fn ui_router() -> Router {
     Router::new()
 }

--- a/os/axvisor/src/http/server.rs
+++ b/os/axvisor/src/http/server.rs
@@ -74,20 +74,20 @@ impl Drop for ListeningGuard {
 }
 
 /// Assemble only the HTTP services selected by build features.
+///
+/// Three roots keep the ownership of every URL namespace visible in one place:
+/// `/api/*` is the resource surface, the console group owns its page and
+/// streams, and `/` together with its page assets belongs to exactly one UI.
 pub fn router() -> Router {
-    let router = Router::new();
-
-    #[cfg(feature = "http-axum")]
-    let router = router.merge(management_router());
-
-    #[cfg(feature = "browser-console")]
-    let router = router.merge(crate::http::browser_console::router());
-
-    router
+    Router::new()
+        .merge(api_router())
+        .merge(console_router())
+        .merge(ui_router())
 }
 
+/// `/api/*`: the resource surface plus the top-level manifest.
 #[cfg(feature = "http-axum")]
-fn management_router() -> Router {
+fn api_router() -> Router {
     Router::new()
         .route("/api/vms", get(vm::list_vms))
         .route("/api/vms/{id}", get(vm::vm_detail).delete(vm::vm_delete))
@@ -96,6 +96,31 @@ fn management_router() -> Router {
         .route("/api/vms/{id}/stop", post(vm::vm_stop))
         .route("/api/vms/{id}/pause", post(vm::vm_pause))
         .route("/api/vms/{id}/resume", post(vm::vm_resume))
+}
+
+#[cfg(not(feature = "http-axum"))]
+fn api_router() -> Router {
+    Router::new()
+}
+
+/// The console page, console discovery, and console streams.
+#[cfg(feature = "browser-console")]
+fn console_router() -> Router {
+    crate::http::browser_console::router()
+}
+
+#[cfg(not(feature = "browser-console"))]
+fn console_router() -> Router {
+    Router::new()
+}
+
+/// `/` and its page assets.
+///
+/// The React dashboard takes this root over once the `web-ui` feature lands,
+/// and the legacy console page moves under `/console/`; until then the console
+/// group is the only UI and this root stays empty.
+fn ui_router() -> Router {
+    Router::new()
 }
 
 /// Bind address for the management HTTP server.

--- a/os/axvisor/src/http/server.rs
+++ b/os/axvisor/src/http/server.rs
@@ -57,6 +57,8 @@ use anyhow::Context;
 use axum::Router;
 
 #[cfg(feature = "http-axum")]
+use crate::http::auth;
+#[cfg(feature = "http-axum")]
 use crate::http::manifest;
 #[cfg(feature = "http-axum")]
 use crate::http::vm;
@@ -93,6 +95,7 @@ pub fn router() -> Router {
 fn api_router() -> Router {
     Router::new()
         .route("/api/", get(manifest::get_manifest))
+        .route("/api/auth", get(auth::check))
         .route("/api/vms", get(vm::list_vms))
         .route("/api/vms/{id}", get(vm::vm_detail).delete(vm::vm_delete))
         .route("/api/vms/create", post(vm::vm_create))

--- a/os/axvisor/src/http/server.rs
+++ b/os/axvisor/src/http/server.rs
@@ -5,6 +5,7 @@
 //! but dispatch and JSON construction are delegated to axum + serde_json.
 //!
 //! ```text
+//! GET    /api/               → 200, JSON control-plane manifest (capability list)
 //! GET    /api/vms            → 200, JSON array (summary form)
 //! GET    /api/vms/{id}       → 200, JSON detail (with vcpu_states) | 404
 //! POST   /api/vms/create     → 200 {"id":N} | 400 | 409 | 500 (body {"toml": "..."})
@@ -56,6 +57,8 @@ use anyhow::Context;
 use axum::Router;
 
 #[cfg(feature = "http-axum")]
+use crate::http::manifest;
+#[cfg(feature = "http-axum")]
 use crate::http::vm;
 #[cfg(feature = "http-axum")]
 use axum::{routing::get, routing::post};
@@ -89,6 +92,7 @@ pub fn router() -> Router {
 #[cfg(feature = "http-axum")]
 fn api_router() -> Router {
     Router::new()
+        .route("/api/", get(manifest::get_manifest))
         .route("/api/vms", get(vm::list_vms))
         .route("/api/vms/{id}", get(vm::vm_detail).delete(vm::vm_delete))
         .route("/api/vms/create", post(vm::vm_create))

--- a/os/axvisor/src/main.rs
+++ b/os/axvisor/src/main.rs
@@ -47,6 +47,8 @@ mod network_console;
 #[cfg(feature = "browser-console")]
 mod network_status;
 mod shell;
+#[cfg(feature = "web-ui")]
+mod web;
 
 /// Axvisor kernel entry point.
 ///

--- a/os/axvisor/src/network_status.rs
+++ b/os/axvisor/src/network_status.rs
@@ -93,5 +93,11 @@ fn append_web_console_endpoint(
         IpAddr::V4(ip) if ip.is_unspecified() => assigned_address.to_string(),
         ip => ip.to_string(),
     };
-    let _ = write!(banner, "  web_console = http://{host}:{}/\r\n", bind.port());
+    let _ = write!(
+        banner,
+        "  web_console = http://{}:{}{}\r\n",
+        host,
+        bind.port(),
+        crate::http::browser_console::PAGE_PATH
+    );
 }

--- a/os/axvisor/src/web/assets.rs
+++ b/os/axvisor/src/web/assets.rs
@@ -1,0 +1,84 @@
+//! Embedded dashboard assets, served straight from memory.
+//!
+//! The bytes come from the table `build.rs` generates out of `web-ui/dist`, so
+//! a request is a lookup plus a response: no filesystem read, no extraction
+//! step, and no runtime state to keep consistent with the router.
+
+use axum::{
+    Router,
+    extract::Path,
+    http::{StatusCode, header},
+    response::{IntoResponse, Response},
+    routing::get,
+};
+
+include!(concat!(env!("OUT_DIR"), "/ui_assets.rs"));
+
+/// Every dashboard response carries the same security headers.
+///
+/// `ws:` is reserved for the terminal stage. `style-src 'unsafe-inline'`
+/// covers React inline style attributes while `script-src 'self'` stays strict
+/// because vite's production output has no inline scripts.
+const CONTENT_SECURITY_POLICY: &str = "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' ws: wss:; font-src 'self'; object-src 'none'; base-uri 'none'; frame-ancestors 'none'";
+
+/// The app shell names the content-hashed assets, so it must be revalidated on
+/// every load; the hashed assets themselves can be cached forever.
+const SHELL_CACHE_CONTROL: &str = "no-cache";
+const HASHED_CACHE_CONTROL: &str = "public, max-age=31536000, immutable";
+
+const APP_SHELL_PATH: &str = "/";
+
+/// Dashboard routes: the app shell and its content-hashed assets.
+///
+/// Only these two shapes are registered. There is deliberately no SPA
+/// catch-all: the shell keeps its navigation in memory rather than in the URL,
+/// so unknown paths (including unmatched `/api/*` or `/ws/*` ones) keep the
+/// router's own 404 instead of being swallowed by the UI.
+pub fn router() -> Router {
+    assert_asset_table_sane();
+
+    Router::new()
+        .route(APP_SHELL_PATH, get(app_shell))
+        .route("/assets/{*path}", get(hashed_asset))
+}
+
+async fn app_shell() -> Response {
+    serve(APP_SHELL_PATH, SHELL_CACHE_CONTROL)
+}
+
+async fn hashed_asset(Path(path): Path<String>) -> Response {
+    serve(&format!("/assets/{path}"), HASHED_CACHE_CONTROL)
+}
+
+/// Serves one entry of the embedded table, or 404 when the path is not in it.
+fn serve(path: &str, cache_control: &'static str) -> Response {
+    match UI_ASSETS.iter().find(|(asset, _, _)| *asset == path) {
+        Some((_, mime, bytes)) => (
+            [
+                (header::CONTENT_TYPE, *mime),
+                (header::CACHE_CONTROL, cache_control),
+                (header::CONTENT_SECURITY_POLICY, CONTENT_SECURITY_POLICY),
+                (header::X_CONTENT_TYPE_OPTIONS, "nosniff"),
+            ],
+            *bytes,
+        )
+            .into_response(),
+        None => StatusCode::NOT_FOUND.into_response(),
+    }
+}
+
+/// Checks the generated table once at startup.
+///
+/// The table is produced by the build script, so a broken one means the build
+/// emitted garbage: failing here beats serving a half-working UI whose
+/// navigation silently 404s.
+fn assert_asset_table_sane() {
+    assert!(
+        !UI_ASSETS.is_empty(),
+        "web-ui: the embedded asset table is empty"
+    );
+    assert!(
+        UI_ASSETS.iter().any(|(path, _, _)| *path == APP_SHELL_PATH),
+        "web-ui: the embedded asset table has no entry for {APP_SHELL_PATH}"
+    );
+}

--- a/os/axvisor/src/web/mod.rs
+++ b/os/axvisor/src/web/mod.rs
@@ -1,0 +1,14 @@
+//! React dashboard served by the axvisor HTTP listener.
+//!
+//! The module owns exactly one URL namespace — `/` and its hashed assets — and
+//! serves it from assets embedded in the binary (see [`assets`]). It is the
+//! slot `server::ui_router()` fills when the `web-ui` feature is enabled.
+
+pub mod assets;
+
+use axum::Router;
+
+/// Dashboard routes: the app shell at `/` plus `/assets/*`.
+pub fn router() -> Router {
+    assets::router()
+}

--- a/os/axvisor/web-ui/.gitignore
+++ b/os/axvisor/web-ui/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/os/axvisor/web-ui/components.json
+++ b/os/axvisor/web-ui/components.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "default",
+  "rsc": false,
+  "tsx": true,
+  "tailwind": {
+    "config": "tailwind.config.js",
+    "css": "src/index.css",
+    "baseColor": "slate",
+    "cssVariables": true,
+    "prefix": ""
+  },
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/lib/utils",
+    "ui": "@/components/ui",
+    "lib": "@/lib",
+    "hooks": "@/hooks"
+  }
+}

--- a/os/axvisor/web-ui/index.html
+++ b/os/axvisor/web-ui/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Axvisor</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/os/axvisor/web-ui/package-lock.json
+++ b/os/axvisor/web-ui/package-lock.json
@@ -1,0 +1,3677 @@
+{
+  "name": "axvisor-web-ui",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "axvisor-web-ui",
+      "version": "0.0.0",
+      "dependencies": {
+        "@radix-ui/react-dialog": "^1.1.4",
+        "@radix-ui/react-slot": "^1.3.3",
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
+        "lucide-react": "^0.469.0",
+        "react": "18.3.1",
+        "react-dom": "18.3.1",
+        "tailwind-merge": "^2.6.0"
+      },
+      "devDependencies": {
+        "@types/node": "^22.10.5",
+        "@types/react": "^18.3.18",
+        "@types/react-dom": "^18.3.5",
+        "@vitejs/plugin-react": "^4.3.4",
+        "autoprefixer": "^10.4.20",
+        "postcss": "^8.4.49",
+        "tailwindcss": "3.4.17",
+        "tailwindcss-animate": "^1.0.7",
+        "typescript": "5.6.3",
+        "vite": "5.4.11",
+        "vitest": "^2.1.8"
+      },
+      "engines": {
+        "node": ">=24",
+        "npm": ">=11.12.1"
+      }
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.3.0.tgz",
+      "integrity": "sha512-U4+70Pc5ZS9osnCBCE5Jha/ciHM+Yp+CNMNC/7HvYbNRk1Ldd+f7qO65W5qfhu/TCv+/ozljlXXe9Nj8419DMA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+      "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.8",
+        "@babel/types": "^7.29.8",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.8"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+      "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+      "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+      "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.8",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.8",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.8",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
+      "integrity": "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.7.tgz",
+      "integrity": "sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.5.tgz",
+      "integrity": "sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.2.2.tgz",
+      "integrity": "sha512-RHCUGwKHDr0hDGg4X7ma4JG4/+12qxw8rkh5QKdDldlCvtja6nUx1Ef/8HVrJze81lEsgLQlqjzjGNHantgnQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.23",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.23.tgz",
+      "integrity": "sha512-Ksw4WeROkO4rC9k/onilX/Ao2Cr1ku1unMNH+XSCcP4jSXYu7HDsg9n4ojMjVb22XpYjAQ9qfrFlVbru1vXDUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-dismissable-layer": "1.1.19",
+        "@radix-ui/react-focus-guards": "1.1.6",
+        "@radix-ui/react-focus-scope": "1.1.16",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-portal": "1.1.17",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-slot": "1.3.3",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-layout-effect": "1.1.4",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.7.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.19.tgz",
+      "integrity": "sha512-8g4pfOL9HoKKLWGiypT+dphVqjFfmcXO5GBnhsG6zI+lxAx/8feQpr+1LSN8Re3hiZ+XkLNS4O9ztK11/LzQ6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "@radix-ui/react-use-effect-event": "0.0.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.6.tgz",
+      "integrity": "sha512-RNOJjfZMTyBM6xYmV3IVGXkPjIhcBAuv48POevAXwrGJhkWZ9p1rFoIS1JFooPuT193AZmRsCPhpoVJxx6OPoQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.16.tgz",
+      "integrity": "sha512-wmRZ2WWLvmt6KHy2rNPOdPUjwq5xOHY02+m+udwJTn0aNIox/rkskAvJTyTLGhPK6KgrUjlJUJpgmx/+wFiFIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.4.tgz",
+      "integrity": "sha512-TMQp2llA+RYn7JcjnrMnz7wN4pcVttPZnRZo52PLQsoLVKzNlVwUeHmfePgTgRluXFvlD3GD5g5MOVVTJCO0qA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal": {
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.17.tgz",
+      "integrity": "sha512-vKQLcWypUnwZVvfV7UkGahH2g6ySe8M8R+zYBwPrv5byZ9QAW6cQVvNKo7GgmD+p8aYb6D9JBuvy8/WhOno2wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.10.tgz",
+      "integrity": "sha512-3wyzCQ6+ubRA+D4uv9m95JYLXxmOHp05qjrkjeA7uKHHtjpPggQzc6DAb0URl7j67oR0K2foO4ip27TiX037Bw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.10.tgz",
+      "integrity": "sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.3.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.3.tgz",
+      "integrity": "sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.4.tgz",
+      "integrity": "sha512-R6OUY2e2fA6Yn6s+VSx5KBV6Nx8LQEhu+cz7LCej18rQ1HLyg9PSC9jP/ZNx0o6FAIK9c0F1kHylzSxKsdlkrQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.6.tgz",
+      "integrity": "sha512-uEQJGT97ZA/TgP/Hydw47lHu+/vQj6z/0jA+WeTbK1o9Rx45GImjpD0tc3W5ad3D6XTSR6e1yEO0FvGq6WQfVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-use-effect-event": "0.0.5",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.5.tgz",
+      "integrity": "sha512-7cshFL8HGS/7HEiHH+9kL9HBwp2sa9yX18Knwek6KYWmXwM7pegMgta2AXMQKI+rq3JnfSj9x8wYqFMTdG1Jgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.4.tgz",
+      "integrity": "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.63.1.tgz",
+      "integrity": "sha512-UZ8sUxPTiHWYX9QNdJedb1kDZSpS1t/VPWBWGSgqHNi9w3Cu6IXvu2mzbhiTiPvtrqgTQJ+zqiAq2iPIPilpaQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.63.1.tgz",
+      "integrity": "sha512-cQ4nFQABN5cDvDpbvJ7bMStCpnaVxynZrRMfUJYgxcIk9Sh54FIO1vtfkg0B69REjER77ioZ/ov+eAApx/KmLQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.63.1.tgz",
+      "integrity": "sha512-FQNqd1lRy/0QhDk3xeRIkSBiCpXCiDnZO3YLVdcDKN1UBiKToNftCzcXYNLshmPDUMlu2TdeS8tGcsU6f3YF1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.63.1.tgz",
+      "integrity": "sha512-pvD16V939D3CloK0+qikpGaxiPrDUXTe7Y5cWOMkMSy7m1cawa8EGy/kXYi/G/cKAC4HDAbSnzCIk1WmsoOKXg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.63.1.tgz",
+      "integrity": "sha512-pcFGeL2345VwdTnJhA6zLbew+YgWB0qBG2+dMtXjCicf6+rm6kO6cOoh5VnTe0ZMrMRgRyuHmCJxZWrIdzYuOw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.63.1.tgz",
+      "integrity": "sha512-mRJlqSRulVzcKq/LKA6ICSIc3K/l4fzlVn/gePn2nXIHy8seRi5z/eeRE0d/XMBxcMldiXtQTSpRj0tkkC3g8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.63.1.tgz",
+      "integrity": "sha512-YDUNvVM85TI3g/1OpnqKP1h4NeW/j64DfWMf+G3M809xNk1bJSnpFp4sh83NpmVE5DXnkh8ULor4LTVZKoYLHw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.63.1.tgz",
+      "integrity": "sha512-7Mcn71p9ZuQFAj+h+dhQXy/yeLePRS2yKRnmW1DijA9thKO5qap0GNOIQK4yQ6iP3SU0Mrb/yWo8h8vgRba8lw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.63.1.tgz",
+      "integrity": "sha512-4YiLQTX6U4CSl0L9cluep9A9W6UmTfqBDc2/CH6wlu54pl4E7Jn3cOD8oxzvBDEGk/JMKgJ47C8g+radF7mwvg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.63.1.tgz",
+      "integrity": "sha512-2ra8F7w8OquwZN9z2/fKFnli69wa8PLwaVzRMIPGb13ByMJwC28Fbp8YcVGoUhlYMTt7j5j9bNgpysrN2UM+vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.63.1.tgz",
+      "integrity": "sha512-Sy20ncyhjmBP0Ml+UvQbimjlk6VFgjW5uNP+qqwHB00mTE8Bl2C1TuHTlRwK2YoXeZbee5lP2XevBWVkAQAtSQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.63.1.tgz",
+      "integrity": "sha512-noITLp8oNjYliPnGWmLyelIHwULGqbHloQHGw1rtxbWhTuWooRpnZarZQJ1y9EUC4szuCusCc+HEpUtxpIwYvA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.63.1.tgz",
+      "integrity": "sha512-hlxxXd+F1mWiAcaFR7Sv9ZQT6m6UfI8+Vy/kFJzztq2pDMU/0wZ9sish0iszNZvsQDo8Gc0i5yuFEOz5dDf6fA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.63.1.tgz",
+      "integrity": "sha512-EF7OpqQTQ/BvGqLzUi4rEHuagCV9MugAUXSHemwPW5vxZ75RR+jxO/2j95Ph2dalMpFHSVECjRoioHZgA9zOYA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.63.1.tgz",
+      "integrity": "sha512-wQO3JesW9PRkwlabQ27y7sPfVOOTLRG73I4F2UYHG5PXun3J9U3y+b7ezVKSYbsvSKGQ1k1cq8Qlun4C9kLt3w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.63.1.tgz",
+      "integrity": "sha512-ouAGwhO6wHRXdnOVCOsB0tRFkA7nhNB2Nwax6oECXN0YiN8EYUTBAOudADOB1PI+yDL61TeNx/u7MVCzksNbkQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.63.1.tgz",
+      "integrity": "sha512-q2R38Sn+1J8RxhfJ+T54wSWmyKXWec+9jgDfqO2AtArEqHO5R2aeayp5H5OYLr5UYDVGsVaZPEFUooMhYCdz5A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.63.1.tgz",
+      "integrity": "sha512-gfI5T24WLLuFfSKw7Go/zDXjAAV0fny0swTaDv+WjK7vqcw4cRhFfdsyKL1n+ukI+ooBxn3bVQnyrn06WpI50w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.63.1.tgz",
+      "integrity": "sha512-4h6XqthmB4Hspji84wvgk+ElodTsGj+dbZqHJHHtKxj4mYq0ANSEEPX9ys3moJueqsRjwpaJYH7874Itwnj2ow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.63.1.tgz",
+      "integrity": "sha512-dlfCOa87o1VAYegLQ9EKilx2JCeRofiyPGhTCmqnuXZ6bMPiycO1rq1+sKoulAp7pGLIsTIw+1x5R+zgh5LhhA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.63.1.tgz",
+      "integrity": "sha512-cjkLbOlfcm3QGhMM1J5zaZjsw1GggbN6rw9UTSSRrPrR1KkcXnN7Uq9rPw34xImQ9VOY9GN+6u2Zj80B9ptkcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.63.1.tgz",
+      "integrity": "sha512-Li1KdUnWGE4N3e1F/B4RTB1ms+nG4WBgjByO46pkeBVX/2UBsY53xf5vK9WygVmnH3RwncIST7lkSdLSY6P9lg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.63.1.tgz",
+      "integrity": "sha512-t4ZYOSoLTgwhuFMrmTMLx/+i1DQVK7HYqMc6kY46EApwi8X0nIVphzdNoThU3xt6n+N5urG1/gxBdCaKDLavfg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.63.1.tgz",
+      "integrity": "sha512-RgroPfMmKlD1RzSDxvwgcPiy2HNQKoYV7OmwIXDsk73uKW5t6B/V8KIy27SMv/FNXFo/oSBtWc9J0X7t91ezZg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.63.1.tgz",
+      "integrity": "sha512-at8QVep6S3h5Y6gSbdGU06bRY5WJkf6WUduM9YtvYMbYhB1MOFfUgc6kehitQXzOtMSaT70q7f9ydPhpqu821w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.2.tgz",
+      "integrity": "sha512-xlvWf4Vs9n1PEVYwP1n4vvG07M6y8WgvJ2t0vbrWTmijsIHp1cS+uJ2kMIRdY3nHZK0nCYKrPeD171+SzF4/zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.31",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
+      "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/autoprefixer": {
+      "version": "10.5.5",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.5.tgz",
+      "integrity": "sha512-uiRYvQYe/nNSzBJ7OUnd2/TZVsAdob3blml44teEpee9Cc1f4rGZFewO+JT3Wo8mgFOSzNqes4FHZn/Qz8WOuw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.28.9",
+        "caniuse-lite": "^1.0.30001810",
+        "fraction.js": "^5.3.4",
+        "picocolors": "^1.1.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.11.21",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.21.tgz",
+      "integrity": "sha512-uh8vpY/1/YyFkunIDFH/12p7/7VdPKA1hejMVEbdkEaWnUz0Hesvx5EbiU6XxjyHZIOju+ZMbQJkRh+es3/spQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.9",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.9.tgz",
+      "integrity": "sha512-EWazOblFYUvlGZcfGhPUPmYh3nikUxBVb+y9MJun5f3hBi812X+8MSQTujLBtgK3cf51fJWbWfOjyeO954d+Eg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.11.20",
+        "caniuse-lite": "^1.0.30001810",
+        "electron-to-chromium": "^1.5.420",
+        "node-releases": "^2.0.54",
+        "update-browserslist-db": "^1.3.2"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/camelcase-css": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001810",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+      "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://polar.sh/cva"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
+    },
+    "node_modules/didyoumean": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
+      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/dlv": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.426",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.426.tgz",
+      "integrity": "sha512-2Gcq6inCQs/AqfHP3f5ftCzk+pqeW2VlA1LgmPqEj2hfBO8HiZRspNYkD4HzFBe4u6lGqca4BspFr6Ix4Q400g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.3.tgz",
+      "integrity": "sha512-XKv5nnLs6nLF71NgiKJLIZFLkPyIEuOselLG7ujZnGrRfQK8HpvY+WqKhAJUAdLomwVHErVS4LfxFlPq0/FTAw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fraction.js": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+      "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "1.21.7",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
+      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.469.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.469.0.tgz",
+      "integrity": "sha512-28vvUnnKQ/dBwiCQtwJw7QauYnE7yd2Cyp4tTTJpvglX4EMpbflcdBgrgToX2j71B3YvugK/NH3BGUk+E/p/Fw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.55",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.55.tgz",
+      "integrity": "sha512-mIrE/Cw9y+9Au6dS5vDKDhQza9YvG6w+ZrS6X+ZzA7yFW/soAeaups4Qzn1bL6g5FVy8WtP79+0j82oPIbqRjQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.28",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.28.tgz",
+      "integrity": "sha512-RRuzqDtt5Y9h3quz5hWhK+TPnsmVs6WwSU6LkJMeY4HstUEDuYTG8UJSdawMRzmzAtV+KEoG8N3Qg2qLy5vM/A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.18",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-import": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
+      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss-value-parser": "^4.0.0",
+        "read-cache": "^1.0.0",
+        "resolve": "^1.1.7"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.0"
+      }
+    },
+    "node_modules/postcss-js": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
+      "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "camelcase-css": "^2.0.1"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >= 16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.21"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-4.0.2.tgz",
+      "integrity": "sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.0.0",
+        "yaml": "^2.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      },
+      "peerDependencies": {
+        "postcss": ">=8.0.9",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "postcss": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/postcss-nested": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
+      "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.14"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.4.tgz",
+      "integrity": "sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-remove-scroll": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+      "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.3",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-style-singleton": "^2.2.2",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/read-cache": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.2.tgz",
+      "integrity": "sha512-/peqiBB/n07gQGLsWaHho3WfvUyRscw0gYTsEFMhrIe/nWLkYaf5SbKYjGYqtRV3aPwykJgF2VEMo1ac4bnsGA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.63.1.tgz",
+      "integrity": "sha512-3Df9jsstwhccuEfmAMi9l8XUh/GOkVObmFTU7CCVBysEbcOZLl84jCtaAZMcPiMz2EGKsATzQcU+Xr3n/wU6cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.63.1",
+        "@rollup/rollup-android-arm64": "4.63.1",
+        "@rollup/rollup-darwin-arm64": "4.63.1",
+        "@rollup/rollup-darwin-x64": "4.63.1",
+        "@rollup/rollup-freebsd-arm64": "4.63.1",
+        "@rollup/rollup-freebsd-x64": "4.63.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.63.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.63.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.63.1",
+        "@rollup/rollup-linux-arm64-musl": "4.63.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.63.1",
+        "@rollup/rollup-linux-loong64-musl": "4.63.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.63.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.63.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.63.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.63.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.63.1",
+        "@rollup/rollup-linux-x64-gnu": "4.63.1",
+        "@rollup/rollup-linux-x64-musl": "4.63.1",
+        "@rollup/rollup-openbsd-x64": "4.63.1",
+        "@rollup/rollup-openharmony-arm64": "4.63.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.63.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.63.1",
+        "@rollup/rollup-win32-x64-gnu": "4.63.1",
+        "@rollup/rollup-win32-x64-msvc": "4.63.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tailwind-merge": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.6.1.tgz",
+      "integrity": "sha512-Oo6tHdpZsGpkKG88HJ8RR1rg/RdnEkQEfMoEk2x1XRI3F1AxeU+ijRXpiVUF4UbLfcxxRGw6TbUINKYdWVsQTQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "3.4.17",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
+      "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "arg": "^5.0.2",
+        "chokidar": "^3.6.0",
+        "didyoumean": "^1.2.2",
+        "dlv": "^1.1.3",
+        "fast-glob": "^3.3.2",
+        "glob-parent": "^6.0.2",
+        "is-glob": "^4.0.3",
+        "jiti": "^1.21.6",
+        "lilconfig": "^3.1.3",
+        "micromatch": "^4.0.8",
+        "normalize-path": "^3.0.0",
+        "object-hash": "^3.0.0",
+        "picocolors": "^1.1.1",
+        "postcss": "^8.4.47",
+        "postcss-import": "^15.1.0",
+        "postcss-js": "^4.0.1",
+        "postcss-load-config": "^4.0.2",
+        "postcss-nested": "^6.2.0",
+        "postcss-selector-parser": "^6.1.2",
+        "resolve": "^1.22.8",
+        "sucrase": "^3.35.0"
+      },
+      "bin": {
+        "tailwind": "lib/cli.js",
+        "tailwindcss": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tailwindcss-animate": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/tailwindcss-animate/-/tailwindcss-animate-1.0.7.tgz",
+      "integrity": "sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || insiders"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.2.tgz",
+      "integrity": "sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "5.4.11",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.11.tgz",
+      "integrity": "sha512-c7jFQRklXua0mTzneGW9QVyxFjUgwcihC4bXEtujIo2ouWCe1Ajt/amn2PCxYnhYfd5k09JX3SB7OYWFKYqj8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    }
+  }
+}

--- a/os/axvisor/web-ui/package.json
+++ b/os/axvisor/web-ui/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "axvisor-web-ui",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "engines": {
+    "node": ">=24",
+    "npm": ">=11.12.1"
+  },
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc --noEmit && vite build",
+    "preview": "vite preview",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@radix-ui/react-dialog": "^1.1.4",
+    "@radix-ui/react-slot": "^1.3.3",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "lucide-react": "^0.469.0",
+    "react": "18.3.1",
+    "react-dom": "18.3.1",
+    "tailwind-merge": "^2.6.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.5",
+    "@types/react": "^18.3.18",
+    "@types/react-dom": "^18.3.5",
+    "@vitejs/plugin-react": "^4.3.4",
+    "autoprefixer": "^10.4.20",
+    "postcss": "^8.4.49",
+    "tailwindcss": "3.4.17",
+    "tailwindcss-animate": "^1.0.7",
+    "typescript": "5.6.3",
+    "vite": "5.4.11",
+    "vitest": "^2.1.8"
+  }
+}

--- a/os/axvisor/web-ui/postcss.config.js
+++ b/os/axvisor/web-ui/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/os/axvisor/web-ui/src/api/auth.ts
+++ b/os/axvisor/web-ui/src/api/auth.ts
@@ -1,9 +1,13 @@
-//! Token 校验：整个前端唯一一处判断「这个 token 后端收不收」的地方。
+//! Token verification: the single place in the frontend that decides whether the
+//! backend accepts this token.
 //!
-//! 探测端点来自 manifest 的 `auth` 节点（见 types.ts 的 AuthProbe），所以这里
-//! 不写死路径，也不依赖具体资源。token 门与面板的危险操作都调这里，避免各写一套。
+//! The probe endpoint comes from the manifest's `auth` node (see AuthProbe in
+//! types.ts), so the path is not hardcoded here and the module does not depend on
+//! any specific resource. Both the token gate and a panel's danger confirmation
+//! call this, instead of each rolling its own check.
 //!
-//! 校验与「是否已登录」是两件事：本模块只回答 token 本身是否可用。
+//! Verification and "already signed in" are two different questions: this module
+//! only answers whether the token itself is usable.
 
 import type { AuthProbe } from './types'
 
@@ -11,7 +15,7 @@ export type TokenVerdict =
   | { ok: true }
   | { ok: false; reason: string }
 
-/** 探测一次 token。只有后端明确接受才算通过；网络错误不当作通过。 */
+/** Probes the token once. Only an explicit backend accept counts; network errors are not treated as success. */
 export async function verifyToken(
   auth: AuthProbe,
   token: string,
@@ -24,7 +28,8 @@ export async function verifyToken(
       signal,
     })
   } catch (e: unknown) {
-    // 管理接口没起来 / 被网络挡住：如实说，不冒充「token 错误」
+    // Management API down or blocked by the network: say so instead of
+    // masquerading as "wrong token".
     return { ok: false, reason: `无法连接管理接口（${auth.href}）：${String(e)}` }
   }
 

--- a/os/axvisor/web-ui/src/api/auth.ts
+++ b/os/axvisor/web-ui/src/api/auth.ts
@@ -1,0 +1,36 @@
+//! Token 校验：整个前端唯一一处判断「这个 token 后端收不收」的地方。
+//!
+//! 探测端点来自 manifest 的 `auth` 节点（见 types.ts 的 AuthProbe），所以这里
+//! 不写死路径，也不依赖具体资源。token 门与面板的危险操作都调这里，避免各写一套。
+//!
+//! 校验与「是否已登录」是两件事：本模块只回答 token 本身是否可用。
+
+import type { AuthProbe } from './types'
+
+export type TokenVerdict =
+  | { ok: true }
+  | { ok: false; reason: string }
+
+/** 探测一次 token。只有后端明确接受才算通过；网络错误不当作通过。 */
+export async function verifyToken(
+  auth: AuthProbe,
+  token: string,
+  signal?: AbortSignal,
+): Promise<TokenVerdict> {
+  let response: Response
+  try {
+    response = await fetch(auth.href, {
+      headers: { Authorization: `${auth.scheme} ${token}` },
+      signal,
+    })
+  } catch (e: unknown) {
+    // 管理接口没起来 / 被网络挡住：如实说，不冒充「token 错误」
+    return { ok: false, reason: `无法连接管理接口（${auth.href}）：${String(e)}` }
+  }
+
+  if (response.ok) return { ok: true }
+  if (response.status === 401 || response.status === 403) {
+    return { ok: false, reason: 'token 未被接受（与构建时的 AXVM_HTTP_TOKEN 不一致）' }
+  }
+  return { ok: false, reason: `校验请求返回 HTTP ${response.status}` }
+}

--- a/os/axvisor/web-ui/src/api/client.ts
+++ b/os/axvisor/web-ui/src/api/client.ts
@@ -1,18 +1,19 @@
-//! REST client。
+//! REST client.
 //!
-//! - baseUrl 用相对路径（不变量 10）：dev 靠 vite 代理，build 产物同源直连，
-//!   同一份 dist 在多形态下通用。
-//! - 后端写路由要 `Authorization: Bearer <构建时 AXVM_HTTP_TOKEN>`；GET 开放，
-//!   带上无妨。
-//! - 错误响应体为空（只回状态码），所以 ApiError 只带状态码，文案由
-//!   `describeError` 的状态码映射负责。
+//! - Base URLs are relative (invariant 10): dev goes through the vite proxy while
+//!   the build output is served same-origin, so one dist serves every form.
+//! - Backend write routes require `Authorization: Bearer <build-time AXVM_HTTP_TOKEN>`;
+//!   GET is open, and sending the header anyway is harmless.
+//! - Error responses carry an empty body (status code only), so ApiError carries
+//!   just the status and `describeError` maps it to readable text.
 
 import { useRef } from 'react'
 import { ApiError } from './types'
 
 export class ApiClient {
-  // scheme 默认 Bearer，但优先用 manifest 声明的 auth.scheme（见 types.ts 的 AuthProbe），
-  // 与 api/auth.ts 的探测保持一致——不再写死。
+  // Defaults to Bearer, but prefers the auth.scheme declared by the manifest (see
+  // AuthProbe in types.ts) so it stays consistent with the api/auth.ts probe —
+  // the scheme is no longer hardcoded.
   constructor(
     private readonly getToken: () => string,
     private readonly getScheme: () => string = () => 'Bearer',
@@ -22,12 +23,12 @@ export class ApiClient {
     return this.request<T>('GET', path, undefined, signal)
   }
 
-  /** 生命周期动作（start/stop/pause/resume）没有请求体。 */
+  /** Lifecycle actions (start/stop/pause/resume) carry no request body. */
   post<T>(path: string, body?: unknown, signal?: AbortSignal): Promise<T> {
     return this.request<T>('POST', path, body, signal)
   }
 
-  /** 删除成功是 204 无响应体，调用方拿不到 JSON。 */
+  /** A successful delete is 204 with no body, so the caller gets no JSON back. */
   delete<T = void>(path: string, signal?: AbortSignal): Promise<T> {
     return this.request<T>('DELETE', path, undefined, signal)
   }
@@ -48,7 +49,8 @@ export class ApiClient {
     }
 
     const res = await fetch(path, init)
-    // 不变量 11：body 只读一次——204/空 body 与 JSON 都从这一份文本派生。
+    // Invariant 11: the body is read exactly once — 204/empty bodies and JSON are
+    // both derived from this single piece of text.
     const raw = await res.text()
     if (!res.ok) {
       throw new ApiError(res.status, raw.trim())
@@ -58,8 +60,9 @@ export class ApiClient {
 }
 
 /**
- * 不变量 12：client 只在 ref 为 null 时构造一次，不随每次渲染重建；
- * token 经 getter 读取，配合 tokenRef 每次渲染刷新，读到的永远是最新的。
+ * Invariant 12: the client is constructed once, only when the ref is null, rather
+ * than rebuilt on every render; the token is read through a getter backed by
+ * tokenRef refreshed each render, so it always observes the latest value.
  */
 export function useApiClient(token: string, scheme?: string): ApiClient {
   const clientRef = useRef<ApiClient | null>(null)
@@ -69,7 +72,8 @@ export function useApiClient(token: string, scheme?: string): ApiClient {
   schemeRef.current = scheme
 
   if (clientRef.current === null) {
-    // scheme 经 getter 读取：与 token 一样，每次请求都取最新（manifest 可能晚到）。
+    // The scheme is read through a getter too: like the token, every request picks
+    // up the latest value (the manifest may arrive late).
     clientRef.current = new ApiClient(
       () => tokenRef.current,
       () => schemeRef.current ?? 'Bearer',

--- a/os/axvisor/web-ui/src/api/client.ts
+++ b/os/axvisor/web-ui/src/api/client.ts
@@ -11,7 +11,12 @@ import { useRef } from 'react'
 import { ApiError } from './types'
 
 export class ApiClient {
-  constructor(private readonly getToken: () => string) {}
+  // scheme 默认 Bearer，但优先用 manifest 声明的 auth.scheme（见 types.ts 的 AuthProbe），
+  // 与 api/auth.ts 的探测保持一致——不再写死。
+  constructor(
+    private readonly getToken: () => string,
+    private readonly getScheme: () => string = () => 'Bearer',
+  ) {}
 
   get<T>(path: string, signal?: AbortSignal): Promise<T> {
     return this.request<T>('GET', path, undefined, signal)
@@ -33,7 +38,9 @@ export class ApiClient {
     body: unknown,
     signal?: AbortSignal,
   ): Promise<T> {
-    const headers: Record<string, string> = { Authorization: `Bearer ${this.getToken()}` }
+    const headers: Record<string, string> = {
+      Authorization: `${this.getScheme()} ${this.getToken()}`,
+    }
     const init: RequestInit = { method, headers, signal }
     if (body !== undefined) {
       headers['Content-Type'] = 'application/json'
@@ -54,13 +61,19 @@ export class ApiClient {
  * 不变量 12：client 只在 ref 为 null 时构造一次，不随每次渲染重建；
  * token 经 getter 读取，配合 tokenRef 每次渲染刷新，读到的永远是最新的。
  */
-export function useApiClient(token: string): ApiClient {
+export function useApiClient(token: string, scheme?: string): ApiClient {
   const clientRef = useRef<ApiClient | null>(null)
   const tokenRef = useRef(token)
   tokenRef.current = token
+  const schemeRef = useRef(scheme)
+  schemeRef.current = scheme
 
   if (clientRef.current === null) {
-    clientRef.current = new ApiClient(() => tokenRef.current)
+    // scheme 经 getter 读取：与 token 一样，每次请求都取最新（manifest 可能晚到）。
+    clientRef.current = new ApiClient(
+      () => tokenRef.current,
+      () => schemeRef.current ?? 'Bearer',
+    )
   }
   return clientRef.current
 }

--- a/os/axvisor/web-ui/src/api/client.ts
+++ b/os/axvisor/web-ui/src/api/client.ts
@@ -1,0 +1,66 @@
+//! REST client。
+//!
+//! - baseUrl 用相对路径（不变量 10）：dev 靠 vite 代理，build 产物同源直连，
+//!   同一份 dist 在多形态下通用。
+//! - 后端写路由要 `Authorization: Bearer <构建时 AXVM_HTTP_TOKEN>`；GET 开放，
+//!   带上无妨。
+//! - 错误响应体为空（只回状态码），所以 ApiError 只带状态码，文案由
+//!   `describeError` 的状态码映射负责。
+
+import { useRef } from 'react'
+import { ApiError } from './types'
+
+export class ApiClient {
+  constructor(private readonly getToken: () => string) {}
+
+  get<T>(path: string, signal?: AbortSignal): Promise<T> {
+    return this.request<T>('GET', path, undefined, signal)
+  }
+
+  /** 生命周期动作（start/stop/pause/resume）没有请求体。 */
+  post<T>(path: string, body?: unknown, signal?: AbortSignal): Promise<T> {
+    return this.request<T>('POST', path, body, signal)
+  }
+
+  /** 删除成功是 204 无响应体，调用方拿不到 JSON。 */
+  delete<T = void>(path: string, signal?: AbortSignal): Promise<T> {
+    return this.request<T>('DELETE', path, undefined, signal)
+  }
+
+  private async request<T>(
+    method: 'GET' | 'POST' | 'DELETE',
+    path: string,
+    body: unknown,
+    signal?: AbortSignal,
+  ): Promise<T> {
+    const headers: Record<string, string> = { Authorization: `Bearer ${this.getToken()}` }
+    const init: RequestInit = { method, headers, signal }
+    if (body !== undefined) {
+      headers['Content-Type'] = 'application/json'
+      init.body = JSON.stringify(body)
+    }
+
+    const res = await fetch(path, init)
+    // 不变量 11：body 只读一次——204/空 body 与 JSON 都从这一份文本派生。
+    const raw = await res.text()
+    if (!res.ok) {
+      throw new ApiError(res.status, raw.trim())
+    }
+    return (raw ? JSON.parse(raw) : undefined) as T
+  }
+}
+
+/**
+ * 不变量 12：client 只在 ref 为 null 时构造一次，不随每次渲染重建；
+ * token 经 getter 读取，配合 tokenRef 每次渲染刷新，读到的永远是最新的。
+ */
+export function useApiClient(token: string): ApiClient {
+  const clientRef = useRef<ApiClient | null>(null)
+  const tokenRef = useRef(token)
+  tokenRef.current = token
+
+  if (clientRef.current === null) {
+    clientRef.current = new ApiClient(() => tokenRef.current)
+  }
+  return clientRef.current
+}

--- a/os/axvisor/web-ui/src/api/feed.ts
+++ b/os/axvisor/web-ui/src/api/feed.ts
@@ -1,0 +1,59 @@
+//! 壳级资源快照。
+//!
+//! 本期后端没有 `/ws/events` 事件流，先按固定周期轮询资源根，并暴露
+//! `{vms, live, refresh}`。接口刻意对齐将来的事件订阅实现，届时只换本文件
+//! 的内部实现（轮询 → 订阅），壳与面板零改动。
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import type { ApiClient } from './client'
+import type { VmInfo } from './types'
+
+const POLL_INTERVAL_MS = 2000
+
+export interface VmFeed {
+  vms: VmInfo[]
+  /** 最近一次轮询是否成功。false 时壳显示「轮询中」，不代表数据已清空。 */
+  live: boolean
+  /** 变更操作收口后调用，立刻重取一次快照。 */
+  refresh: () => void
+}
+
+export function useVmFeed(api: ApiClient, href: string | null): VmFeed {
+  const [vms, setVms] = useState<VmInfo[]>([])
+  const [live, setLive] = useState(false)
+  const [generation, setGeneration] = useState(0)
+  const inFlight = useRef(false)
+
+  const refresh = useCallback(() => setGeneration((g) => g + 1), [])
+
+  useEffect(() => {
+    if (href === null) return
+    let stopped = false
+
+    const tick = async () => {
+      // 上一请求未返回则跳过本 tick，不排队堆积
+      if (inFlight.current) return
+      inFlight.current = true
+      try {
+        const list = await api.get<VmInfo[]>(href)
+        if (!stopped) {
+          setVms(list)
+          setLive(true)
+        }
+      } catch {
+        if (!stopped) setLive(false)
+      } finally {
+        inFlight.current = false
+      }
+    }
+
+    void tick()
+    const timer = window.setInterval(() => void tick(), POLL_INTERVAL_MS)
+    return () => {
+      stopped = true
+      window.clearInterval(timer)
+    }
+  }, [api, href, generation])
+
+  return { vms, live, refresh }
+}

--- a/os/axvisor/web-ui/src/api/feed.ts
+++ b/os/axvisor/web-ui/src/api/feed.ts
@@ -1,8 +1,10 @@
-//! 壳级资源快照。
+//! Shell-level resource snapshot.
 //!
-//! 本期后端没有 `/ws/events` 事件流，先按固定周期轮询资源根，并暴露
-//! `{vms, live, refresh}`。接口刻意对齐将来的事件订阅实现，届时只换本文件
-//! 的内部实现（轮询 → 订阅），壳与面板零改动。
+//! The backend has no `/ws/events` stream yet, so this polls the resource root on
+//! a fixed interval and exposes `{vms, live, refresh}`. The interface is
+//! deliberately shaped like the future event subscription: when that lands, only
+//! the internals of this file change (polling -> subscription) and the shell and
+//! panels stay untouched.
 
 import { useCallback, useEffect, useRef, useState } from 'react'
 import type { ApiClient } from './client'
@@ -12,9 +14,9 @@ const POLL_INTERVAL_MS = 2000
 
 export interface VmFeed {
   vms: VmInfo[]
-  /** 最近一次轮询是否成功。false 时壳显示「轮询中」，不代表数据已清空。 */
+  /** Whether the most recent poll succeeded. When false the shell shows "polling"; it does not mean the data was cleared. */
   live: boolean
-  /** 变更操作收口后调用，立刻重取一次快照。 */
+  /** Call once a mutating operation settles, to refetch the snapshot immediately. */
   refresh: () => void
 }
 
@@ -31,7 +33,7 @@ export function useVmFeed(api: ApiClient, href: string | null): VmFeed {
     let stopped = false
 
     const tick = async () => {
-      // 上一请求未返回则跳过本 tick，不排队堆积
+      // Skip this tick if the previous request has not returned; never queue up.
       if (inFlight.current) return
       inFlight.current = true
       try {

--- a/os/axvisor/web-ui/src/api/types.ts
+++ b/os/axvisor/web-ui/src/api/types.ts
@@ -1,0 +1,112 @@
+//! 前后端契约类型：manifest / 面板渲染器契约 / VM 摘要 / 错误对象。
+//! shell/ 只依赖这里，不依赖 panels/（不变量 5）。
+
+import type { ComponentType } from 'react'
+import type { ApiClient } from './client'
+
+/**
+ * manifest 里的一个资源族节点。
+ * `href` 是该资源的根，create/详情/动作路由都由它派生（href + "/{id}" 等）——
+ * 面板不得硬编码端点。
+ */
+export interface ResourceMeta {
+  kind: string
+  title: string
+  href: string
+  verbs: string[]
+}
+
+/** 后端 manifest（`GET /api/`）：proto 之后只增不改，老前端对未知字段降级。 */
+export interface Manifest {
+  proto: number
+  resources: ResourceMeta[]
+}
+
+/** 每个面板拿到的上下文：manifest 节点 + REST client + 壳级资源快照。
+ *  resources/refresh 是壳级轮询快照的注入——资源型面板（vms）使用，其它面板忽略。 */
+export interface PanelProps {
+  meta: ResourceMeta
+  token: string
+  api: ApiClient
+  resources?: VmInfo[]
+  focusVm?: number | null
+  /** 变更操作收口后立即刷新壳级快照。 */
+  refresh?: () => void
+}
+
+export type PanelComponent = ComponentType<PanelProps>
+
+/** 注册表契约。具体实现在 panels/registry.ts，由入口注入进壳。 */
+export interface PanelRegistry {
+  resolve(kind: string): PanelComponent
+}
+
+/** VM 摘要（`GET /api/vms` 的元素）。status 是不透明字符串：后端可以比前端新。 */
+export interface VmInfo {
+  id: number
+  name?: string
+  status: string
+  cpu_num?: number
+  memory_mb?: number
+}
+
+/** VM 详情（`GET /api/vms/{id}`）：摘要 + vCPU 状态与两个单调计数器。 */
+export interface VmDetail extends VmInfo {
+  vcpu_states?: string[]
+  /** vCPU 真正进入 guest 的次数（start/resume 的终态证据）。 */
+  guest_entry_count?: number
+  /** vCPU 真正 park 的次数（pause 的终态证据）。 */
+  guest_park_count?: number
+}
+
+/**
+ * 已知状态的中文文案。`describeStatus` 对未知值原样返回，
+ * 所以后端新增状态时界面降级显示而不是崩。
+ */
+const STATUS_TEXT: Record<string, string> = {
+  ready: '就绪',
+  running: '运行中',
+  pausing: '暂停中…',
+  paused: '已暂停',
+  stopping: '停止中…',
+  stopped: '已停止',
+  destroying: '销毁中…',
+  destroyed: '已销毁',
+  failed: '失败',
+}
+
+export function describeStatus(status: string): string {
+  return STATUS_TEXT[status] ?? status
+}
+
+/**
+ * 错误对象携带 HTTP 状态码。后端错误响应体为空（只回状态码），
+ * 所以可读文案来自下面的映射表。
+ */
+export class ApiError extends Error {
+  readonly status: number
+  readonly detail: string
+
+  constructor(status: number, detail: string) {
+    super(`HTTP ${status} · ${detail}`)
+    this.status = status
+    this.detail = detail
+  }
+}
+
+const STATUS_HINT: Record<number, string> = {
+  400: '请求不合法',
+  401: 'token 缺失或不匹配（构建时的 AXVM_HTTP_TOKEN）',
+  404: 'VM 不存在',
+  409: '当前状态不允许该操作',
+  500: '宿主错误，可查串口日志',
+  503: '宿主资源不足',
+}
+
+export function describeError(e: unknown): string {
+  if (e instanceof ApiError) {
+    const hint = STATUS_HINT[e.status] ?? '请求失败'
+    return e.detail ? `HTTP ${e.status} · ${e.detail}` : `HTTP ${e.status} · ${hint}`
+  }
+  return e instanceof Error ? e.message : String(e)
+}

--- a/os/axvisor/web-ui/src/api/types.ts
+++ b/os/axvisor/web-ui/src/api/types.ts
@@ -16,9 +16,20 @@ export interface ResourceMeta {
   verbs: string[]
 }
 
+/**
+ * manifest 声明的鉴权方式与 token 探测路径。
+ * 客户端从这里取探测端点，不硬编码——后端换路径前端不必改。
+ */
+export interface AuthProbe {
+  href: string
+  scheme: string
+}
+
 /** 后端 manifest（`GET /api/`）：proto 之后只增不改，老前端对未知字段降级。 */
 export interface Manifest {
   proto: number
+  /** 可选：后端未声明时前端只能退化为「写入时才校验」。 */
+  auth?: AuthProbe
   resources: ResourceMeta[]
 }
 
@@ -29,9 +40,9 @@ export interface PanelProps {
   token: string
   api: ApiClient
   resources?: VmInfo[]
-  focusVm?: number | null
-  /** 变更操作收口后立即刷新壳级快照。 */
   refresh?: () => void
+  /** manifest 声明的鉴权方式；面板做危险操作确认时用它校验重输的 token。 */
+  auth?: AuthProbe
 }
 
 export type PanelComponent = ComponentType<PanelProps>

--- a/os/axvisor/web-ui/src/api/types.ts
+++ b/os/axvisor/web-ui/src/api/types.ts
@@ -1,13 +1,15 @@
-//! 前后端契约类型：manifest / 面板渲染器契约 / VM 摘要 / 错误对象。
-//! shell/ 只依赖这里，不依赖 panels/（不变量 5）。
+//! Contract types shared by the backend and the frontend: the manifest, the
+//! panel renderer contract, the VM summary, and the error object.
+//! shell/ depends only on this module, never on panels/ (invariant 5).
 
 import type { ComponentType } from 'react'
 import type { ApiClient } from './client'
 
 /**
- * manifest 里的一个资源族节点。
- * `href` 是该资源的根，create/详情/动作路由都由它派生（href + "/{id}" 等）——
- * 面板不得硬编码端点。
+ * One resource family node from the manifest.
+ * `href` is the root of the resource; the create, detail and action routes are
+ * all derived from it (href + "/{id}" and so on) — panels must not hardcode
+ * endpoints.
  */
 export interface ResourceMeta {
   kind: string
@@ -17,42 +19,43 @@ export interface ResourceMeta {
 }
 
 /**
- * manifest 声明的鉴权方式与 token 探测路径。
- * 客户端从这里取探测端点，不硬编码——后端换路径前端不必改。
+ * The auth scheme and token probe path declared by the manifest.
+ * The client reads the probe endpoint from here instead of hardcoding it, so the
+ * backend can move the path without a frontend change.
  */
 export interface AuthProbe {
   href: string
   scheme: string
 }
 
-/** 后端 manifest（`GET /api/`）：proto 之后只增不改，老前端对未知字段降级。 */
+/** Backend manifest (`GET /api/`): additive after `proto`, so an older frontend degrades on unknown fields. */
 export interface Manifest {
   proto: number
-  /** 可选：后端未声明时前端只能退化为「写入时才校验」。 */
+  /** Optional: when the backend omits it, the frontend can only fall back to validating on write. */
   auth?: AuthProbe
   resources: ResourceMeta[]
 }
 
-/** 每个面板拿到的上下文：manifest 节点 + REST client + 壳级资源快照。
- *  resources/refresh 是壳级轮询快照的注入——资源型面板（vms）使用，其它面板忽略。 */
+/** Context handed to every panel: manifest node + REST client + shell-level resource snapshot.
+ *  resources/refresh inject the shell polling snapshot — resource panels (vms) use them, other panels ignore them. */
 export interface PanelProps {
   meta: ResourceMeta
   token: string
   api: ApiClient
   resources?: VmInfo[]
   refresh?: () => void
-  /** manifest 声明的鉴权方式；面板做危险操作确认时用它校验重输的 token。 */
+  /** Auth scheme declared by the manifest; a panel uses it to re-verify the token retyped in a danger confirmation. */
   auth?: AuthProbe
 }
 
 export type PanelComponent = ComponentType<PanelProps>
 
-/** 注册表契约。具体实现在 panels/registry.ts，由入口注入进壳。 */
+/** Registry contract. The implementation lives in panels/registry.ts and is injected into the shell by the entry point. */
 export interface PanelRegistry {
   resolve(kind: string): PanelComponent
 }
 
-/** VM 摘要（`GET /api/vms` 的元素）。status 是不透明字符串：后端可以比前端新。 */
+/** VM summary (an element of `GET /api/vms`). status is an opaque string: the backend may be newer than the frontend. */
 export interface VmInfo {
   id: number
   name?: string
@@ -61,18 +64,18 @@ export interface VmInfo {
   memory_mb?: number
 }
 
-/** VM 详情（`GET /api/vms/{id}`）：摘要 + vCPU 状态与两个单调计数器。 */
+/** VM detail (`GET /api/vms/{id}`): the summary plus vCPU states and two monotonic counters. */
 export interface VmDetail extends VmInfo {
   vcpu_states?: string[]
-  /** vCPU 真正进入 guest 的次数（start/resume 的终态证据）。 */
+  /** Times a vCPU really entered the guest (terminal-state evidence for start/resume). */
   guest_entry_count?: number
-  /** vCPU 真正 park 的次数（pause 的终态证据）。 */
+  /** Times a vCPU really parked (terminal-state evidence for pause). */
   guest_park_count?: number
 }
 
 /**
- * 已知状态的中文文案。`describeStatus` 对未知值原样返回，
- * 所以后端新增状态时界面降级显示而不是崩。
+ * Display text for the known statuses. `describeStatus` returns unknown values
+ * verbatim, so a new backend status degrades to plain text instead of crashing.
  */
 const STATUS_TEXT: Record<string, string> = {
   ready: '就绪',
@@ -91,8 +94,8 @@ export function describeStatus(status: string): string {
 }
 
 /**
- * 错误对象携带 HTTP 状态码。后端错误响应体为空（只回状态码），
- * 所以可读文案来自下面的映射表。
+ * Error object carrying the HTTP status. Backend error responses carry an empty
+ * body (status code only), so the readable text comes from the table below.
  */
 export class ApiError extends Error {
   readonly status: number

--- a/os/axvisor/web-ui/src/api/types.ts
+++ b/os/axvisor/web-ui/src/api/types.ts
@@ -107,7 +107,7 @@ export class ApiError extends Error {
 
 const STATUS_HINT: Record<number, string> = {
   400: '请求不合法',
-  401: 'token 缺失或不匹配：用右上角「重设 token」重新输入构建时的 AXVM_HTTP_TOKEN',  404: 'VM 不存在',
+  401: 'token 缺失或不匹配：token 已失效，请刷新页面用构建时的 AXVM_HTTP_TOKEN 重新登录',  404: 'VM 不存在',
   409: '当前状态不允许该操作',
   500: '宿主错误，可查串口日志',
   503: '宿主资源不足',

--- a/os/axvisor/web-ui/src/api/types.ts
+++ b/os/axvisor/web-ui/src/api/types.ts
@@ -96,8 +96,7 @@ export class ApiError extends Error {
 
 const STATUS_HINT: Record<number, string> = {
   400: '请求不合法',
-  401: 'token 缺失或不匹配（构建时的 AXVM_HTTP_TOKEN）',
-  404: 'VM 不存在',
+  401: 'token 缺失或不匹配：用右上角「重设 token」重新输入构建时的 AXVM_HTTP_TOKEN',  404: 'VM 不存在',
   409: '当前状态不允许该操作',
   500: '宿主错误，可查串口日志',
   503: '宿主资源不足',

--- a/os/axvisor/web-ui/src/components/ui/badge.tsx
+++ b/os/axvisor/web-ui/src/components/ui/badge.tsx
@@ -1,0 +1,36 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-primary text-primary-foreground hover:bg-primary/80",
+        secondary:
+          "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        destructive:
+          "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80",
+        outline: "text-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+  )
+}
+
+export { Badge, badgeVariants }

--- a/os/axvisor/web-ui/src/components/ui/button.tsx
+++ b/os/axvisor/web-ui/src/components/ui/button.tsx
@@ -1,0 +1,56 @@
+import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        destructive:
+          "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+        outline:
+          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+        secondary:
+          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-10 px-4 py-2",
+        sm: "h-9 rounded-md px-3",
+        lg: "h-11 rounded-md px-8",
+        icon: "h-10 w-10",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : "button"
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Button.displayName = "Button"
+
+export { Button, buttonVariants }

--- a/os/axvisor/web-ui/src/components/ui/card.tsx
+++ b/os/axvisor/web-ui/src/components/ui/card.tsx
@@ -1,0 +1,79 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Card = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      "rounded-lg border bg-card text-card-foreground shadow-sm",
+      className
+    )}
+    {...props}
+  />
+))
+Card.displayName = "Card"
+
+const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    {...props}
+  />
+))
+CardHeader.displayName = "CardHeader"
+
+const CardTitle = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      "text-2xl font-semibold leading-none tracking-tight",
+      className
+    )}
+    {...props}
+  />
+))
+CardTitle.displayName = "CardTitle"
+
+const CardDescription = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+CardDescription.displayName = "CardDescription"
+
+const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+))
+CardContent.displayName = "CardContent"
+
+const CardFooter = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex items-center p-6 pt-0", className)}
+    {...props}
+  />
+))
+CardFooter.displayName = "CardFooter"
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent }

--- a/os/axvisor/web-ui/src/components/ui/dialog.tsx
+++ b/os/axvisor/web-ui/src/components/ui/dialog.tsx
@@ -1,0 +1,120 @@
+import * as React from "react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { X } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Dialog = DialogPrimitive.Root
+
+const DialogTrigger = DialogPrimitive.Trigger
+
+const DialogPortal = DialogPrimitive.Portal
+
+const DialogClose = DialogPrimitive.Close
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+  />
+))
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+))
+DialogContent.displayName = DialogPrimitive.Content.displayName
+
+const DialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-1.5 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+)
+DialogHeader.displayName = "DialogHeader"
+
+const DialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+    {...props}
+  />
+)
+DialogFooter.displayName = "DialogFooter"
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn(
+      "text-lg font-semibold leading-none tracking-tight",
+      className
+    )}
+    {...props}
+  />
+))
+DialogTitle.displayName = DialogPrimitive.Title.displayName
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+DialogDescription.displayName = DialogPrimitive.Description.displayName
+
+export {
+  Dialog,
+  DialogPortal,
+  DialogOverlay,
+  DialogClose,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+}

--- a/os/axvisor/web-ui/src/components/ui/input.tsx
+++ b/os/axvisor/web-ui/src/components/ui/input.tsx
@@ -1,0 +1,22 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Input.displayName = "Input"
+
+export { Input }

--- a/os/axvisor/web-ui/src/index.css
+++ b/os/axvisor/web-ui/src/index.css
@@ -1,0 +1,39 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  :root {
+    --background: 0 0% 100%;
+    --foreground: 222.2 84% 4.9%;
+    --card: 0 0% 100%;
+    --card-foreground: 222.2 84% 4.9%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 222.2 84% 4.9%;
+    --primary: 222.2 47.4% 11.2%;
+    --primary-foreground: 210 40% 98%;
+    --secondary: 210 40% 96.1%;
+    --secondary-foreground: 222.2 47.4% 11.2%;
+    --muted: 210 40% 96.1%;
+    --muted-foreground: 215.4 16.3% 46.9%;
+    --accent: 210 40% 96.1%;
+    --accent-foreground: 222.2 47.4% 11.2%;
+    --destructive: 0 84.2% 60.2%;
+    --destructive-foreground: 210 40% 98%;
+    --border: 214.3 31.8% 91.4%;
+    --input: 214.3 31.8% 91.4%;
+    --ring: 222.2 84% 4.9%;
+    --radius: 0.5rem;
+  }
+}
+
+@layer base {
+  * {
+    @apply border-border;
+  }
+  body {
+    @apply bg-background text-foreground;
+    font-family: ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto,
+      'Helvetica Neue', Arial, 'Noto Sans', sans-serif;
+  }
+}

--- a/os/axvisor/web-ui/src/lib/lifecycle.test.ts
+++ b/os/axvisor/web-ui/src/lib/lifecycle.test.ts
@@ -114,6 +114,19 @@ describe('settleToTerminalState', () => {
     expect(result.ok).toBe(false)
   })
 
+  // Regression: without a per-request signal the loop awaited a request that
+  // never settles and the deadline below was never reached, so the poll hung
+  // forever and neither the timeout message nor the caller's `busy` reset ran.
+  it('a detail request that never settles is aborted instead of hanging the poll', async () => {
+    const { deps } = fakeClock(1, 1)
+    const neverSettles = (signal?: AbortSignal) =>
+      new Promise<VmDetail>((_resolve, reject) => {
+        signal?.addEventListener('abort', () => reject(new Error('aborted at the deadline')))
+      })
+    const result = await settleToTerminalState('stop', BEFORE, neverSettles, deps)
+    expect(result.ok).toBe(false)
+  })
+
   it('a non-zero baseline is judged by the delta, not by an absolute zero', () => {
     const before: Counters = { guest_entry_count: 7, guest_park_count: 0 }
     expect(isSettled('start', before, detail('running', 7, 0))).toBe(false)

--- a/os/axvisor/web-ui/src/lib/lifecycle.test.ts
+++ b/os/axvisor/web-ui/src/lib/lifecycle.test.ts
@@ -1,7 +1,9 @@
-//! 生命周期收口的确定性单测。
+//! Deterministic unit tests for lifecycle settling.
 //!
-//! 断言纪律与 `http_probe.py` 一致：200 不代表终态，要靠轮询详情里的计数增长
-//! 或状态到达来证明。这里用注入的假时钟把「何时算收口、何时算超时」钉死。
+//! The assertion discipline matches `http_probe.py`: a 200 does not mean the terminal
+//! state was reached — it has to be proven by a growing counter or a settled status in
+//! the polled detail. An injected fake clock pins down what counts as settled and what
+//! counts as a timeout.
 
 import { describe, expect, it } from 'vitest'
 import { ApiError, describeError, describeStatus, type VmDetail } from '@/api/types'
@@ -19,7 +21,7 @@ function detail(status: string, entry = 0, park = 0): VmDetail {
   return { id: 1, status, guest_entry_count: entry, guest_park_count: park }
 }
 
-/** 假时钟：每次 sleep 前进一个周期，并在超时前让序列走完。 */
+/** Fake clock: every sleep advances one interval, letting the sequence run out before the timeout. */
 function fakeClock(intervalMs = 100, timeoutMs = 1000) {
   let now = 0
   return {
@@ -34,7 +36,7 @@ function fakeClock(intervalMs = 100, timeoutMs = 1000) {
   }
 }
 
-/** 依次返回给定观测序列，用尽后重复最后一个（模拟状态不再变化）。 */
+/** Yields the given observation sequence, then repeats the last one (simulating a status that stops changing). */
 function sequenceFetcher(observations: VmDetail[]) {
   let index = 0
   return async () => {
@@ -50,43 +52,43 @@ async function settle(op: LifecycleOp, observations: VmDetail[], before = BEFORE
 }
 
 describe('isSettled', () => {
-  it('start 只有在 vCPU 真正进入 guest 后才算收口', () => {
+  it('start settles only after a vCPU really entered the guest', () => {
     expect(isSettled('start', BEFORE, detail('running', 0, 0))).toBe(false)
     expect(isSettled('start', BEFORE, detail('running', 1, 0))).toBe(true)
   })
 
-  it('pause 只有在 vCPU 真正 park 后才算收口', () => {
+  it('pause settles only after a vCPU really parked', () => {
     expect(isSettled('pause', BEFORE, detail('paused', 0, 0))).toBe(false)
     expect(isSettled('pause', BEFORE, detail('paused', 0, 1))).toBe(true)
   })
 
-  it('resume 与 start 同判据', () => {
+  it('resume shares the start predicate', () => {
     expect(isSettled('resume', BEFORE, detail('running', 0, 0))).toBe(false)
     expect(isSettled('resume', BEFORE, detail('running', 1, 0))).toBe(true)
   })
 
-  it('stop 只需到达 stopped（异步，vCPU 退出后才成立）', () => {
+  it('stop only needs to reach stopped (async, holds once the vCPU exits)', () => {
     expect(isSettled('stop', BEFORE, detail('stopping'))).toBe(false)
     expect(isSettled('stop', BEFORE, detail('stopped'))).toBe(true)
   })
 
-  it('create 只需到达 ready', () => {
+  it('create only needs to reach ready', () => {
     expect(isSettled('create', BEFORE, detail('created'))).toBe(false)
     expect(isSettled('create', BEFORE, detail('ready'))).toBe(true)
   })
 
-  it('delete 没有可断言的状态，由 404 判定', () => {
+  it('delete has no assertable status; a 404 decides it', () => {
     expect(isSettled('delete', BEFORE, detail('stopped'))).toBe(false)
   })
 })
 
 describe('settleToTerminalState', () => {
-  it('轮询到计数增长为止', async () => {
+  it('polls until the counter grows', async () => {
     const result = await settle('start', [detail('running', 0), detail('running', 1)])
     expect(result.ok).toBe(true)
   })
 
-  it('计数不增长时超时，并保留最后一次观测', async () => {
+  it('times out when the counter does not grow, keeping the last observation', async () => {
     const result = await settle('pause', [detail('paused', 0, 0)])
     expect(result.ok).toBe(false)
     if (result.ok) return
@@ -95,7 +97,7 @@ describe('settleToTerminalState', () => {
     expect(result.message).toContain('park=0')
   })
 
-  it('delete 遇到 404 视为成功', async () => {
+  it('delete treats a 404 as success', async () => {
     const { deps } = fakeClock()
     const fetchDetail = async () => {
       throw new ApiError(404, '')
@@ -103,7 +105,7 @@ describe('settleToTerminalState', () => {
     expect((await settleToTerminalState('delete', BEFORE, fetchDetail, deps)).ok).toBe(true)
   })
 
-  it('delete 的 404 之外的错误继续轮询到超时', async () => {
+  it('errors other than 404 keep delete polling until the timeout', async () => {
     const { deps } = fakeClock()
     const fetchDetail = async () => {
       throw new ApiError(500, '')
@@ -112,7 +114,7 @@ describe('settleToTerminalState', () => {
     expect(result.ok).toBe(false)
   })
 
-  it('基线非零时按增量判断，而不是按绝对值为零', () => {
+  it('a non-zero baseline is judged by the delta, not by an absolute zero', () => {
     const before: Counters = { guest_entry_count: 7, guest_park_count: 0 }
     expect(isSettled('start', before, detail('running', 7, 0))).toBe(false)
     expect(isSettled('start', before, detail('running', 8, 0))).toBe(true)
@@ -120,18 +122,18 @@ describe('settleToTerminalState', () => {
 })
 
 describe('countersOf', () => {
-  it('缺失字段按 0 处理', () => {
+  it('missing fields are treated as 0', () => {
     expect(countersOf({ id: 1, status: 'ready' })).toEqual(BEFORE)
   })
 })
 
-describe('展示降级', () => {
-  it('未知状态原样显示而不是崩', () => {
+describe('display degradation', () => {
+  it('an unknown status is shown verbatim instead of crashing', () => {
     expect(describeStatus('running')).toBe('运行中')
     expect(describeStatus('some-future-state')).toBe('some-future-state')
   })
 
-  it('空错误体按状态码给出可读文案', () => {
+  it('an empty error body yields readable text from the status code', () => {
     expect(describeError(new ApiError(409, ''))).toBe('HTTP 409 · 当前状态不允许该操作')
     expect(describeError(new ApiError(401, ''))).toContain('AXVM_HTTP_TOKEN')
     expect(describeError(new ApiError(503, ''))).toBe('HTTP 503 · 宿主资源不足')

--- a/os/axvisor/web-ui/src/lib/lifecycle.test.ts
+++ b/os/axvisor/web-ui/src/lib/lifecycle.test.ts
@@ -1,0 +1,139 @@
+//! 生命周期收口的确定性单测。
+//!
+//! 断言纪律与 `http_probe.py` 一致：200 不代表终态，要靠轮询详情里的计数增长
+//! 或状态到达来证明。这里用注入的假时钟把「何时算收口、何时算超时」钉死。
+
+import { describe, expect, it } from 'vitest'
+import { ApiError, describeError, describeStatus, type VmDetail } from '@/api/types'
+import {
+  countersOf,
+  isSettled,
+  settleToTerminalState,
+  type Counters,
+  type LifecycleOp,
+} from '@/lib/lifecycle'
+
+const BEFORE: Counters = { guest_entry_count: 0, guest_park_count: 0 }
+
+function detail(status: string, entry = 0, park = 0): VmDetail {
+  return { id: 1, status, guest_entry_count: entry, guest_park_count: park }
+}
+
+/** 假时钟：每次 sleep 前进一个周期，并在超时前让序列走完。 */
+function fakeClock(intervalMs = 100, timeoutMs = 1000) {
+  let now = 0
+  return {
+    deps: {
+      now: () => now,
+      sleep: async () => {
+        now += intervalMs
+      },
+      intervalMs,
+      timeoutMs,
+    },
+  }
+}
+
+/** 依次返回给定观测序列，用尽后重复最后一个（模拟状态不再变化）。 */
+function sequenceFetcher(observations: VmDetail[]) {
+  let index = 0
+  return async () => {
+    const observation = observations[Math.min(index, observations.length - 1)]
+    index += 1
+    return observation
+  }
+}
+
+async function settle(op: LifecycleOp, observations: VmDetail[], before = BEFORE) {
+  const { deps } = fakeClock()
+  return settleToTerminalState(op, before, sequenceFetcher(observations), deps)
+}
+
+describe('isSettled', () => {
+  it('start 只有在 vCPU 真正进入 guest 后才算收口', () => {
+    expect(isSettled('start', BEFORE, detail('running', 0, 0))).toBe(false)
+    expect(isSettled('start', BEFORE, detail('running', 1, 0))).toBe(true)
+  })
+
+  it('pause 只有在 vCPU 真正 park 后才算收口', () => {
+    expect(isSettled('pause', BEFORE, detail('paused', 0, 0))).toBe(false)
+    expect(isSettled('pause', BEFORE, detail('paused', 0, 1))).toBe(true)
+  })
+
+  it('resume 与 start 同判据', () => {
+    expect(isSettled('resume', BEFORE, detail('running', 0, 0))).toBe(false)
+    expect(isSettled('resume', BEFORE, detail('running', 1, 0))).toBe(true)
+  })
+
+  it('stop 只需到达 stopped（异步，vCPU 退出后才成立）', () => {
+    expect(isSettled('stop', BEFORE, detail('stopping'))).toBe(false)
+    expect(isSettled('stop', BEFORE, detail('stopped'))).toBe(true)
+  })
+
+  it('create 只需到达 ready', () => {
+    expect(isSettled('create', BEFORE, detail('created'))).toBe(false)
+    expect(isSettled('create', BEFORE, detail('ready'))).toBe(true)
+  })
+
+  it('delete 没有可断言的状态，由 404 判定', () => {
+    expect(isSettled('delete', BEFORE, detail('stopped'))).toBe(false)
+  })
+})
+
+describe('settleToTerminalState', () => {
+  it('轮询到计数增长为止', async () => {
+    const result = await settle('start', [detail('running', 0), detail('running', 1)])
+    expect(result.ok).toBe(true)
+  })
+
+  it('计数不增长时超时，并保留最后一次观测', async () => {
+    const result = await settle('pause', [detail('paused', 0, 0)])
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.detail?.status).toBe('paused')
+    expect(result.message).toContain('guest_park_count')
+    expect(result.message).toContain('park=0')
+  })
+
+  it('delete 遇到 404 视为成功', async () => {
+    const { deps } = fakeClock()
+    const fetchDetail = async () => {
+      throw new ApiError(404, '')
+    }
+    expect((await settleToTerminalState('delete', BEFORE, fetchDetail, deps)).ok).toBe(true)
+  })
+
+  it('delete 的 404 之外的错误继续轮询到超时', async () => {
+    const { deps } = fakeClock()
+    const fetchDetail = async () => {
+      throw new ApiError(500, '')
+    }
+    const result = await settleToTerminalState('delete', BEFORE, fetchDetail, deps)
+    expect(result.ok).toBe(false)
+  })
+
+  it('基线非零时按增量判断，而不是按绝对值为零', () => {
+    const before: Counters = { guest_entry_count: 7, guest_park_count: 0 }
+    expect(isSettled('start', before, detail('running', 7, 0))).toBe(false)
+    expect(isSettled('start', before, detail('running', 8, 0))).toBe(true)
+  })
+})
+
+describe('countersOf', () => {
+  it('缺失字段按 0 处理', () => {
+    expect(countersOf({ id: 1, status: 'ready' })).toEqual(BEFORE)
+  })
+})
+
+describe('展示降级', () => {
+  it('未知状态原样显示而不是崩', () => {
+    expect(describeStatus('running')).toBe('运行中')
+    expect(describeStatus('some-future-state')).toBe('some-future-state')
+  })
+
+  it('空错误体按状态码给出可读文案', () => {
+    expect(describeError(new ApiError(409, ''))).toBe('HTTP 409 · 当前状态不允许该操作')
+    expect(describeError(new ApiError(401, ''))).toContain('AXVM_HTTP_TOKEN')
+    expect(describeError(new ApiError(503, ''))).toBe('HTTP 503 · 宿主资源不足')
+  })
+})

--- a/os/axvisor/web-ui/src/lib/lifecycle.ts
+++ b/os/axvisor/web-ui/src/lib/lifecycle.ts
@@ -120,11 +120,15 @@ export function timeoutMessage(
  * A 404 during polling counts as success only for delete; other errors keep polling
  * until the timeout, because one transient failure does not mean the operation had
  * no effect.
+ *
+ * Every detail request receives an AbortSignal that fires once the deadline
+ * passes, so a request that never settles cannot park the loop forever and
+ * swallow the timeout.
  */
 export async function settleToTerminalState(
   op: LifecycleOp,
   before: Counters,
-  fetchDetail: () => Promise<VmDetail>,
+  fetchDetail: (signal?: AbortSignal) => Promise<VmDetail>,
   deps: SettleDeps = defaultDeps,
 ): Promise<SettleResult> {
   const deadline = deps.now() + deps.timeoutMs
@@ -132,8 +136,15 @@ export async function settleToTerminalState(
   let lastError: unknown
 
   for (;;) {
+    const remaining = deadline - deps.now()
+    if (remaining <= 0) {
+      return { ok: false, message: timeoutMessage(op, last, lastError), detail: last }
+    }
+
+    const controller = new AbortController()
+    const abortAt = setTimeout(() => controller.abort(), Math.max(remaining, 1))
     try {
-      const detail = await fetchDetail()
+      const detail = await fetchDetail(controller.signal)
       last = detail
       lastError = undefined
       if (isSettled(op, before, detail)) {
@@ -144,6 +155,8 @@ export async function settleToTerminalState(
       if (op === 'delete' && error instanceof ApiError && error.status === 404) {
         return { ok: true }
       }
+    } finally {
+      clearTimeout(abortAt)
     }
 
     if (deps.now() >= deadline) {

--- a/os/axvisor/web-ui/src/lib/lifecycle.ts
+++ b/os/axvisor/web-ui/src/lib/lifecycle.ts
@@ -1,0 +1,149 @@
+//! 生命周期收口：**HTTP 200 只代表请求被接受，不等于到达终态**。
+//!
+//! 每个变更操作完成后轮询 VM 详情，直到断言成立或超时。断言纪律与
+//! `test-suit/axvisor/normal/qemu-http-control-plane` 的 `http_probe.py` 一致：
+//! start/resume 要 `guest_entry_count` 严格增长（vCPU 真正进入 guest），
+//! pause 要 `guest_park_count` 严格增长（vCPU 真正 park，不只是状态翻转），
+//! stop 要 `stopped`，create 要 `ready`，delete 要详情变 404。
+//!
+//! 全部是纯函数 + 注入依赖，便于用 vitest 做确定性单测。
+
+import { ApiError, type VmDetail } from '@/api/types'
+
+export type LifecycleOp = 'create' | 'start' | 'pause' | 'resume' | 'stop' | 'delete'
+
+/** 操作前的计数基线：只有需要「严格增长」证明的操作才会用到。 */
+export interface Counters {
+  guest_entry_count: number
+  guest_park_count: number
+}
+
+export const POLL_INTERVAL_MS = 500
+export const POLL_TIMEOUT_MS = 15_000
+
+export function countersOf(detail: VmDetail): Counters {
+  return {
+    guest_entry_count: detail.guest_entry_count ?? 0,
+    guest_park_count: detail.guest_park_count ?? 0,
+  }
+}
+
+/** 该操作此刻是否已到达真实终态。delete 没有可断言的状态，由 404 判定。 */
+export function isSettled(op: LifecycleOp, before: Counters, after: VmDetail): boolean {
+  switch (op) {
+    case 'start':
+    case 'resume':
+      return (
+        after.status === 'running' &&
+        (after.guest_entry_count ?? 0) > before.guest_entry_count
+      )
+    case 'pause':
+      return (
+        after.status === 'paused' && (after.guest_park_count ?? 0) > before.guest_park_count
+      )
+    case 'stop':
+      return after.status === 'stopped'
+    case 'create':
+      return after.status === 'ready'
+    case 'delete':
+      return false
+  }
+}
+
+/** 等待中的提示语，超时后随观测值一起展示。 */
+export function settleHint(op: LifecycleOp): string {
+  switch (op) {
+    case 'start':
+    case 'resume':
+      return '等待 vCPU 真正进入 guest（guest_entry_count 增长）'
+    case 'pause':
+      return '等待 vCPU 真正 park（guest_park_count 增长）'
+    case 'stop':
+      return '等待 vCPU 退出（status 变 stopped）'
+    case 'create':
+      return '等待注册完成（status 变 ready）'
+    case 'delete':
+      return '等待详情变 404'
+  }
+}
+
+export interface SettleSuccess {
+  ok: true
+  detail?: VmDetail
+}
+
+export interface SettleTimeout {
+  ok: false
+  message: string
+  /** 超时时最后一次观测到的详情；一次都没取到则为 undefined。 */
+  detail?: VmDetail
+}
+
+export type SettleResult = SettleSuccess | SettleTimeout
+
+export interface SettleDeps {
+  now: () => number
+  sleep: (ms: number) => Promise<void>
+  intervalMs: number
+  timeoutMs: number
+}
+
+const defaultDeps: SettleDeps = {
+  now: () => Date.now(),
+  sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+  intervalMs: POLL_INTERVAL_MS,
+  timeoutMs: POLL_TIMEOUT_MS,
+}
+
+/** 超时文案：如实带上已观测到的状态与计数，方便定位卡在哪一步。 */
+export function timeoutMessage(
+  op: LifecycleOp,
+  last: VmDetail | undefined,
+  lastError: unknown,
+): string {
+  const observed =
+    last === undefined
+      ? '未取到详情'
+      : `最后观测 status=${last.status} entry=${last.guest_entry_count ?? '-'} park=${last.guest_park_count ?? '-'}`
+  const failure = lastError === undefined ? '' : `（最近一次请求错误：${String(lastError)}）`
+  return `${settleHint(op)}超时：${observed}${failure}`
+}
+
+/**
+ * 轮询详情直到终态断言成立。
+ *
+ * 采样基线由调用方在动作**之前**取好并传入（`before`）。
+ * 轮询期间的 404 只对 delete 视为成功；其它错误继续轮询到超时，
+ * 因为一次瞬时失败不代表操作没有生效。
+ */
+export async function settleToTerminalState(
+  op: LifecycleOp,
+  before: Counters,
+  fetchDetail: () => Promise<VmDetail>,
+  deps: SettleDeps = defaultDeps,
+): Promise<SettleResult> {
+  const deadline = deps.now() + deps.timeoutMs
+  let last: VmDetail | undefined
+  let lastError: unknown
+
+  for (;;) {
+    try {
+      const detail = await fetchDetail()
+      last = detail
+      lastError = undefined
+      if (isSettled(op, before, detail)) {
+        return { ok: true, detail }
+      }
+    } catch (error) {
+      lastError = error
+      if (op === 'delete' && error instanceof ApiError && error.status === 404) {
+        return { ok: true }
+      }
+    }
+
+    if (deps.now() >= deadline) {
+      return { ok: false, message: timeoutMessage(op, last, lastError), detail: last }
+    }
+    await deps.sleep(deps.intervalMs)
+  }
+}

--- a/os/axvisor/web-ui/src/lib/lifecycle.ts
+++ b/os/axvisor/web-ui/src/lib/lifecycle.ts
@@ -1,18 +1,22 @@
-//! 生命周期收口：**HTTP 200 只代表请求被接受，不等于到达终态**。
+//! Lifecycle settling: **HTTP 200 only means the request was accepted, not that the
+//! terminal state was reached**.
 //!
-//! 每个变更操作完成后轮询 VM 详情，直到断言成立或超时。断言纪律与
-//! `test-suit/axvisor/normal/qemu-http-control-plane` 的 `http_probe.py` 一致：
-//! start/resume 要 `guest_entry_count` 严格增长（vCPU 真正进入 guest），
-//! pause 要 `guest_park_count` 严格增长（vCPU 真正 park，不只是状态翻转），
-//! stop 要 `stopped`，create 要 `ready`，delete 要详情变 404。
+//! After every mutating operation this polls the VM detail until the assertion holds
+//! or it times out. The assertion discipline matches `http_probe.py` in
+//! `test-suit/axvisor/normal/qemu-http-control-plane`: start/resume require
+//! `guest_entry_count` to strictly increase (a vCPU really entered the guest), pause
+//! requires `guest_park_count` to strictly increase (a vCPU really parked, not just a
+//! status flip), stop requires `stopped`, create requires `ready`, and delete requires
+//! the detail to turn 404.
 //!
-//! 全部是纯函数 + 注入依赖，便于用 vitest 做确定性单测。
+//! Everything here is a pure function with injected dependencies, so vitest can drive
+//! it deterministically.
 
 import { ApiError, type VmDetail } from '@/api/types'
 
 export type LifecycleOp = 'create' | 'start' | 'pause' | 'resume' | 'stop' | 'delete'
 
-/** 操作前的计数基线：只有需要「严格增长」证明的操作才会用到。 */
+/** Counter baseline captured before the operation; only operations proven by "strictly increased" use it. */
 export interface Counters {
   guest_entry_count: number
   guest_park_count: number
@@ -28,7 +32,7 @@ export function countersOf(detail: VmDetail): Counters {
   }
 }
 
-/** 该操作此刻是否已到达真实终态。delete 没有可断言的状态，由 404 判定。 */
+/** Whether this operation has reached its real terminal state. delete has no assertable status; a 404 decides it. */
 export function isSettled(op: LifecycleOp, before: Counters, after: VmDetail): boolean {
   switch (op) {
     case 'start':
@@ -50,7 +54,7 @@ export function isSettled(op: LifecycleOp, before: Counters, after: VmDetail): b
   }
 }
 
-/** 等待中的提示语，超时后随观测值一起展示。 */
+/** Hint shown while waiting; on timeout it is displayed together with the observed values. */
 export function settleHint(op: LifecycleOp): string {
   switch (op) {
     case 'start':
@@ -75,7 +79,7 @@ export interface SettleSuccess {
 export interface SettleTimeout {
   ok: false
   message: string
-  /** 超时时最后一次观测到的详情；一次都没取到则为 undefined。 */
+  /** Last detail observed before the timeout; undefined if none was ever fetched. */
   detail?: VmDetail
 }
 
@@ -95,7 +99,7 @@ const defaultDeps: SettleDeps = {
   timeoutMs: POLL_TIMEOUT_MS,
 }
 
-/** 超时文案：如实带上已观测到的状态与计数，方便定位卡在哪一步。 */
+/** Timeout text: reports the observed status and counters verbatim, so the stuck step is easy to locate. */
 export function timeoutMessage(
   op: LifecycleOp,
   last: VmDetail | undefined,
@@ -110,11 +114,12 @@ export function timeoutMessage(
 }
 
 /**
- * 轮询详情直到终态断言成立。
+ * Polls the detail until the terminal-state assertion holds.
  *
- * 采样基线由调用方在动作**之前**取好并传入（`before`）。
- * 轮询期间的 404 只对 delete 视为成功；其它错误继续轮询到超时，
- * 因为一次瞬时失败不代表操作没有生效。
+ * The caller samples the baseline **before** the action and passes it as `before`.
+ * A 404 during polling counts as success only for delete; other errors keep polling
+ * until the timeout, because one transient failure does not mean the operation had
+ * no effect.
  */
 export async function settleToTerminalState(
   op: LifecycleOp,

--- a/os/axvisor/web-ui/src/lib/utils.ts
+++ b/os/axvisor/web-ui/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from 'clsx'
+import { twMerge } from 'tailwind-merge'
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}

--- a/os/axvisor/web-ui/src/main.tsx
+++ b/os/axvisor/web-ui/src/main.tsx
@@ -4,8 +4,9 @@ import App from './shell/App'
 import { panelRegistry } from './panels/registry'
 import './index.css'
 
-// 整个仓库唯一一处「壳 与 面板」的接线点：壳只认 PanelRegistry 契约，
-// 不知道 panels/ 下有什么。新增面板不需要动 shell/，也不需要动这里。
+// The one place in the repo where the shell is wired to the panels: the shell only
+// knows the PanelRegistry contract and nothing about what lives under panels/. Adding
+// a panel touches neither shell/ nor this file.
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <App registry={panelRegistry} />

--- a/os/axvisor/web-ui/src/main.tsx
+++ b/os/axvisor/web-ui/src/main.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './shell/App'
+import { panelRegistry } from './panels/registry'
+import './index.css'
+
+// 整个仓库唯一一处「壳 与 面板」的接线点：壳只认 PanelRegistry 契约，
+// 不知道 panels/ 下有什么。新增面板不需要动 shell/，也不需要动这里。
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App registry={panelRegistry} />
+  </React.StrictMode>,
+)

--- a/os/axvisor/web-ui/src/panels/FallbackPanel.tsx
+++ b/os/axvisor/web-ui/src/panels/FallbackPanel.tsx
@@ -1,7 +1,9 @@
-//! 未知 kind 的降级视图（不变量 7）：不报错，直接把 manifest 节点渲染成 JSON。
+//! Degraded view for an unknown kind (invariant 7): no error, just render the
+//! manifest node as JSON.
 //!
-//! 前向兼容的意义：前端与后端可以是不同代——后端先挂上新 kind，
-//! 老前端照样能看见它，而不是白屏。
+//! The point is forward compatibility: frontend and backend may be of different
+//! generations — the backend can expose a new kind first and an older frontend still
+//! shows it instead of a blank page.
 
 import { Badge } from '@/components/ui/badge'
 import {

--- a/os/axvisor/web-ui/src/panels/FallbackPanel.tsx
+++ b/os/axvisor/web-ui/src/panels/FallbackPanel.tsx
@@ -1,0 +1,35 @@
+//! 未知 kind 的降级视图（不变量 7）：不报错，直接把 manifest 节点渲染成 JSON。
+//!
+//! 前向兼容的意义：前端与后端可以是不同代——后端先挂上新 kind，
+//! 老前端照样能看见它，而不是白屏。
+
+import { Badge } from '@/components/ui/badge'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import type { PanelProps } from '@/api/types'
+
+export function FallbackPanel({ meta }: PanelProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          {meta.title}
+          <Badge variant="secondary">未注册 kind：{meta.kind}</Badge>
+        </CardTitle>
+        <CardDescription>
+          渲染器注册表中没有这个 kind，降级为 JSON 视图——后端可以比前端新。
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <pre className="overflow-auto rounded-md bg-muted p-4 text-sm">
+          {JSON.stringify(meta, null, 2)}
+        </pre>
+      </CardContent>
+    </Card>
+  )
+}

--- a/os/axvisor/web-ui/src/panels/registry.ts
+++ b/os/axvisor/web-ui/src/panels/registry.ts
@@ -1,19 +1,21 @@
-//! 渲染器注册表：kind → 懒加载组件。
+//! Renderer registry: kind -> lazily loaded component.
 //!
-//! 不变量 6：新增一个面板 = panels/ 加目录 + 本文件加一行 + manifest 加一个节点，
-//! 共三处，其余（壳、路由、client）零改动。
-//! 面板之间零 import——vms（管理页）与 console（终端宿主）是两个独立组件，
-//! 只共享壳注入的资源事件流；这就是「积木式组合，不焊接」。
+//! Invariant 6: adding a panel means a new panels/ directory, one line here, and one
+//! manifest node — three places in total, with the shell, routes and client unchanged.
+//! Panels never import each other: vms (management page) and console (terminal host)
+//! are independent components that only share the resource event stream injected by
+//! the shell. That is "composable building blocks, not welded together".
 
 import { lazy } from 'react'
 import type { PanelComponent, PanelRegistry } from '@/api/types'
 import { FallbackPanel } from './FallbackPanel'
 
-// 懒加载：注册表里有 kind，不等于用户点了它——用到了才下载那一块代码
+// Lazy loading: having a kind in the registry does not mean the user opened it —
+// the chunk is downloaded only when it is actually used.
 const VmsPanel = lazy(() => import('./vms/VmsPanel'))
 
 const renderers: Record<string, PanelComponent> = {
-  vms: VmsPanel, // 虚拟机管理页：创建/生命周期/列表
+  vms: VmsPanel, // VM management page: create / lifecycle / list
 }
 
 export function resolvePanel(kind: string): PanelComponent {

--- a/os/axvisor/web-ui/src/panels/registry.ts
+++ b/os/axvisor/web-ui/src/panels/registry.ts
@@ -1,0 +1,23 @@
+//! 渲染器注册表：kind → 懒加载组件。
+//!
+//! 不变量 6：新增一个面板 = panels/ 加目录 + 本文件加一行 + manifest 加一个节点，
+//! 共三处，其余（壳、路由、client）零改动。
+//! 面板之间零 import——vms（管理页）与 console（终端宿主）是两个独立组件，
+//! 只共享壳注入的资源事件流；这就是「积木式组合，不焊接」。
+
+import { lazy } from 'react'
+import type { PanelComponent, PanelRegistry } from '@/api/types'
+import { FallbackPanel } from './FallbackPanel'
+
+// 懒加载：注册表里有 kind，不等于用户点了它——用到了才下载那一块代码
+const VmsPanel = lazy(() => import('./vms/VmsPanel'))
+
+const renderers: Record<string, PanelComponent> = {
+  vms: VmsPanel, // 虚拟机管理页：创建/生命周期/列表
+}
+
+export function resolvePanel(kind: string): PanelComponent {
+  return renderers[kind] ?? FallbackPanel
+}
+
+export const panelRegistry: PanelRegistry = { resolve: resolvePanel }

--- a/os/axvisor/web-ui/src/panels/vms/VmsPanel.tsx
+++ b/os/axvisor/web-ui/src/panels/vms/VmsPanel.tsx
@@ -5,7 +5,13 @@
 //! 路由全部从 `meta.href` 派生，不硬编码端点。
 
 import { useState } from 'react'
-import { describeError, describeStatus, type PanelProps, type VmDetail } from '@/api/types'
+import {
+  ApiError,
+  describeError,
+  describeStatus,
+  type PanelProps,
+  type VmDetail,
+} from '@/api/types'
 import {
   countersOf,
   settleToTerminalState,
@@ -107,6 +113,10 @@ export default function VmsPanel({ meta, api, resources = [], refresh }: PanelPr
   const [busy, setBusy] = useState<{ id: number; op: LifecycleOp } | null>(null)
   const [confirming, setConfirming] = useState<{ op: ActionName; id: number } | null>(null)
   const [createOpen, setCreateOpen] = useState(false)
+  // A create failure must be readable while the dialog holds the screen: the
+  // card's own banner sits behind the overlay, so it would look like nothing
+  // happened.
+  const [createError, setCreateError] = useState<string | null>(null)
   const [toml, setToml] = useState(DEFAULT_VM_TOML)
 
   // 资源根来自 manifest：详情/动作路由都从它派生（href + "/{id}" 等）。
@@ -137,7 +147,7 @@ export default function VmsPanel({ meta, api, resources = [], refresh }: PanelPr
 
   const runCreate = async () => {
     setBusy({ id: -1, op: 'create' })
-    setError(null)
+    setCreateError(null)
     try {
       const created = await api.post<{ id: number }>(`${base}/create`, { toml })
       setCreateOpen(false)
@@ -146,7 +156,12 @@ export default function VmsPanel({ meta, api, resources = [], refresh }: PanelPr
       )
       if (!result.ok) setError(result.message)
     } catch (e: unknown) {
-      setError(describeError(e))
+      // 409 在创建场景下的含义是「这个 id 已经被占用」，通用状态码文案说不清楚。
+      setCreateError(
+        e instanceof ApiError && e.status === 409
+          ? '该 id 已被占用：先删除现有 VM，或换一个构建期内嵌了镜像的 id'
+          : describeError(e),
+      )
     } finally {
       setBusy(null)
       refresh?.()
@@ -167,7 +182,14 @@ export default function VmsPanel({ meta, api, resources = [], refresh }: PanelPr
       </CardHeader>
       <CardContent className="space-y-3">
         <div className="flex items-center gap-2">
-          <Button size="sm" disabled={busy !== null} onClick={() => setCreateOpen(true)}>
+          <Button
+            size="sm"
+            disabled={busy !== null}
+            onClick={() => {
+              setCreateError(null)
+              setCreateOpen(true)
+            }}
+          >
             创建 VM
           </Button>
           {error && <span className="font-mono text-xs text-destructive">{error}</span>}
@@ -274,6 +296,11 @@ export default function VmsPanel({ meta, api, resources = [], refresh }: PanelPr
             value={toml}
             onChange={(e) => setToml(e.target.value)}
           />
+          {createError && (
+            <p className="font-mono text-xs text-destructive" role="alert">
+              {createError}
+            </p>
+          )}
           <DialogFooter>
             <Button variant="outline" onClick={() => setCreateOpen(false)}>
               取消

--- a/os/axvisor/web-ui/src/panels/vms/VmsPanel.tsx
+++ b/os/axvisor/web-ui/src/panels/vms/VmsPanel.tsx
@@ -5,7 +5,7 @@
 //! guest_entry_count to grow, pause requires guest_park_count to grow).
 //! Every route is derived from `meta.href`; no endpoint is hardcoded.
 
-import { useState } from 'react'
+import { useCallback, useRef, useState } from 'react'
 import { verifyToken } from '@/api/auth'
 import {
   ApiError,
@@ -131,6 +131,37 @@ export default function VmsPanel({ meta, api, resources = [], refresh, auth }: P
   const [verifying, setVerifying] = useState(false)
   const [confirmError, setConfirmError] = useState<string | null>(null)
 
+  // Each dialog owns a session counter that every open and close bumps. Token
+  // verification is async, so the user can dismiss a dialog while it is in
+  // flight; comparing the counter after the await drops the result instead of
+  // performing an operation that was just cancelled.
+  const confirmSessionRef = useRef(0)
+  const createSessionRef = useRef(0)
+
+  const openConfirm = useCallback((op: ActionName, id: number) => {
+    confirmSessionRef.current += 1
+    setRetyped('')
+    setConfirmError(null)
+    setConfirming({ op, id })
+  }, [])
+
+  const closeConfirm = useCallback(() => {
+    confirmSessionRef.current += 1
+    setConfirming(null)
+  }, [])
+
+  const openCreate = useCallback(() => {
+    createSessionRef.current += 1
+    setCreateError(null)
+    setRetyped('')
+    setCreateOpen(true)
+  }, [])
+
+  const closeCreate = useCallback(() => {
+    createSessionRef.current += 1
+    setCreateOpen(false)
+  }, [])
+
   /**
    * Re-verifies the token before a dangerous operation.
    * When the backend declares no probe endpoint (auth missing) this degrades to
@@ -154,7 +185,8 @@ export default function VmsPanel({ meta, api, resources = [], refresh, auth }: P
   // The resource root comes from the manifest: detail and action routes are derived
   // from it (href + "/{id}" and so on).
   const base = meta.href
-  const fetchDetail = (id: number) => api.get<VmDetail>(`${base}/${id}`)
+  const fetchDetail = (id: number, signal?: AbortSignal) =>
+    api.get<VmDetail>(`${base}/${id}`, signal)
 
   const runAction = async (op: ActionName, id: number) => {
     setConfirming(null)
@@ -169,7 +201,7 @@ export default function VmsPanel({ meta, api, resources = [], refresh, auth }: P
       } else {
         await api.post(`${base}/${id}/${op}`)
       }
-      const result = await settleToTerminalState(op, before, () => fetchDetail(id))
+      const result = await settleToTerminalState(op, before, (signal) => fetchDetail(id, signal))
       if (!result.ok) setError(result.message)
     } catch (e: unknown) {
       setError(describeError(e))
@@ -180,14 +212,18 @@ export default function VmsPanel({ meta, api, resources = [], refresh, auth }: P
   }
 
   const runCreate = async () => {
+    const session = createSessionRef.current
     setCreateError(null)
     if (!(await verifyRetyped(setCreateError))) return
+    // The dialog may have been dismissed while the token was being verified;
+    // creating now would allocate resources the user just declined.
+    if (createSessionRef.current !== session) return
     setBusy({ id: -1, op: 'create' })
     try {
       const created = await api.post<{ id: number }>(`${base}/create`, { toml })
-      setCreateOpen(false)
-      const result = await settleToTerminalState('create', NO_COUNTERS, () =>
-        fetchDetail(created.id),
+      closeCreate()
+      const result = await settleToTerminalState('create', NO_COUNTERS, (signal) =>
+        fetchDetail(created.id, signal),
       )
       if (!result.ok) setError(result.message)
     } catch (e: unknown) {
@@ -218,15 +254,7 @@ export default function VmsPanel({ meta, api, resources = [], refresh, auth }: P
       </CardHeader>
       <CardContent className="space-y-3">
         <div className="flex items-center gap-2">
-          <Button
-            size="sm"
-            disabled={busy !== null}
-            onClick={() => {
-              setCreateError(null)
-              setRetyped('')
-              setCreateOpen(true)
-            }}
-          >
+          <Button size="sm" disabled={busy !== null} onClick={openCreate}>
             创建 VM
           </Button>
           {error && <span className="font-mono text-xs text-destructive">{error}</span>}
@@ -268,9 +296,7 @@ export default function VmsPanel({ meta, api, resources = [], refresh, auth }: P
                         // stop/delete are destructive and irreversible, so ask for a
                         // second confirmation.
                         if (action.op === 'stop' || action.op === 'delete') {
-                          setRetyped('')
-                          setConfirmError(null)
-                          setConfirming({ op: action.op, id: vm.id })
+                          openConfirm(action.op, vm.id)
                         } else {
                           void runAction(action.op, vm.id)
                         }
@@ -294,7 +320,7 @@ export default function VmsPanel({ meta, api, resources = [], refresh, auth }: P
       <Dialog
         open={confirming !== null}
         onOpenChange={(open) => {
-          if (!open) setConfirming(null)
+          if (!open) closeConfirm()
         }}
       >
         <DialogContent>
@@ -334,7 +360,7 @@ export default function VmsPanel({ meta, api, resources = [], refresh, auth }: P
           )}
 
           <DialogFooter>
-            <Button variant="outline" onClick={() => setConfirming(null)}>
+            <Button variant="outline" onClick={closeConfirm}>
               取消
             </Button>
             <Button
@@ -343,12 +369,17 @@ export default function VmsPanel({ meta, api, resources = [], refresh, auth }: P
               onClick={() => {
                 if (!confirming) return
                 const target = confirming
+                const session = confirmSessionRef.current
                 void (async () => {
                   // Delete is irreversible: have the backend re-verify the retyped
                   // token before running it.
                   if (target.op === 'delete') {
                     setConfirmError(null)
                     if (!(await verifyRetyped(setConfirmError))) return
+                    // The dialog may have been dismissed while the token was being
+                    // verified; deleting now would destroy a VM the user just
+                    // decided to keep.
+                    if (confirmSessionRef.current !== session) return
                   }
                   await runAction(target.op, target.id)
                 })()
@@ -360,7 +391,12 @@ export default function VmsPanel({ meta, api, resources = [], refresh, auth }: P
         </DialogContent>
       </Dialog>
 
-      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
+      <Dialog
+        open={createOpen}
+        onOpenChange={(open) => {
+          if (!open) closeCreate()
+        }}
+      >
         <DialogContent>
           <DialogHeader>
             <DialogTitle>创建 VM</DialogTitle>
@@ -399,7 +435,7 @@ export default function VmsPanel({ meta, api, resources = [], refresh, auth }: P
             </p>
           )}
           <DialogFooter>
-            <Button variant="outline" onClick={() => setCreateOpen(false)}>
+            <Button variant="outline" onClick={closeCreate}>
               取消
             </Button>
             <Button

--- a/os/axvisor/web-ui/src/panels/vms/VmsPanel.tsx
+++ b/os/axvisor/web-ui/src/panels/vms/VmsPanel.tsx
@@ -1,8 +1,9 @@
-//! vms 面板 —— 纯管理页：列表、创建、生命周期动作、删除。
+//! vms panel — a pure management page: list, create, lifecycle actions, delete.
 //!
-//! 语义纪律：HTTP 200 只代表请求被接受，终态由 `@/lib/lifecycle` 轮询详情断言
-//! （start/resume 要 guest_entry_count 增长、pause 要 guest_park_count 增长）。
-//! 路由全部从 `meta.href` 派生，不硬编码端点。
+//! Semantics: HTTP 200 only means the request was accepted; the terminal state is
+//! asserted by `@/lib/lifecycle` polling the detail (start/resume require
+//! guest_entry_count to grow, pause requires guest_park_count to grow).
+//! Every route is derived from `meta.href`; no endpoint is hardcoded.
 
 import { useState } from 'react'
 import { verifyToken } from '@/api/auth'
@@ -38,14 +39,16 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 
-/** 动作前的零基线：stop/delete 不需要计数增长证明，只做状态断言。 */
+/** Zero baseline for actions that only assert a status: stop/delete need no counter growth. */
 const NO_COUNTERS: Counters = { guest_entry_count: 0, guest_park_count: 0 }
 
 /**
- * 创建对话框的默认模板：一份 `image_location = "memory"` 的 guest 配置。
- * 运行期只能实例化构建期内嵌的镜像，且只按 `base.id` 匹配，所以这份模板与
- * `test-suit/axvisor/normal/qemu-web-ui/web-ui/vm-memory.toml` 的 `base.id` 一致；
- * 改成别的 id 会因为找不到内嵌镜像而返回 500（后端既有行为）。
+ * Default template for the create dialog: a guest config with
+ * `image_location = "memory"`.
+ * At runtime only images embedded at build time can be instantiated, matched by
+ * `base.id` alone, so this template keeps the same `base.id` as
+ * `test-suit/axvisor/normal/qemu-web-ui/web-ui/vm-memory.toml`; any other id returns
+ * 500 because no embedded image matches (existing backend behaviour).
  */
 const DEFAULT_VM_TOML = `[base]
 id = 1
@@ -81,7 +84,7 @@ interface RowAction {
   destructive?: boolean
 }
 
-/** 行内可用动作：非法动作不渲染，而不是点了才报 409。 */
+/** Actions available per row: illegal actions are not rendered, rather than returning 409 only once clicked. */
 function actionsFor(status: string): RowAction[] {
   switch (status) {
     case 'ready':
@@ -102,10 +105,11 @@ function actionsFor(status: string): RowAction[] {
         { op: 'delete', label: '删除', destructive: true },
       ]
     case 'stopped':
-      // 后端不支持重启已停止的 VM（start 会 409）：只能删除后重新创建。
+      // The backend cannot restart a stopped VM (start returns 409): delete and
+      // recreate is the only path.
       return [{ op: 'delete', label: '删除', destructive: true }]
     default:
-      // failed / destroying / 未知状态：只读展示，等待后端收敛
+      // failed / destroying / unknown: read-only display, waiting for the backend to converge.
       return []
   }
 }
@@ -120,15 +124,17 @@ export default function VmsPanel({ meta, api, resources = [], refresh, auth }: P
   // happened.
   const [createError, setCreateError] = useState<string | null>(null)
   const [toml, setToml] = useState(DEFAULT_VM_TOML)
-  // 危险操作（create/delete）要求重输 token：这是确认式摩擦，不是安全边界——
-  // token 本来就在这个浏览器里。校验复用 api/auth.ts 的同一原语。
+  // Dangerous operations (create/delete) require retyping the token: this is
+  // confirmation friction, not a security boundary — the token is already in this
+  // browser. Verification reuses the same primitive from api/auth.ts.
   const [retyped, setRetyped] = useState('')
   const [verifying, setVerifying] = useState(false)
   const [confirmError, setConfirmError] = useState<string | null>(null)
 
   /**
-   * 危险操作前的 token 复核。
-   * 后端未声明校验端点（auth 缺失）时退化为放行，并把这句话写在对话框里。
+   * Re-verifies the token before a dangerous operation.
+   * When the backend declares no probe endpoint (auth missing) this degrades to
+   * letting it through, and the dialog says so.
    */
   const verifyRetyped = async (report: (message: string) => void): Promise<boolean> => {
     if (!auth) return true
@@ -145,7 +151,8 @@ export default function VmsPanel({ meta, api, resources = [], refresh, auth }: P
     return false
   }
 
-  // 资源根来自 manifest：详情/动作路由都从它派生（href + "/{id}" 等）。
+  // The resource root comes from the manifest: detail and action routes are derived
+  // from it (href + "/{id}" and so on).
   const base = meta.href
   const fetchDetail = (id: number) => api.get<VmDetail>(`${base}/${id}`)
 
@@ -154,7 +161,8 @@ export default function VmsPanel({ meta, api, resources = [], refresh, auth }: P
     setBusy({ id, op })
     setError(null)
     try {
-      // start/resume 要证明计数增长，pause 要证明 park 增长，所以先采基线。
+      // start/resume must prove the entry counter grew and pause must prove park grew,
+      // so the baseline is sampled first.
       const before = op === 'stop' ? NO_COUNTERS : countersOf(await fetchDetail(id))
       if (op === 'delete') {
         await api.delete(`${base}/${id}`)
@@ -183,7 +191,8 @@ export default function VmsPanel({ meta, api, resources = [], refresh, auth }: P
       )
       if (!result.ok) setError(result.message)
     } catch (e: unknown) {
-      // 409 在创建场景下的含义是「这个 id 已经被占用」，通用状态码文案说不清楚。
+      // A 409 in the create case means "this id is already taken", which the generic
+      // status text cannot convey.
       setCreateError(
         e instanceof ApiError && e.status === 409
           ? '该 id 已被占用：先删除现有 VM，或换一个构建期内嵌了镜像的 id'
@@ -226,7 +235,8 @@ export default function VmsPanel({ meta, api, resources = [], refresh, auth }: P
         <ul className="divide-y rounded-md border">
           {resources.map((vm) => {
             const actions = actionsFor(vm.status)
-            // 行级 busy：既用于防重（按钮 disabled），也用于显示当前动作
+            // Row-level busy: used both to prevent double submission (button disabled)
+            // and to show the active action.
             const busyHere = busy !== null && busy.id === vm.id ? busy : null
             return (
               <li key={vm.id} className="flex items-center justify-between gap-2 px-3 py-2">
@@ -255,7 +265,8 @@ export default function VmsPanel({ meta, api, resources = [], refresh, auth }: P
                       disabled={busy !== null}
                       variant={action.destructive ? 'destructive' : 'outline'}
                       onClick={() => {
-                        // stop/delete 是破坏性且不可撤销的，先二次确认
+                        // stop/delete are destructive and irreversible, so ask for a
+                        // second confirmation.
                         if (action.op === 'stop' || action.op === 'delete') {
                           setRetyped('')
                           setConfirmError(null)
@@ -333,7 +344,8 @@ export default function VmsPanel({ meta, api, resources = [], refresh, auth }: P
                 if (!confirming) return
                 const target = confirming
                 void (async () => {
-                  // 删除不可逆：先让后端复核一次重输的 token 再执行。
+                  // Delete is irreversible: have the backend re-verify the retyped
+                  // token before running it.
                   if (target.op === 'delete') {
                     setConfirmError(null)
                     if (!(await verifyRetyped(setConfirmError))) return

--- a/os/axvisor/web-ui/src/panels/vms/VmsPanel.tsx
+++ b/os/axvisor/web-ui/src/panels/vms/VmsPanel.tsx
@@ -5,6 +5,7 @@
 //! 路由全部从 `meta.href` 派生，不硬编码端点。
 
 import { useState } from 'react'
+import { verifyToken } from '@/api/auth'
 import {
   ApiError,
   describeError,
@@ -27,6 +28,7 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
 import {
   Dialog,
   DialogContent,
@@ -108,7 +110,7 @@ function actionsFor(status: string): RowAction[] {
   }
 }
 
-export default function VmsPanel({ meta, api, resources = [], refresh }: PanelProps) {
+export default function VmsPanel({ meta, api, resources = [], refresh, auth }: PanelProps) {
   const [error, setError] = useState<string | null>(null)
   const [busy, setBusy] = useState<{ id: number; op: LifecycleOp } | null>(null)
   const [confirming, setConfirming] = useState<{ op: ActionName; id: number } | null>(null)
@@ -118,6 +120,30 @@ export default function VmsPanel({ meta, api, resources = [], refresh }: PanelPr
   // happened.
   const [createError, setCreateError] = useState<string | null>(null)
   const [toml, setToml] = useState(DEFAULT_VM_TOML)
+  // 危险操作（create/delete）要求重输 token：这是确认式摩擦，不是安全边界——
+  // token 本来就在这个浏览器里。校验复用 api/auth.ts 的同一原语。
+  const [retyped, setRetyped] = useState('')
+  const [verifying, setVerifying] = useState(false)
+  const [confirmError, setConfirmError] = useState<string | null>(null)
+
+  /**
+   * 危险操作前的 token 复核。
+   * 后端未声明校验端点（auth 缺失）时退化为放行，并把这句话写在对话框里。
+   */
+  const verifyRetyped = async (report: (message: string) => void): Promise<boolean> => {
+    if (!auth) return true
+    const candidate = retyped.trim()
+    if (!candidate) {
+      report('请重新输入 token')
+      return false
+    }
+    setVerifying(true)
+    const verdict = await verifyToken(auth, candidate)
+    setVerifying(false)
+    if (verdict.ok) return true
+    report(verdict.reason)
+    return false
+  }
 
   // 资源根来自 manifest：详情/动作路由都从它派生（href + "/{id}" 等）。
   const base = meta.href
@@ -146,8 +172,9 @@ export default function VmsPanel({ meta, api, resources = [], refresh }: PanelPr
   }
 
   const runCreate = async () => {
-    setBusy({ id: -1, op: 'create' })
     setCreateError(null)
+    if (!(await verifyRetyped(setCreateError))) return
+    setBusy({ id: -1, op: 'create' })
     try {
       const created = await api.post<{ id: number }>(`${base}/create`, { toml })
       setCreateOpen(false)
@@ -187,6 +214,7 @@ export default function VmsPanel({ meta, api, resources = [], refresh }: PanelPr
             disabled={busy !== null}
             onClick={() => {
               setCreateError(null)
+              setRetyped('')
               setCreateOpen(true)
             }}
           >
@@ -229,6 +257,8 @@ export default function VmsPanel({ meta, api, resources = [], refresh }: PanelPr
                       onClick={() => {
                         // stop/delete 是破坏性且不可撤销的，先二次确认
                         if (action.op === 'stop' || action.op === 'delete') {
+                          setRetyped('')
+                          setConfirmError(null)
                           setConfirming({ op: action.op, id: vm.id })
                         } else {
                           void runAction(action.op, vm.id)
@@ -267,13 +297,50 @@ export default function VmsPanel({ meta, api, resources = [], refresh }: PanelPr
                 : '停止是异步操作：状态会先进入 stopping，等 vCPU 退出后才到达 stopped。'}
             </DialogDescription>
           </DialogHeader>
+
+          {confirming?.op === 'delete' && auth && (
+            <div className="space-y-1">
+              <label className="text-xs text-muted-foreground" htmlFor="confirm-token">
+                删除不可逆：请重新输入管理 token 确认
+              </label>
+              <Input
+                id="confirm-token"
+                type="password"
+                value={retyped}
+                onChange={(e) => {
+                  setRetyped(e.target.value)
+                  setConfirmError(null)
+                }}
+                placeholder="Bearer token"
+                aria-label="确认删除的 token"
+              />
+              {confirmError && (
+                <p className="font-mono text-xs text-destructive" role="alert">
+                  {confirmError}
+                </p>
+              )}
+            </div>
+          )}
+
           <DialogFooter>
             <Button variant="outline" onClick={() => setConfirming(null)}>
               取消
             </Button>
             <Button
               variant="destructive"
-              onClick={() => confirming && void runAction(confirming.op, confirming.id)}
+              disabled={verifying}
+              onClick={() => {
+                if (!confirming) return
+                const target = confirming
+                void (async () => {
+                  // 删除不可逆：先让后端复核一次重输的 token 再执行。
+                  if (target.op === 'delete') {
+                    setConfirmError(null)
+                    if (!(await verifyRetyped(setConfirmError))) return
+                  }
+                  await runAction(target.op, target.id)
+                })()
+              }}
             >
               确认
             </Button>
@@ -296,6 +363,24 @@ export default function VmsPanel({ meta, api, resources = [], refresh }: PanelPr
             value={toml}
             onChange={(e) => setToml(e.target.value)}
           />
+          {auth && (
+            <div className="space-y-1">
+              <label className="text-xs text-muted-foreground" htmlFor="create-token">
+                创建会占用资源：请重新输入管理 token 确认
+              </label>
+              <Input
+                id="create-token"
+                type="password"
+                value={retyped}
+                onChange={(e) => {
+                  setRetyped(e.target.value)
+                  setCreateError(null)
+                }}
+                placeholder="Bearer token"
+                aria-label="确认创建的 token"
+              />
+            </div>
+          )}
           {createError && (
             <p className="font-mono text-xs text-destructive" role="alert">
               {createError}
@@ -305,8 +390,11 @@ export default function VmsPanel({ meta, api, resources = [], refresh }: PanelPr
             <Button variant="outline" onClick={() => setCreateOpen(false)}>
               取消
             </Button>
-            <Button disabled={busy !== null || !toml.trim()} onClick={() => void runCreate()}>
-              创建
+            <Button
+              disabled={busy !== null || verifying || !toml.trim()}
+              onClick={() => void runCreate()}
+            >
+              {verifying ? '校验中…' : '创建'}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/os/axvisor/web-ui/src/panels/vms/VmsPanel.tsx
+++ b/os/axvisor/web-ui/src/panels/vms/VmsPanel.tsx
@@ -1,0 +1,289 @@
+//! vms 面板 —— 纯管理页：列表、创建、生命周期动作、删除。
+//!
+//! 语义纪律：HTTP 200 只代表请求被接受，终态由 `@/lib/lifecycle` 轮询详情断言
+//! （start/resume 要 guest_entry_count 增长、pause 要 guest_park_count 增长）。
+//! 路由全部从 `meta.href` 派生，不硬编码端点。
+
+import { useState } from 'react'
+import { describeError, describeStatus, type PanelProps, type VmDetail } from '@/api/types'
+import {
+  countersOf,
+  settleToTerminalState,
+  type Counters,
+  type LifecycleOp,
+} from '@/lib/lifecycle'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+
+/** 动作前的零基线：stop/delete 不需要计数增长证明，只做状态断言。 */
+const NO_COUNTERS: Counters = { guest_entry_count: 0, guest_park_count: 0 }
+
+/**
+ * 创建对话框的默认模板：一份 `image_location = "memory"` 的 guest 配置。
+ * 运行期只能实例化构建期内嵌的镜像，且只按 `base.id` 匹配，所以这份模板与
+ * `test-suit/axvisor/normal/qemu-web-ui/web-ui/vm-memory.toml` 的 `base.id` 一致；
+ * 改成别的 id 会因为找不到内嵌镜像而返回 500（后端既有行为）。
+ */
+const DEFAULT_VM_TOML = `[base]
+id = 1
+name = "linux-web-ui"
+guest_type = "passthrough"
+cpu_num = 1
+phys_cpu_ids = [1]
+
+[kernel]
+entry_point = 0x8020_0000
+image_location = "memory"
+kernel_path = "\${workspace}/tmp/axbuild/images/qemu-aarch64/linux/linux-qemu"
+kernel_load_addr = 0x8020_0000
+dtb_load_addr = 0x8000_0000
+ramdisk_path = "\${workspace}/tmp/axbuild/axvisor/qemu-web-ui/initramfs-aarch64.cpio.gz"
+ramdisk_load_addr = 0x8400_0000
+
+memory_regions = [
+  [0x8000_0000, 0x1000_0000, 0x7, 0],
+]
+
+[devices]
+passthrough = []
+# The host's own PCI bridge (and with it virtio-net) must stay with the host.
+disabled = [{ path = "/pcie@10000000" }]
+`
+
+type ActionName = Exclude<LifecycleOp, 'create'>
+
+interface RowAction {
+  op: ActionName
+  label: string
+  destructive?: boolean
+}
+
+/** 行内可用动作：非法动作不渲染，而不是点了才报 409。 */
+function actionsFor(status: string): RowAction[] {
+  switch (status) {
+    case 'ready':
+      return [
+        { op: 'start', label: '启动' },
+        { op: 'delete', label: '删除', destructive: true },
+      ]
+    case 'running':
+      return [
+        { op: 'pause', label: '暂停' },
+        { op: 'stop', label: '停止' },
+        { op: 'delete', label: '删除', destructive: true },
+      ]
+    case 'paused':
+      return [
+        { op: 'resume', label: '恢复' },
+        { op: 'stop', label: '停止' },
+        { op: 'delete', label: '删除', destructive: true },
+      ]
+    case 'stopped':
+      // 后端不支持重启已停止的 VM（start 会 409）：只能删除后重新创建。
+      return [{ op: 'delete', label: '删除', destructive: true }]
+    default:
+      // failed / destroying / 未知状态：只读展示，等待后端收敛
+      return []
+  }
+}
+
+export default function VmsPanel({ meta, api, resources = [], refresh }: PanelProps) {
+  const [error, setError] = useState<string | null>(null)
+  const [busy, setBusy] = useState<{ id: number; op: LifecycleOp } | null>(null)
+  const [confirming, setConfirming] = useState<{ op: ActionName; id: number } | null>(null)
+  const [createOpen, setCreateOpen] = useState(false)
+  const [toml, setToml] = useState(DEFAULT_VM_TOML)
+
+  // 资源根来自 manifest：详情/动作路由都从它派生（href + "/{id}" 等）。
+  const base = meta.href
+  const fetchDetail = (id: number) => api.get<VmDetail>(`${base}/${id}`)
+
+  const runAction = async (op: ActionName, id: number) => {
+    setConfirming(null)
+    setBusy({ id, op })
+    setError(null)
+    try {
+      // start/resume 要证明计数增长，pause 要证明 park 增长，所以先采基线。
+      const before = op === 'stop' ? NO_COUNTERS : countersOf(await fetchDetail(id))
+      if (op === 'delete') {
+        await api.delete(`${base}/${id}`)
+      } else {
+        await api.post(`${base}/${id}/${op}`)
+      }
+      const result = await settleToTerminalState(op, before, () => fetchDetail(id))
+      if (!result.ok) setError(result.message)
+    } catch (e: unknown) {
+      setError(describeError(e))
+    } finally {
+      setBusy(null)
+      refresh?.()
+    }
+  }
+
+  const runCreate = async () => {
+    setBusy({ id: -1, op: 'create' })
+    setError(null)
+    try {
+      const created = await api.post<{ id: number }>(`${base}/create`, { toml })
+      setCreateOpen(false)
+      const result = await settleToTerminalState('create', NO_COUNTERS, () =>
+        fetchDetail(created.id),
+      )
+      if (!result.ok) setError(result.message)
+    } catch (e: unknown) {
+      setError(describeError(e))
+    } finally {
+      setBusy(null)
+      refresh?.()
+    }
+  }
+
+  return (
+    <Card className="max-w-3xl">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          虚拟机
+          <Badge variant="secondary">{resources.length} 台</Badge>
+        </CardTitle>
+        <CardDescription>
+          每个操作都轮询到真实终态：启动/恢复以 guest_entry_count 增长为证，暂停以
+          guest_park_count 增长为证。
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div className="flex items-center gap-2">
+          <Button size="sm" disabled={busy !== null} onClick={() => setCreateOpen(true)}>
+            创建 VM
+          </Button>
+          {error && <span className="font-mono text-xs text-destructive">{error}</span>}
+        </div>
+
+        <ul className="divide-y rounded-md border">
+          {resources.map((vm) => {
+            const actions = actionsFor(vm.status)
+            // 行级 busy：既用于防重（按钮 disabled），也用于显示当前动作
+            const busyHere = busy !== null && busy.id === vm.id ? busy : null
+            return (
+              <li key={vm.id} className="flex items-center justify-between gap-2 px-3 py-2">
+                <span className="flex items-center gap-2 font-mono text-sm">
+                  VM #{vm.id}
+                  <Badge
+                    variant={vm.status === 'running' ? 'default' : 'outline'}
+                    className="text-[10px]"
+                  >
+                    {describeStatus(vm.status)}
+                  </Badge>
+                  {vm.status === 'stopped' && (
+                    <span className="text-xs text-muted-foreground">
+                      已停止的 VM 不能重启，请删除后重新创建
+                    </span>
+                  )}
+                </span>
+                <span className="flex items-center gap-2">
+                  {busyHere !== null && (
+                    <span className="text-xs text-muted-foreground">{busyHere.op} 进行中…</span>
+                  )}
+                  {actions.map((action) => (
+                    <Button
+                      key={action.op}
+                      size="sm"
+                      disabled={busy !== null}
+                      variant={action.destructive ? 'destructive' : 'outline'}
+                      onClick={() => {
+                        // stop/delete 是破坏性且不可撤销的，先二次确认
+                        if (action.op === 'stop' || action.op === 'delete') {
+                          setConfirming({ op: action.op, id: vm.id })
+                        } else {
+                          void runAction(action.op, vm.id)
+                        }
+                      }}
+                    >
+                      {action.label}
+                    </Button>
+                  ))}
+                </span>
+              </li>
+            )
+          })}
+          {resources.length === 0 && (
+            <li className="px-3 py-2 text-sm text-muted-foreground">
+              还没有 VM——点「创建 VM」
+            </li>
+          )}
+        </ul>
+      </CardContent>
+
+      <Dialog
+        open={confirming !== null}
+        onOpenChange={(open) => {
+          if (!open) setConfirming(null)
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              确认{confirming?.op === 'delete' ? '删除' : '停止'} VM #{confirming?.id}？
+            </DialogTitle>
+            <DialogDescription>
+              {confirming?.op === 'delete'
+                ? '删除后该 VM 从列表消失；要再次使用需重新创建。'
+                : '停止是异步操作：状态会先进入 stopping，等 vCPU 退出后才到达 stopped。'}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setConfirming(null)}>
+              取消
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() => confirming && void runAction(confirming.op, confirming.id)}
+            >
+              确认
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>创建 VM</DialogTitle>
+            <DialogDescription>
+              运行期只能实例化构建期内嵌的镜像（按 base.id 匹配）。改 id 或路径会让请求
+              返回 500。
+            </DialogDescription>
+          </DialogHeader>
+          <textarea
+            className="h-64 w-full resize-y rounded-md border bg-muted/40 p-2 font-mono text-xs"
+            aria-label="创建 VM 的 TOML 配置"
+            value={toml}
+            onChange={(e) => setToml(e.target.value)}
+          />
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setCreateOpen(false)}>
+              取消
+            </Button>
+            <Button disabled={busy !== null || !toml.trim()} onClick={() => void runCreate()}>
+              创建
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </Card>
+  )
+}

--- a/os/axvisor/web-ui/src/shell/App.tsx
+++ b/os/axvisor/web-ui/src/shell/App.tsx
@@ -65,7 +65,6 @@ export default function App({ registry }: { registry: PanelRegistry }) {
       manifest={manifest}
       manifestError={manifestError}
       onReloadManifest={reloadManifest}
-      onResetToken={() => setToken(null)}
     />
   )
 }
@@ -76,14 +75,12 @@ function Shell({
   manifest,
   manifestError,
   onReloadManifest,
-  onResetToken,
 }: {
   registry: PanelRegistry
   token: string
   manifest: Manifest | null
   manifestError: string | null
   onReloadManifest: () => void
-  onResetToken: () => void
 }) {
   const api = useApiClient(token)
   const [tabs, setTabs] = useState<TabState[]>([])
@@ -154,11 +151,6 @@ function Shell({
           {/* 重扫 manifest：后端插拔了能力，点一下导航就跟着变 */}
           <Button size="sm" variant="ghost" onClick={onReloadManifest}>
             刷新能力清单
-          </Button>
-          {/* token 只存在内存态：写操作报 401 时唯一的补救就是重新输入，
-             所以必须给一个入口，否则只能刷新页面。 */}
-          <Button size="sm" variant="outline" onClick={onResetToken}>
-            重设 token
           </Button>
         </div>
       </header>

--- a/os/axvisor/web-ui/src/shell/App.tsx
+++ b/os/axvisor/web-ui/src/shell/App.tsx
@@ -1,10 +1,13 @@
-//! 应用壳：拉能力清单 → token 门 → 布局 → 标签栏 → 导航（manifest 驱动）。
+//! Application shell: fetch the capability manifest -> token gate -> layout -> tab bar
+//! -> navigation, all manifest driven.
 //!
-//! 不变量 5：本目录下没有一处 import panels/*，也没有任何 kind 字面量。
-//! 面板怎么渲染由注入进来的 registry 决定（types.ts 里的 PanelRegistry 契约）。
+//! Invariant 5: nothing under this directory imports panels/*, and there is no kind
+//! literal. How a panel renders is decided by the injected registry (the PanelRegistry
+//! contract in types.ts).
 //!
-//! manifest 是**开放**端点（`GET /api/`），所以在登录前就取：token 门需要它声明
-//! 的 auth 探测路径才能校验 token，而不是自己去猜一个端点。
+//! The manifest is an **open** endpoint (`GET /api/`), so it is fetched before sign-in:
+//! the token gate needs the auth probe path it declares in order to verify the token,
+//! rather than guessing an endpoint itself.
 
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useApiClient } from '@/api/client'
@@ -16,14 +19,16 @@ import { Tabs } from './Tabs'
 import { TokenGate } from './TokenGate'
 
 export interface TabState {
-  /** 标签实例 id：同 kind 可以开多个实例（终端阶段的独占语义靠它演示） */
+  /** Tab instance id: one kind may have several instances (the terminal phase demos exclusive semantics through it). */
   id: string
   kind: string
 }
 
-// 引导期拉清单用的根路径（manifest 尚未拿到，只能先写死这一处，且集中成常量）。
+// Root path used to fetch the manifest during bootstrap: it is not available yet, so
+// this one hardcoded value is hoisted into a constant.
 const MANIFEST_HREF = '/api/'
-// 资源 kind 的唯一真相源：壳与面板都引用它，不再散落 'vms' 字面量。
+// Single source of truth for the resource kind: the shell and the panels both
+// reference it instead of scattering 'vms' literals.
 const VM_KIND = 'vms'
 
 export default function App({ registry }: { registry: PanelRegistry }) {
@@ -92,7 +97,7 @@ function Shell({
   const [activeId, setActiveId] = useState<string | null>(null)
   const bootstrappedRef = useRef(false)
 
-  // 默认打开第一个面板，省掉一次点击
+  // Open the first panel by default, saving one click.
   useEffect(() => {
     if (manifest === null || bootstrappedRef.current) return
     bootstrappedRef.current = true
@@ -104,11 +109,12 @@ function Shell({
     }
   }, [manifest])
 
-  // 壳级资源快照：跟随 manifest 给 vms 资源的 href，不硬编码端点。
+  // Shell-level resource snapshot: follows the href the manifest assigns to the vms
+  // resource instead of hardcoding an endpoint.
   const vmsHref = manifest?.resources.find((r) => r.kind === VM_KIND)?.href ?? null
   const feed = useVmFeed(api, vmsHref)
 
-  // 关掉当前标签后，退回到还开着的最近一个
+  // After closing the active tab, fall back to the most recently opened one still present.
   useEffect(() => {
     if (activeId === null && tabs.length > 0) {
       setActiveId(tabs[tabs.length - 1].id)
@@ -117,7 +123,7 @@ function Shell({
 
   const openPanel = useCallback(
     (kind: string) => {
-      // 导航语义：这种 kind 已有实例就聚焦它，没有才新建
+      // Navigation semantics: focus an existing instance of this kind, otherwise create one.
       const existing = tabs.find((t) => t.kind === kind)
       if (existing) {
         setActiveId(existing.id)
@@ -132,7 +138,7 @@ function Shell({
 
   const newTab = useCallback(
     (kind: string) => {
-      // 「+」语义：无条件新开一个实例（每标签一个独立面板实例）
+      // "+" semantics: always open a new instance (one independent panel instance per tab).
       const tab = { id: tabId(tabs.length), kind }
       setTabs((prev) => [...prev, tab])
       setActiveId(tab.id)
@@ -153,7 +159,7 @@ function Shell({
           <span className="text-xs text-muted-foreground">
             manifest proto {manifest?.proto ?? '-'} · {manifest?.resources.length ?? 0} 个资源
           </span>
-          {/* 重扫 manifest：后端插拔了能力，点一下导航就跟着变 */}
+          {/* Rescan the manifest: when the backend adds or removes a capability, one click updates the navigation. */}
           <Button size="sm" variant="ghost" onClick={onReloadManifest}>
             刷新能力清单
           </Button>
@@ -162,7 +168,7 @@ function Shell({
 
       {manifestError && (
         <div className="flex items-center justify-between gap-4 border-b bg-destructive/10 px-4 py-2 text-sm">
-          {/* 错误消息同时给出 HTTP 状态与后端错误两个维度（不变量 11） */}
+          {/* The error message surfaces both the HTTP status and the backend error (invariant 11). */}
           <span className="font-mono text-destructive">{manifestError}</span>
           <Button size="sm" variant="outline" onClick={onReloadManifest}>
             重试

--- a/os/axvisor/web-ui/src/shell/App.tsx
+++ b/os/axvisor/web-ui/src/shell/App.tsx
@@ -1,7 +1,10 @@
-//! 应用壳：token 门 → 布局 → 标签栏 → 导航（manifest 驱动）。
+//! 应用壳：拉能力清单 → token 门 → 布局 → 标签栏 → 导航（manifest 驱动）。
 //!
 //! 不变量 5：本目录下没有一处 import panels/*，也没有任何 kind 字面量。
 //! 面板怎么渲染由注入进来的 registry 决定（types.ts 里的 PanelRegistry 契约）。
+//!
+//! manifest 是**开放**端点（`GET /api/`），所以在登录前就取：token 门需要它声明
+//! 的 auth 探测路径才能校验 token，而不是自己去猜一个端点。
 
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useApiClient } from '@/api/client'
@@ -20,52 +23,84 @@ export interface TabState {
 
 export default function App({ registry }: { registry: PanelRegistry }) {
   const [token, setToken] = useState<string | null>(null)
+  const [manifest, setManifest] = useState<Manifest | null>(null)
+  const [manifestError, setManifestError] = useState<string | null>(null)
+  const [reloadKey, setReloadKey] = useState(0)
 
-  if (token === null) return <TokenGate onSubmit={setToken} />
-  return <Shell registry={registry} token={token} onResetToken={() => setToken(null)} />
+  useEffect(() => {
+    const ac = new AbortController()
+    fetch('/api/', { signal: ac.signal })
+      .then(async (res) => {
+        if (!res.ok) throw new Error(`能力清单返回 HTTP ${res.status}`)
+        return (await res.json()) as Manifest
+      })
+      .then((fetched) => {
+        setManifest(fetched)
+        setManifestError(null)
+      })
+      .catch((e: unknown) => {
+        if (ac.signal.aborted) return
+        setManifestError(describeError(e))
+      })
+    return () => ac.abort()
+  }, [reloadKey])
+
+  const reloadManifest = useCallback(() => setReloadKey((k) => k + 1), [])
+
+  if (token === null) {
+    return (
+      <TokenGate
+        auth={manifest?.auth ?? null}
+        manifestError={manifestError}
+        onRetryManifest={reloadManifest}
+        onSubmit={setToken}
+      />
+    )
+  }
+
+  return (
+    <Shell
+      registry={registry}
+      token={token}
+      manifest={manifest}
+      manifestError={manifestError}
+      onReloadManifest={reloadManifest}
+      onResetToken={() => setToken(null)}
+    />
+  )
 }
 
 function Shell({
   registry,
   token,
+  manifest,
+  manifestError,
+  onReloadManifest,
   onResetToken,
 }: {
   registry: PanelRegistry
   token: string
+  manifest: Manifest | null
+  manifestError: string | null
+  onReloadManifest: () => void
   onResetToken: () => void
 }) {
   const api = useApiClient(token)
-  const [manifest, setManifest] = useState<Manifest | null>(null)
-  const [error, setError] = useState<string | null>(null)
-  const [reloadKey, setReloadKey] = useState(0)
   const [tabs, setTabs] = useState<TabState[]>([])
   const [activeId, setActiveId] = useState<string | null>(null)
   const bootstrappedRef = useRef(false)
 
+  // 默认打开第一个面板，省掉一次点击
   useEffect(() => {
-    const ac = new AbortController()
-    api
-      .get<Manifest>('/api/', ac.signal)
-      .then((m) => {
-        setManifest(m)
-        setError(null)
-        // 默认打开第一个面板，省掉一次点击
-        if (!bootstrappedRef.current) {
-          bootstrappedRef.current = true
-          const first = m.resources[0]
-          if (first) {
-            const tab: TabState = { id: tabId(0), kind: first.kind }
-            setTabs([tab])
-            setActiveId(tab.id)
-          }
-        }
-      })
-      .catch((e: unknown) => {
-        if (ac.signal.aborted) return
-        setError(describeError(e))
-      })
-    return () => ac.abort()
-  }, [api, reloadKey])
+    if (manifest === null || bootstrappedRef.current) return
+    bootstrappedRef.current = true
+    const first = manifest.resources[0]
+    if (first) {
+      const tab: TabState = { id: tabId(0), kind: first.kind }
+      setTabs([tab])
+      setActiveId(tab.id)
+    }
+  }, [manifest])
 
   // 壳级资源快照：跟随 manifest 给 vms 资源的 href，不硬编码端点。
   const vmsHref = manifest?.resources.find((r) => r.kind === 'vms')?.href ?? null
@@ -117,7 +152,7 @@ function Shell({
             manifest proto {manifest?.proto ?? '-'} · {manifest?.resources.length ?? 0} 个资源
           </span>
           {/* 重扫 manifest：后端插拔了能力，点一下导航就跟着变 */}
-          <Button size="sm" variant="ghost" onClick={() => setReloadKey((k) => k + 1)}>
+          <Button size="sm" variant="ghost" onClick={onReloadManifest}>
             刷新能力清单
           </Button>
           {/* token 只存在内存态：写操作报 401 时唯一的补救就是重新输入，
@@ -128,11 +163,11 @@ function Shell({
         </div>
       </header>
 
-      {error && (
+      {manifestError && (
         <div className="flex items-center justify-between gap-4 border-b bg-destructive/10 px-4 py-2 text-sm">
           {/* 错误消息同时给出 HTTP 状态与后端错误两个维度（不变量 11） */}
-          <span className="font-mono text-destructive">{error}</span>
-          <Button size="sm" variant="outline" onClick={() => setReloadKey((k) => k + 1)}>
+          <span className="font-mono text-destructive">{manifestError}</span>
+          <Button size="sm" variant="outline" onClick={onReloadManifest}>
             重试
           </Button>
         </div>
@@ -149,6 +184,7 @@ function Shell({
         />
         <Tabs
           resources={manifest?.resources ?? []}
+          auth={manifest?.auth}
           tabs={tabs}
           activeId={activeId}
           registry={registry}

--- a/os/axvisor/web-ui/src/shell/App.tsx
+++ b/os/axvisor/web-ui/src/shell/App.tsx
@@ -1,0 +1,161 @@
+//! 应用壳：token 门 → 布局 → 标签栏 → 导航（manifest 驱动）。
+//!
+//! 不变量 5：本目录下没有一处 import panels/*，也没有任何 kind 字面量。
+//! 面板怎么渲染由注入进来的 registry 决定（types.ts 里的 PanelRegistry 契约）。
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useApiClient } from '@/api/client'
+import { useVmFeed } from '@/api/feed'
+import { describeError, type Manifest, type PanelRegistry } from '@/api/types'
+import { Button } from '@/components/ui/button'
+import { Nav } from './Nav'
+import { Tabs } from './Tabs'
+import { TokenGate } from './TokenGate'
+
+export interface TabState {
+  /** 标签实例 id：同 kind 可以开多个实例（终端阶段的独占语义靠它演示） */
+  id: string
+  kind: string
+}
+
+export default function App({ registry }: { registry: PanelRegistry }) {
+  const [token, setToken] = useState<string | null>(null)
+
+  if (token === null) return <TokenGate onSubmit={setToken} />
+  return <Shell registry={registry} token={token} />
+}
+
+function Shell({ registry, token }: { registry: PanelRegistry; token: string }) {
+  const api = useApiClient(token)
+  const [manifest, setManifest] = useState<Manifest | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [reloadKey, setReloadKey] = useState(0)
+  const [tabs, setTabs] = useState<TabState[]>([])
+  const [activeId, setActiveId] = useState<string | null>(null)
+  const bootstrappedRef = useRef(false)
+
+  useEffect(() => {
+    const ac = new AbortController()
+    api
+      .get<Manifest>('/api/', ac.signal)
+      .then((m) => {
+        setManifest(m)
+        setError(null)
+        // 默认打开第一个面板，省掉一次点击
+        if (!bootstrappedRef.current) {
+          bootstrappedRef.current = true
+          const first = m.resources[0]
+          if (first) {
+            const tab: TabState = { id: tabId(0), kind: first.kind }
+            setTabs([tab])
+            setActiveId(tab.id)
+          }
+        }
+      })
+      .catch((e: unknown) => {
+        if (ac.signal.aborted) return
+        setError(describeError(e))
+      })
+    return () => ac.abort()
+  }, [api, reloadKey])
+
+  // 壳级资源快照：跟随 manifest 给 vms 资源的 href，不硬编码端点。
+  const vmsHref = manifest?.resources.find((r) => r.kind === 'vms')?.href ?? null
+  const feed = useVmFeed(api, vmsHref)
+
+  // 关掉当前标签后，退回到还开着的最近一个
+  useEffect(() => {
+    if (activeId === null && tabs.length > 0) {
+      setActiveId(tabs[tabs.length - 1].id)
+    }
+  }, [activeId, tabs])
+
+  const openPanel = useCallback(
+    (kind: string) => {
+      // 导航语义：这种 kind 已有实例就聚焦它，没有才新建
+      const existing = tabs.find((t) => t.kind === kind)
+      if (existing) {
+        setActiveId(existing.id)
+        return
+      }
+      const tab = { id: tabId(tabs.length), kind }
+      setTabs((prev) => [...prev, tab])
+      setActiveId(tab.id)
+    },
+    [tabs],
+  )
+
+  const newTab = useCallback(
+    (kind: string) => {
+      // 「+」语义：无条件新开一个实例（每标签一个独立面板实例）
+      const tab = { id: tabId(tabs.length), kind }
+      setTabs((prev) => [...prev, tab])
+      setActiveId(tab.id)
+    },
+    [tabs],
+  )
+
+  const closeTab = useCallback((id: string) => {
+    setTabs((prev) => prev.filter((t) => t.id !== id))
+    setActiveId((cur) => (cur === id ? null : cur))
+  }, [])
+
+  return (
+    <div className="flex h-screen flex-col">
+      <header className="flex items-center justify-between border-b px-4 py-2">
+        <span className="text-sm font-semibold">Axvisor</span>
+        <div className="flex items-center gap-3">
+          <span className="text-xs text-muted-foreground">
+            manifest proto {manifest?.proto ?? '-'} · {manifest?.resources.length ?? 0} 个资源
+          </span>
+          {/* 重扫 manifest：后端插拔了能力，点一下导航就跟着变 */}
+          <Button size="sm" variant="ghost" onClick={() => setReloadKey((k) => k + 1)}>
+            刷新能力清单
+          </Button>
+        </div>
+      </header>
+
+      {error && (
+        <div className="flex items-center justify-between gap-4 border-b bg-destructive/10 px-4 py-2 text-sm">
+          {/* 错误消息同时给出 HTTP 状态与后端错误两个维度（不变量 11） */}
+          <span className="font-mono text-destructive">{error}</span>
+          <Button size="sm" variant="outline" onClick={() => setReloadKey((k) => k + 1)}>
+            重试
+          </Button>
+        </div>
+      )}
+
+      <div className="flex min-h-0 flex-1">
+        <Nav
+          resources={manifest?.resources ?? []}
+          vms={feed.vms}
+          live={feed.live}
+          activeKind={activeKindOf(tabs, activeId)}
+          onOpen={openPanel}
+          onOpenVm={() => openPanel('vms')}
+        />
+        <Tabs
+          resources={manifest?.resources ?? []}
+          tabs={tabs}
+          activeId={activeId}
+          registry={registry}
+          api={api}
+          token={token}
+          vms={feed.vms}
+          refresh={feed.refresh}
+          onActivate={setActiveId}
+          onClose={closeTab}
+          onNew={newTab}
+        />
+      </div>
+    </div>
+  )
+}
+
+function tabId(n: number): string {
+  return `tab-${n}-${Math.random().toString(36).slice(2, 7)}`
+}
+
+function activeKindOf(tabs: TabState[], activeId: string | null): string | null {
+  return tabs.find((t) => t.id === activeId)?.kind ?? null
+}

--- a/os/axvisor/web-ui/src/shell/App.tsx
+++ b/os/axvisor/web-ui/src/shell/App.tsx
@@ -21,6 +21,11 @@ export interface TabState {
   kind: string
 }
 
+// 引导期拉清单用的根路径（manifest 尚未拿到，只能先写死这一处，且集中成常量）。
+const MANIFEST_HREF = '/api/'
+// 资源 kind 的唯一真相源：壳与面板都引用它，不再散落 'vms' 字面量。
+const VM_KIND = 'vms'
+
 export default function App({ registry }: { registry: PanelRegistry }) {
   const [token, setToken] = useState<string | null>(null)
   const [manifest, setManifest] = useState<Manifest | null>(null)
@@ -29,7 +34,7 @@ export default function App({ registry }: { registry: PanelRegistry }) {
 
   useEffect(() => {
     const ac = new AbortController()
-    fetch('/api/', { signal: ac.signal })
+    fetch(MANIFEST_HREF, { signal: ac.signal })
       .then(async (res) => {
         if (!res.ok) throw new Error(`能力清单返回 HTTP ${res.status}`)
         return (await res.json()) as Manifest
@@ -82,7 +87,7 @@ function Shell({
   manifestError: string | null
   onReloadManifest: () => void
 }) {
-  const api = useApiClient(token)
+  const api = useApiClient(token, manifest?.auth?.scheme)
   const [tabs, setTabs] = useState<TabState[]>([])
   const [activeId, setActiveId] = useState<string | null>(null)
   const bootstrappedRef = useRef(false)
@@ -100,7 +105,7 @@ function Shell({
   }, [manifest])
 
   // 壳级资源快照：跟随 manifest 给 vms 资源的 href，不硬编码端点。
-  const vmsHref = manifest?.resources.find((r) => r.kind === 'vms')?.href ?? null
+  const vmsHref = manifest?.resources.find((r) => r.kind === VM_KIND)?.href ?? null
   const feed = useVmFeed(api, vmsHref)
 
   // 关掉当前标签后，退回到还开着的最近一个
@@ -172,7 +177,7 @@ function Shell({
           live={feed.live}
           activeKind={activeKindOf(tabs, activeId)}
           onOpen={openPanel}
-          onOpenVm={() => openPanel('vms')}
+          onOpenVm={() => openPanel(VM_KIND)}
         />
         <Tabs
           resources={manifest?.resources ?? []}

--- a/os/axvisor/web-ui/src/shell/App.tsx
+++ b/os/axvisor/web-ui/src/shell/App.tsx
@@ -22,10 +22,18 @@ export default function App({ registry }: { registry: PanelRegistry }) {
   const [token, setToken] = useState<string | null>(null)
 
   if (token === null) return <TokenGate onSubmit={setToken} />
-  return <Shell registry={registry} token={token} />
+  return <Shell registry={registry} token={token} onResetToken={() => setToken(null)} />
 }
 
-function Shell({ registry, token }: { registry: PanelRegistry; token: string }) {
+function Shell({
+  registry,
+  token,
+  onResetToken,
+}: {
+  registry: PanelRegistry
+  token: string
+  onResetToken: () => void
+}) {
   const api = useApiClient(token)
   const [manifest, setManifest] = useState<Manifest | null>(null)
   const [error, setError] = useState<string | null>(null)
@@ -111,6 +119,11 @@ function Shell({ registry, token }: { registry: PanelRegistry; token: string }) 
           {/* 重扫 manifest：后端插拔了能力，点一下导航就跟着变 */}
           <Button size="sm" variant="ghost" onClick={() => setReloadKey((k) => k + 1)}>
             刷新能力清单
+          </Button>
+          {/* token 只存在内存态：写操作报 401 时唯一的补救就是重新输入，
+             所以必须给一个入口，否则只能刷新页面。 */}
+          <Button size="sm" variant="outline" onClick={onResetToken}>
+            重设 token
           </Button>
         </div>
       </header>

--- a/os/axvisor/web-ui/src/shell/Nav.tsx
+++ b/os/axvisor/web-ui/src/shell/Nav.tsx
@@ -1,0 +1,94 @@
+//! 导航项 100% 来自 manifest（不变量 5）：这里没有任何 kind 的硬编码，
+//! 后端 manifest 加一个节点，导航就多一项。
+
+import { Badge } from '@/components/ui/badge'
+import { describeStatus, type ResourceMeta, type VmInfo } from '@/api/types'
+
+interface NavProps {
+  /** manifest 暴露的资源族（能力区） */
+  resources: ResourceMeta[]
+  /** 壳级资源快照（轮询，见 api/feed.ts） */
+  vms: VmInfo[]
+  live: boolean
+  activeKind: string | null
+  onOpen: (kind: string) => void
+  onOpenVm: (id: number) => void
+}
+
+export function Nav({ resources, vms, live, activeKind, onOpen, onOpenVm }: NavProps) {
+  return (
+    <nav className="flex w-60 shrink-0 flex-col overflow-y-auto border-r bg-muted/30">
+      <div className="px-4 py-3 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        能力 · 来自 manifest
+      </div>
+      <ul className="flex flex-col gap-1 px-2">
+        {resources.map((r) => (
+          <li key={r.kind}>
+            <button
+              type="button"
+              onClick={() => onOpen(r.kind)}
+              className={
+                'flex w-full flex-col items-start gap-1 rounded-md px-3 py-2 text-left transition-colors ' +
+                (r.kind === activeKind
+                  ? 'bg-primary text-primary-foreground'
+                  : 'hover:bg-accent hover:text-accent-foreground')
+              }
+            >
+              <span className="text-sm font-medium">{r.title}</span>
+              <span className="flex flex-wrap gap-1">
+                {r.verbs.map((v) => (
+                  <Badge key={v} variant="outline" className="text-[10px]">
+                    {v}
+                  </Badge>
+                ))}
+              </span>
+            </button>
+          </li>
+        ))}
+      </ul>
+      {resources.length === 0 && (
+        <p className="px-4 py-2 text-sm text-muted-foreground">manifest 未暴露任何资源</p>
+      )}
+
+      <div className="mt-2 flex items-center justify-between px-4 py-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        <span>资源 · 实时</span>
+        <span
+          className={
+            'rounded-full px-1.5 py-0.5 text-[10px] ' +
+            (live ? 'bg-green-100 text-green-700' : 'bg-amber-100 text-amber-700')
+          }
+          title="资源快照的刷新状态"
+        >
+          {live ? '已同步' : '轮询中'}
+        </span>
+      </div>
+      <ul className="flex flex-col gap-1 px-2 pb-4">
+        {vms.map((vm) => (
+          <li key={vm.id}>
+            <button
+              type="button"
+              onClick={() => onOpenVm(vm.id)}
+              className="flex w-full items-center justify-between rounded-md px-3 py-2 text-left text-sm hover:bg-accent hover:text-accent-foreground"
+            >
+              <span className="font-mono">VM #{vm.id}</span>
+              <StateBadge status={vm.status} />
+            </button>
+          </li>
+        ))}
+        {vms.length === 0 && (
+          <li className="px-4 py-1 text-sm text-muted-foreground">暂无资源</li>
+        )}
+      </ul>
+    </nav>
+  )
+}
+
+function StateBadge({ status }: { status: string }) {
+  // 状态是不透明字符串：只对已知终态上色，未知值原样显示（降级不崩）。
+  const variant = status === 'running' ? 'default' : status === 'failed' ? 'destructive' : 'outline'
+  return (
+    <Badge variant={variant} className="text-[10px]">
+      {describeStatus(status)}
+    </Badge>
+  )
+}

--- a/os/axvisor/web-ui/src/shell/Nav.tsx
+++ b/os/axvisor/web-ui/src/shell/Nav.tsx
@@ -83,9 +83,15 @@ export function Nav({ resources, vms, live, activeKind, onOpen, onOpenVm }: NavP
   )
 }
 
-function StateBadge({ status }: { status: string }) {
+function statusVariant(status: string): 'default' | 'destructive' | 'outline' {
   // 状态是不透明字符串：只对已知终态上色，未知值原样显示（降级不崩）。
-  const variant = status === 'running' ? 'default' : status === 'failed' ? 'destructive' : 'outline'
+  if (status === 'running') return 'default'
+  if (status === 'failed') return 'destructive'
+  return 'outline'
+}
+
+function StateBadge({ status }: { status: string }) {
+  const variant = statusVariant(status)
   return (
     <Badge variant={variant} className="text-[10px]">
       {describeStatus(status)}

--- a/os/axvisor/web-ui/src/shell/Nav.tsx
+++ b/os/axvisor/web-ui/src/shell/Nav.tsx
@@ -1,13 +1,13 @@
-//! 导航项 100% 来自 manifest（不变量 5）：这里没有任何 kind 的硬编码，
-//! 后端 manifest 加一个节点，导航就多一项。
+//! Navigation items come 100% from the manifest (invariant 5): no kind is hardcoded
+//! here, so one new manifest node means one more navigation entry.
 
 import { Badge } from '@/components/ui/badge'
 import { describeStatus, type ResourceMeta, type VmInfo } from '@/api/types'
 
 interface NavProps {
-  /** manifest 暴露的资源族（能力区） */
+  /** Resource families exposed by the manifest (capability area). */
   resources: ResourceMeta[]
-  /** 壳级资源快照（轮询，见 api/feed.ts） */
+  /** Shell-level resource snapshot (polled; see api/feed.ts). */
   vms: VmInfo[]
   live: boolean
   activeKind: string | null
@@ -84,7 +84,8 @@ export function Nav({ resources, vms, live, activeKind, onOpen, onOpenVm }: NavP
 }
 
 function statusVariant(status: string): 'default' | 'destructive' | 'outline' {
-  // 状态是不透明字符串：只对已知终态上色，未知值原样显示（降级不崩）。
+  // The status is an opaque string: only known terminal states get a colour, unknown
+  // values are shown verbatim (degrade, never crash).
   if (status === 'running') return 'default'
   if (status === 'failed') return 'destructive'
   return 'outline'

--- a/os/axvisor/web-ui/src/shell/Tabs.tsx
+++ b/os/axvisor/web-ui/src/shell/Tabs.tsx
@@ -7,7 +7,7 @@
 
 import { Suspense, useState } from 'react'
 import type { ApiClient } from '@/api/client'
-import type { PanelRegistry, ResourceMeta, VmInfo } from '@/api/types'
+import type { AuthProbe, PanelRegistry, ResourceMeta, VmInfo } from '@/api/types'
 import { cn } from '@/lib/utils'
 import type { TabState } from './App'
 
@@ -22,14 +22,28 @@ interface TabsProps {
   vms: VmInfo[]
   /** 变更操作收口后立即刷新壳级快照 */
   refresh: () => void
+  /** manifest 声明的鉴权方式，透传给面板做危险操作确认 */
+  auth?: AuthProbe
   onActivate: (id: string) => void
   onClose: (id: string) => void
   onNew: (kind: string) => void
 }
 
 export function Tabs(props: TabsProps) {
-  const { resources, tabs, activeId, registry, api, token, vms, refresh, onActivate, onClose, onNew } =
-    props
+  const {
+    resources,
+    tabs,
+    activeId,
+    registry,
+    api,
+    token,
+    vms,
+    refresh,
+    auth,
+    onActivate,
+    onClose,
+    onNew,
+  } = props
   const [pickerOpen, setPickerOpen] = useState(false)
 
   // 同 kind 多实例时给标签编号，方便辨认是哪个会话
@@ -117,7 +131,14 @@ export function Tabs(props: TabsProps) {
           return (
             <div key={t.id} className={cn('h-full', t.id === activeId ? 'block' : 'hidden')}>
               <Suspense fallback={<p className="text-sm text-muted-foreground">加载面板…</p>}>
-                <Panel meta={meta} api={api} token={token} resources={vms} refresh={refresh} />
+                <Panel
+                  meta={meta}
+                  api={api}
+                  token={token}
+                  resources={vms}
+                  refresh={refresh}
+                  auth={auth}
+                />
               </Suspense>
             </div>
           )

--- a/os/axvisor/web-ui/src/shell/Tabs.tsx
+++ b/os/axvisor/web-ui/src/shell/Tabs.tsx
@@ -1,0 +1,128 @@
+//! 多标签：每标签一个面板实例。
+//!
+//! 所有已打开的标签都保持挂载（非激活的用 hidden 隐藏），这样将来终端这类
+//! 「独占订阅」的面板在两个标签同时打开时才真的会撞上 409。
+//!
+//! 「+」新开实例：从 manifest 里的资源中挑一个，无条件新开一个标签。
+
+import { Suspense, useState } from 'react'
+import type { ApiClient } from '@/api/client'
+import type { PanelRegistry, ResourceMeta, VmInfo } from '@/api/types'
+import { cn } from '@/lib/utils'
+import type { TabState } from './App'
+
+interface TabsProps {
+  resources: ResourceMeta[]
+  tabs: TabState[]
+  activeId: string | null
+  registry: PanelRegistry
+  api: ApiClient
+  token: string
+  /** 壳级资源快照透传给面板（资源型面板使用，其余忽略） */
+  vms: VmInfo[]
+  /** 变更操作收口后立即刷新壳级快照 */
+  refresh: () => void
+  onActivate: (id: string) => void
+  onClose: (id: string) => void
+  onNew: (kind: string) => void
+}
+
+export function Tabs(props: TabsProps) {
+  const { resources, tabs, activeId, registry, api, token, vms, refresh, onActivate, onClose, onNew } =
+    props
+  const [pickerOpen, setPickerOpen] = useState(false)
+
+  // 同 kind 多实例时给标签编号，方便辨认是哪个会话
+  const counts = new Map<string, number>()
+  for (const t of tabs) counts.set(t.kind, (counts.get(t.kind) ?? 0) + 1)
+  const seen = new Map<string, number>()
+
+  return (
+    <div className="flex min-w-0 flex-1 flex-col">
+      <div className="flex items-center gap-1 border-b px-2 py-1">
+        {tabs.map((t) => {
+          const meta = resources.find((r) => r.kind === t.kind)
+          if (!meta) return null
+          const index = (seen.get(t.kind) ?? 0) + 1
+          seen.set(t.kind, index)
+          const multi = (counts.get(t.kind) ?? 0) > 1
+          return (
+            <div
+              key={t.id}
+              className={cn(
+                'flex items-center gap-2 rounded-md px-3 py-1.5 text-sm',
+                t.id === activeId ? 'bg-secondary' : 'text-muted-foreground hover:bg-accent',
+              )}
+            >
+              <button type="button" onClick={() => onActivate(t.id)}>
+                {meta.title}
+                {multi && ` ·${index}`}
+              </button>
+              <button
+                type="button"
+                aria-label={`关闭 ${meta.title}`}
+                className="text-muted-foreground hover:text-foreground"
+                onClick={() => onClose(t.id)}
+              >
+                ×
+              </button>
+            </div>
+          )
+        })}
+        <div className="relative">
+          <button
+            type="button"
+            aria-label="新开面板实例"
+            title="新开面板实例"
+            className="rounded-md px-2.5 py-1.5 text-muted-foreground hover:bg-accent hover:text-foreground"
+            onClick={() => setPickerOpen((o) => !o)}
+          >
+            +
+          </button>
+          {pickerOpen && (
+            <div className="absolute right-0 top-full z-10 mt-1 w-60 rounded-md border bg-popover p-2 shadow-md">
+              <p className="px-2 pb-1 text-xs text-muted-foreground">
+                新开一个面板实例（每标签独立）
+              </p>
+              {resources.map((r) => (
+                <button
+                  key={r.kind}
+                  type="button"
+                  className="flex w-full items-center justify-between rounded-md px-2 py-1.5 text-sm hover:bg-accent"
+                  onClick={() => {
+                    setPickerOpen(false)
+                    onNew(r.kind)
+                  }}
+                >
+                  {r.title}
+                  <span className="font-mono text-xs text-muted-foreground">{r.kind}</span>
+                </button>
+              ))}
+              {resources.length === 0 && (
+                <p className="px-2 py-1 text-xs text-muted-foreground">manifest 未暴露任何资源</p>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-auto p-4">
+        {tabs.length === 0 && (
+          <p className="text-sm text-muted-foreground">从左侧导航打开一个面板。</p>
+        )}
+        {tabs.map((t) => {
+          const meta = resources.find((r) => r.kind === t.kind)
+          if (!meta) return null
+          const Panel = registry.resolve(t.kind)
+          return (
+            <div key={t.id} className={cn('h-full', t.id === activeId ? 'block' : 'hidden')}>
+              <Suspense fallback={<p className="text-sm text-muted-foreground">加载面板…</p>}>
+                <Panel meta={meta} api={api} token={token} resources={vms} refresh={refresh} />
+              </Suspense>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/os/axvisor/web-ui/src/shell/Tabs.tsx
+++ b/os/axvisor/web-ui/src/shell/Tabs.tsx
@@ -1,9 +1,11 @@
-//! 多标签：每标签一个面板实例。
+//! Tabs: one panel instance per tab.
 //!
-//! 所有已打开的标签都保持挂载（非激活的用 hidden 隐藏），这样将来终端这类
-//! 「独占订阅」的面板在两个标签同时打开时才真的会撞上 409。
+//! Every opened tab stays mounted (inactive ones are hidden with `hidden`), so that a
+//! future "exclusive subscription" panel such as the terminal really does hit the 409
+//! when two tabs hold it at once.
 //!
-//! 「+」新开实例：从 manifest 里的资源中挑一个，无条件新开一个标签。
+//! "+" opens a new instance: pick one of the manifest resources and unconditionally
+//! open a new tab.
 
 import { Suspense, useState } from 'react'
 import type { ApiClient } from '@/api/client'
@@ -18,11 +20,11 @@ interface TabsProps {
   registry: PanelRegistry
   api: ApiClient
   token: string
-  /** 壳级资源快照透传给面板（资源型面板使用，其余忽略） */
+  /** Shell-level resource snapshot passed through to panels (used by resource panels, ignored by the rest). */
   vms: VmInfo[]
-  /** 变更操作收口后立即刷新壳级快照 */
+  /** Refreshes the shell-level snapshot as soon as a mutating operation settles. */
   refresh: () => void
-  /** manifest 声明的鉴权方式，透传给面板做危险操作确认 */
+  /** Auth scheme declared by the manifest, passed through to panels for danger confirmations. */
   auth?: AuthProbe
   onActivate: (id: string) => void
   onClose: (id: string) => void
@@ -46,7 +48,7 @@ export function Tabs(props: TabsProps) {
   } = props
   const [pickerOpen, setPickerOpen] = useState(false)
 
-  // 同 kind 多实例时给标签编号，方便辨认是哪个会话
+  // Number tabs when one kind has several instances, so each session is identifiable.
   const counts = new Map<string, number>()
   for (const t of tabs) counts.set(t.kind, (counts.get(t.kind) ?? 0) + 1)
   const seen = new Map<string, number>()

--- a/os/axvisor/web-ui/src/shell/TokenGate.tsx
+++ b/os/axvisor/web-ui/src/shell/TokenGate.tsx
@@ -1,9 +1,11 @@
-//! token 门：进入界面前先让后端校验 token。
+//! Token gate: have the backend verify the token before the UI is entered.
 //!
-//! 探测路径来自 manifest 的 auth 节点——门不硬编码端点，也不假设后端一定有
-//! token 校验（老后端没有 auth 节点时退化为「写入时才校验」，并把这句话说清楚）。
+//! The probe path comes from the manifest's auth node — the gate hardcodes no endpoint
+//! and does not assume the backend verifies tokens at all (an older backend without an
+//! auth node degrades to "verified on write", and the copy says so explicitly).
 //!
-//! token 只存在内存态（由 App 持有），不落 sessionStorage/localStorage。
+//! The token lives only in memory (held by App); it is never written to
+//! sessionStorage or localStorage.
 
 import { useState } from 'react'
 import { verifyToken } from '@/api/auth'
@@ -13,15 +15,15 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Input } from '@/components/ui/input'
 
 interface TokenGateProps {
-  /** manifest 声明的鉴权方式；null 表示后端没声明（或清单还没取到）。 */
+  /** Auth scheme declared by the manifest; null means the backend declared none (or the manifest has not arrived yet). */
   auth: AuthProbe | null
-  /** manifest 拉取失败的原因；此时无从校验，只能先修清单可达性。 */
+  /** Why the manifest fetch failed; nothing can be verified until the manifest is reachable. */
   manifestError: string | null
   onRetryManifest: () => void
   onSubmit: (token: string) => void
 }
 
-/** 进门卡片的说明文案：按「清单失败 / 未声明校验 / 已声明校验」三态分支，避免嵌套三元。 */
+/** Copy for the gate card: branches over "manifest failed / no probe declared / probe declared", avoiding a nested ternary. */
 function gateDescription(manifestError: string | null, auth: AuthProbe | null) {
   if (manifestError) {
     return <>无法读取能力清单，界面无法确定入口与鉴权方式。</>
@@ -55,7 +57,8 @@ export function TokenGate({ auth, manifestError, onRetryManifest, onSubmit }: To
     setFailure(null)
 
     if (auth === null) {
-      // 没有探测端点可用：只能放行，并把「校验发生在写入时」讲清楚。
+      // No probe endpoint available: let it through, and be explicit that verification
+      // happens on write.
       onSubmit(token)
       return
     }

--- a/os/axvisor/web-ui/src/shell/TokenGate.tsx
+++ b/os/axvisor/web-ui/src/shell/TokenGate.tsx
@@ -1,0 +1,45 @@
+//! token 门。token 只存在内存态（useState），不落 sessionStorage/localStorage。
+
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+
+export function TokenGate({ onSubmit }: { onSubmit: (token: string) => void }) {
+  const [value, setValue] = useState('')
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-muted/40 p-4">
+      <Card className="w-full max-w-sm">
+        <CardHeader>
+          <CardTitle>Axvisor</CardTitle>
+          <CardDescription>
+            管理接口的写操作需要 token：填入与构建时{' '}
+            <code className="font-mono">AXVM_HTTP_TOKEN</code> 一致的值
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form
+            className="flex gap-2"
+            onSubmit={(e) => {
+              e.preventDefault()
+              const token = value.trim()
+              if (token) onSubmit(token)
+            }}
+          >
+            <Input
+              autoFocus
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+              placeholder="Bearer token"
+              aria-label="token"
+            />
+            <Button type="submit" disabled={!value.trim()}>
+              进入
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/os/axvisor/web-ui/src/shell/TokenGate.tsx
+++ b/os/axvisor/web-ui/src/shell/TokenGate.tsx
@@ -21,6 +21,29 @@ interface TokenGateProps {
   onSubmit: (token: string) => void
 }
 
+/** 进门卡片的说明文案：按「清单失败 / 未声明校验 / 已声明校验」三态分支，避免嵌套三元。 */
+function gateDescription(manifestError: string | null, auth: AuthProbe | null) {
+  if (manifestError) {
+    return <>无法读取能力清单，界面无法确定入口与鉴权方式。</>
+  }
+  if (auth === null) {
+    return (
+      <>
+        管理接口需要 token：填入与构建时{' '}
+        <code className="font-mono">AXVM_HTTP_TOKEN</code> 一致的值。后端未声明
+        校验端点，token 会在写入时才被检验。
+      </>
+    )
+  }
+  return (
+    <>
+      管理接口需要 token：填入与构建时{' '}
+      <code className="font-mono">AXVM_HTTP_TOKEN</code> 一致的值，进入前会向后端
+      校验一次。
+    </>
+  )
+}
+
 export function TokenGate({ auth, manifestError, onRetryManifest, onSubmit }: TokenGateProps) {
   const [value, setValue] = useState('')
   const [failure, setFailure] = useState<string | null>(null)
@@ -52,23 +75,7 @@ export function TokenGate({ auth, manifestError, onRetryManifest, onSubmit }: To
       <Card className="w-full max-w-md">
         <CardHeader>
           <CardTitle>Axvisor</CardTitle>
-          <CardDescription>
-            {manifestError ? (
-              <>无法读取能力清单，界面无法确定入口与鉴权方式。</>
-            ) : auth === null ? (
-              <>
-                管理接口需要 token：填入与构建时{' '}
-                <code className="font-mono">AXVM_HTTP_TOKEN</code> 一致的值。后端未声明
-                校验端点，token 会在写入时才被检验。
-              </>
-            ) : (
-              <>
-                管理接口需要 token：填入与构建时{' '}
-                <code className="font-mono">AXVM_HTTP_TOKEN</code> 一致的值，进入前会向后端
-                校验一次。
-              </>
-            )}
-          </CardDescription>
+        <CardDescription>{gateDescription(manifestError, auth)}</CardDescription>
         </CardHeader>
         <CardContent className="space-y-3">
           {manifestError && (

--- a/os/axvisor/web-ui/src/shell/TokenGate.tsx
+++ b/os/axvisor/web-ui/src/shell/TokenGate.tsx
@@ -1,43 +1,113 @@
-//! token 门。token 只存在内存态（useState），不落 sessionStorage/localStorage。
+//! token 门：进入界面前先让后端校验 token。
+//!
+//! 探测路径来自 manifest 的 auth 节点——门不硬编码端点，也不假设后端一定有
+//! token 校验（老后端没有 auth 节点时退化为「写入时才校验」，并把这句话说清楚）。
+//!
+//! token 只存在内存态（由 App 持有），不落 sessionStorage/localStorage。
 
 import { useState } from 'react'
+import { verifyToken } from '@/api/auth'
+import type { AuthProbe } from '@/api/types'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 
-export function TokenGate({ onSubmit }: { onSubmit: (token: string) => void }) {
+interface TokenGateProps {
+  /** manifest 声明的鉴权方式；null 表示后端没声明（或清单还没取到）。 */
+  auth: AuthProbe | null
+  /** manifest 拉取失败的原因；此时无从校验，只能先修清单可达性。 */
+  manifestError: string | null
+  onRetryManifest: () => void
+  onSubmit: (token: string) => void
+}
+
+export function TokenGate({ auth, manifestError, onRetryManifest, onSubmit }: TokenGateProps) {
   const [value, setValue] = useState('')
+  const [failure, setFailure] = useState<string | null>(null)
+  const [checking, setChecking] = useState(false)
+
+  const submit = async () => {
+    const token = value.trim()
+    if (!token) return
+    setFailure(null)
+
+    if (auth === null) {
+      // 没有探测端点可用：只能放行，并把「校验发生在写入时」讲清楚。
+      onSubmit(token)
+      return
+    }
+
+    setChecking(true)
+    const verdict = await verifyToken(auth, token)
+    setChecking(false)
+    if (verdict.ok) {
+      onSubmit(token)
+    } else {
+      setFailure(verdict.reason)
+    }
+  }
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-muted/40 p-4">
-      <Card className="w-full max-w-sm">
+      <Card className="w-full max-w-md">
         <CardHeader>
           <CardTitle>Axvisor</CardTitle>
           <CardDescription>
-            管理接口的写操作需要 token：填入与构建时{' '}
-            <code className="font-mono">AXVM_HTTP_TOKEN</code> 一致的值
+            {manifestError ? (
+              <>无法读取能力清单，界面无法确定入口与鉴权方式。</>
+            ) : auth === null ? (
+              <>
+                管理接口需要 token：填入与构建时{' '}
+                <code className="font-mono">AXVM_HTTP_TOKEN</code> 一致的值。后端未声明
+                校验端点，token 会在写入时才被检验。
+              </>
+            ) : (
+              <>
+                管理接口需要 token：填入与构建时{' '}
+                <code className="font-mono">AXVM_HTTP_TOKEN</code> 一致的值，进入前会向后端
+                校验一次。
+              </>
+            )}
           </CardDescription>
         </CardHeader>
-        <CardContent>
+        <CardContent className="space-y-3">
+          {manifestError && (
+            <div className="space-y-2">
+              <p className="font-mono text-xs text-destructive">{manifestError}</p>
+              <Button size="sm" variant="outline" onClick={onRetryManifest}>
+                重试读取能力清单
+              </Button>
+            </div>
+          )}
+
           <form
             className="flex gap-2"
             onSubmit={(e) => {
               e.preventDefault()
-              const token = value.trim()
-              if (token) onSubmit(token)
+              void submit()
             }}
           >
             <Input
               autoFocus
               value={value}
-              onChange={(e) => setValue(e.target.value)}
+              onChange={(e) => {
+                setValue(e.target.value)
+                setFailure(null)
+              }}
               placeholder="Bearer token"
               aria-label="token"
+              disabled={manifestError !== null}
             />
-            <Button type="submit" disabled={!value.trim()}>
-              进入
+            <Button type="submit" disabled={manifestError !== null || checking || !value.trim()}>
+              {checking ? '校验中…' : '进入'}
             </Button>
           </form>
+
+          {failure && (
+            <p className="font-mono text-xs text-destructive" role="alert">
+              {failure}
+            </p>
+          )}
         </CardContent>
       </Card>
     </div>

--- a/os/axvisor/web-ui/tailwind.config.js
+++ b/os/axvisor/web-ui/tailwind.config.js
@@ -1,0 +1,71 @@
+import tailwindcssAnimate from 'tailwindcss-animate'
+
+/** @type {import('tailwindcss').Config} */
+export default {
+  darkMode: ['class'],
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    container: {
+      center: true,
+      padding: '2rem',
+      screens: { '2xl': '1400px' },
+    },
+    extend: {
+      colors: {
+        border: 'hsl(var(--border))',
+        input: 'hsl(var(--input))',
+        ring: 'hsl(var(--ring))',
+        background: 'hsl(var(--background))',
+        foreground: 'hsl(var(--foreground))',
+        primary: {
+          DEFAULT: 'hsl(var(--primary))',
+          foreground: 'hsl(var(--primary-foreground))',
+        },
+        secondary: {
+          DEFAULT: 'hsl(var(--secondary))',
+          foreground: 'hsl(var(--secondary-foreground))',
+        },
+        destructive: {
+          DEFAULT: 'hsl(var(--destructive))',
+          foreground: 'hsl(var(--destructive-foreground))',
+        },
+        muted: {
+          DEFAULT: 'hsl(var(--muted))',
+          foreground: 'hsl(var(--muted-foreground))',
+        },
+        accent: {
+          DEFAULT: 'hsl(var(--accent))',
+          foreground: 'hsl(var(--accent-foreground))',
+        },
+        popover: {
+          DEFAULT: 'hsl(var(--popover))',
+          foreground: 'hsl(var(--popover-foreground))',
+        },
+        card: {
+          DEFAULT: 'hsl(var(--card))',
+          foreground: 'hsl(var(--card-foreground))',
+        },
+      },
+      borderRadius: {
+        lg: 'var(--radius)',
+        md: 'calc(var(--radius) - 2px)',
+        sm: 'calc(var(--radius) - 4px)',
+      },
+      keyframes: {
+        'accordion-down': {
+          from: { height: '0' },
+          to: { height: 'var(--radix-accordion-content-height)' },
+        },
+        'accordion-up': {
+          from: { height: 'var(--radix-accordion-content-height)' },
+          to: { height: '0' },
+        },
+      },
+      animation: {
+        'accordion-down': 'accordion-down 0.2s ease-out',
+        'accordion-up': 'accordion-up 0.2s ease-out',
+      },
+    },
+  },
+  plugins: [tailwindcssAnimate],
+}

--- a/os/axvisor/web-ui/tsconfig.json
+++ b/os/axvisor/web-ui/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "isolatedModules": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+    "types": ["vite/client", "node"]
+  },
+  "include": ["src", "vite.config.ts"]
+}

--- a/os/axvisor/web-ui/vite.config.ts
+++ b/os/axvisor/web-ui/vite.config.ts
@@ -11,8 +11,9 @@ export default defineConfig({
   },
   server: {
     port: 5173,
-    // dev 形态：浏览器同源访问 5173，/api 与 /ws 代理到 server。
-    // 前端代码本身用相对路径（不变量 10），所以 build 产物不经代理也能跑。
+    // Dev form: the browser hits 5173 same-origin, with /api and /ws proxied to the
+    // server. The frontend itself uses relative paths (invariant 10), so the build
+    // output runs without the proxy too.
     proxy: {
       '/api': 'http://localhost:8080',
       '/ws': { target: 'ws://localhost:8080', ws: true },

--- a/os/axvisor/web-ui/vite.config.ts
+++ b/os/axvisor/web-ui/vite.config.ts
@@ -1,0 +1,21 @@
+import { fileURLToPath, URL } from 'node:url'
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
+  server: {
+    port: 5173,
+    // dev 形态：浏览器同源访问 5173，/api 与 /ws 代理到 server。
+    // 前端代码本身用相对路径（不变量 10），所以 build 产物不经代理也能跑。
+    proxy: {
+      '/api': 'http://localhost:8080',
+      '/ws': { target: 'ws://localhost:8080', ws: true },
+    },
+  },
+})

--- a/test-suit/axvisor/normal/qemu-browser-console/browser-console/http_probe.py
+++ b/test-suit/axvisor/normal/qemu-browser-console/browser-console/http_probe.py
@@ -180,8 +180,11 @@ def check_page():
     expect_status("GET /", status, 200)
     for marker in (
         b"/api/consoles",
-        b"/assets/xterm.js",
-        b"/assets/xterm.css",
+        # The page references its xterm assets relatively, so the same HTML
+        # resolves them wherever the page is mounted (/ or /console/).
+        b'href="assets/xterm.css"',
+        b'src="assets/xterm.js"',
+
         b"new Terminal",
         b"terminal.onData",
         b"catch(() => document.execCommand('copy'))",

--- a/test-suit/axvisor/normal/qemu-http-control-plane/http-control-plane/http_probe.py
+++ b/test-suit/axvisor/normal/qemu-http-control-plane/http-control-plane/http_probe.py
@@ -27,6 +27,7 @@ auth/error mapping, start/stop, pause/resume, and the destroy-then-recreate
 resource re-acquire regression — mirroring
 `os/axvisor/doc/http-control-plane-quickstart.md`:
 
+    GET    /api/               -> 200            (control-plane manifest; vms node)
     GET    /api/vms            -> 200            (list; id=1 present)
     GET    /api/vms/1          -> 200 ready      (detail; id/name/cpu_num/vcpu_states/guest_entry_count)
     GET    /api/vms/not-an-id  -> 404            (non-numeric id)
@@ -387,6 +388,29 @@ def main():
     #    request briefly in case the axum router is still binding.
     poll_ready()
     print("  http probe: guest management server reachable")
+
+    # 1b. Control-plane manifest: the capability list a dashboard shell
+    #     navigates by. The shape is asserted, not just the status, because the
+    #     shell follows `href` instead of hardcoding routes.
+    status, body = request("GET", "/api/")
+    check("GET /api/", status, 200)
+    if body.get("proto") != 1:
+        raise AssertionError("GET /api/ reported proto=%r" % (body.get("proto"),))
+    resources = body.get("resources")
+    if not isinstance(resources, list):
+        raise AssertionError("GET /api/ reported no resources array: %r" % (body,))
+    vms_nodes = [node for node in resources if node.get("kind") == "vms"]
+    if len(vms_nodes) != 1:
+        raise AssertionError(
+            "GET /api/ did not report exactly one vms node: %r" % (body,)
+        )
+    vms_node = vms_nodes[0]
+    if vms_node.get("href") != "/api/vms":
+        raise AssertionError("GET /api/ vms node href=%r" % (vms_node.get("href"),))
+    if "read" not in vms_node.get("verbs", []) or "write" not in vms_node.get(
+        "verbs", []
+    ):
+        raise AssertionError("GET /api/ vms node verbs=%r" % (vms_node.get("verbs"),))
 
     # 2. List: the default VM (id 1) is registered and `Ready`.
     status, body = request("GET", "/api/vms")

--- a/test-suit/axvisor/normal/qemu-http-control-plane/http-control-plane/http_probe.py
+++ b/test-suit/axvisor/normal/qemu-http-control-plane/http-control-plane/http_probe.py
@@ -127,12 +127,15 @@ POLL_DEADLINE = 120.0
 POLL_INTERVAL = 1.0
 
 
-def request(method, path, token=None, body=None):
+def request(method, path, token=None, body=None, scheme="Bearer"):
     """One HTTP request; returns (status, parsed JSON or None).
 
     `token` defaults to `None`: the unauthenticated steps assert the 401
     rejections, and the poll loops mirror the runner's no-token GETs. The
     authenticated steps pass `token=TOKEN` explicitly.
+
+    `scheme` defaults to `Bearer`; the auth-scheme casing is a parameter so
+    the probe can assert the case-insensitive form clients may send.
 
     A JSON `body` is sent with `Content-Type: application/json`. A non-2xx
     response is not an error here — the caller asserts the status. A transport
@@ -141,7 +144,7 @@ def request(method, path, token=None, body=None):
     """
     headers = {}
     if token:
-        headers["Authorization"] = "Bearer " + token
+        headers["Authorization"] = scheme + " " + token
     data = None
     if body is not None:
         headers["Content-Type"] = "application/json"
@@ -460,6 +463,10 @@ def main():
     check("GET /api/auth", status, 200)
     if auth_body != {"ok": True}:
         raise AssertionError("GET /api/auth body=%r" % (auth_body,))
+    # RFC 7235 makes the auth scheme case-insensitive: a client that spells the
+    # manifest's `scheme` verbatim (lowercase) must still authenticate.
+    status, _ = request("GET", "/api/auth", token=TOKEN, scheme="bearer")
+    check("GET /api/auth (lowercase scheme)", status, 200)
 
     status, _ = request("POST", "/api/vms/create")
     check("POST /api/vms/create (no auth)", status, 401)

--- a/test-suit/axvisor/normal/qemu-http-control-plane/http-control-plane/http_probe.py
+++ b/test-suit/axvisor/normal/qemu-http-control-plane/http-control-plane/http_probe.py
@@ -27,7 +27,8 @@ auth/error mapping, start/stop, pause/resume, and the destroy-then-recreate
 resource re-acquire regression — mirroring
 `os/axvisor/doc/http-control-plane-quickstart.md`:
 
-    GET    /api/               -> 200            (control-plane manifest; vms node)
+    GET    /api/               -> 200            (control-plane manifest; vms node + auth href)
+    GET    /api/auth           -> 401 | 200      (token probe: no token / valid token)
     GET    /api/vms            -> 200            (list; id=1 present)
     GET    /api/vms/1          -> 200 ready      (detail; id/name/cpu_num/vcpu_states/guest_entry_count)
     GET    /api/vms/not-an-id  -> 404            (non-numeric id)
@@ -411,6 +412,9 @@ def main():
         "verbs", []
     ):
         raise AssertionError("GET /api/ vms node verbs=%r" % (vms_node.get("verbs"),))
+    auth_node = body.get("auth")
+    if not isinstance(auth_node, dict) or auth_node.get("href") != "/api/auth":
+        raise AssertionError("GET /api/ did not declare the auth probe: %r" % (auth_node,))
 
     # 2. List: the default VM (id 1) is registered and `Ready`.
     status, body = request("GET", "/api/vms")
@@ -447,8 +451,16 @@ def main():
     status, _ = request("GET", "/api/vms/999")
     check("GET /api/vms/999", status, 404)
 
-    # 6-11. Auth: every mutating route rejects an unauthenticated write with
-    #        401, before any VM lookup or body parse.
+    # 6-11. Auth: the token probe answers for itself, and every mutating route
+    #        rejects an unauthenticated write with 401, before any VM lookup or
+    #        body parse.
+    status, _ = request("GET", "/api/auth")
+    check("GET /api/auth (no auth)", status, 401)
+    status, auth_body = request("GET", "/api/auth", token=TOKEN)
+    check("GET /api/auth", status, 200)
+    if auth_body != {"ok": True}:
+        raise AssertionError("GET /api/auth body=%r" % (auth_body,))
+
     status, _ = request("POST", "/api/vms/create")
     check("POST /api/vms/create (no auth)", status, 401)
     status, _ = request("POST", "/api/vms/1/start")

--- a/test-suit/axvisor/normal/qemu-web-ui/build-aarch64-unknown-none-softfloat.toml
+++ b/test-suit/axvisor/normal/qemu-web-ui/build-aarch64-unknown-none-softfloat.toml
@@ -1,0 +1,28 @@
+# Web dashboard build for the `qemu-web-ui` case.
+#
+# `web-ui` serves the React dashboard from assets embedded in the hypervisor at
+# build time (no rootfs, no runtime filesystem read), and it also makes the
+# legacy console page yield `/` and `/assets/*` to the dashboard.
+# `no-auto-start` keeps the default VM (`web-ui/vm-memory.toml`, a build-time
+# embedded `memory` guest) in `Ready` (registered but not booted): the typed
+# probe drives the whole lifecycle over HTTP while also asserting the dashboard
+# shell, its hashed assets, and their response headers.
+#
+# The bundle is NOT built by cargo — run
+# `cd os/axvisor/web-ui && npm ci && npm run build` before building this case,
+# otherwise the build fails with a message naming that command.
+features = [
+    "web-ui",
+    "no-auto-start",
+]
+log = "Info"
+target = "aarch64-unknown-none-softfloat"
+vm_configs = ["test-suit/axvisor/normal/qemu-web-ui/web-ui/vm-memory.toml"]
+
+# Control-plane auth + bind, same contract as the http-control-plane case. The
+# BusyBox initramfs is generated from the managed rootfs into the path the
+# fixture's `ramdisk_path` points at.
+[env]
+AXVM_HTTP_TOKEN = "axvisor-http-test-token"
+AXVM_HTTP_BIND = "0.0.0.0:8080"
+AXVISOR_TEST_BUSYBOX_INITRAMFS = "tmp/axbuild/axvisor/qemu-web-ui/initramfs-aarch64.cpio.gz"

--- a/test-suit/axvisor/normal/qemu-web-ui/web-ui/http_probe.py
+++ b/test-suit/axvisor/normal/qemu-web-ui/web-ui/http_probe.py
@@ -1,0 +1,720 @@
+#!/usr/bin/env python3
+"""Host-side probe asset for the AxVisor management HTTP control plane.
+
+Case asset for the `http-control-plane` test case
+(`test-suit/axvisor/normal/qemu-http-control-plane/`). It owns the *test
+content* — the concrete requests, the `vm-memory.toml` fixture, and the
+assertions — and can evolve independently of the axbuild runner.
+
+The generic axbuild probe runner
+(`scripts/axbuild/src/axvisor/test/http_probe.rs`) executes this script after
+the QEMU hostfwd port is reachable, then treats the exit code as the verdict:
+0 = all assertions passed, nonzero = a step failed. The script dials the axum
+management API running *inside* the AxVisor guest through QEMU user-mode
+networking hostfwd. Nothing in the hypervisor knows a test is running.
+
+Environment (set by the generic runner):
+
+    AXVISOR_HTTP_BASE            http://127.0.0.1:<host_port> (forwarded)
+    AXVISOR_HTTP_TOKEN           bearer token for authenticated requests
+    AXVISOR_HTTP_CASE_DIR        case directory holding `vm-memory.toml`
+                                 (default: this file's directory)
+    AXVISOR_HTTP_CONNECT_TIMEOUT seconds for the initial reachability wait
+    AXVISOR_HTTP_REQUEST_TIMEOUT seconds per HTTP request
+
+The probe drives the whole `/api/vms` lifecycle contract in one boot —
+auth/error mapping, start/stop, pause/resume, and the destroy-then-recreate
+resource re-acquire regression — mirroring
+`os/axvisor/doc/http-control-plane-quickstart.md`:
+
+    GET    /                 -> 200            (dashboard shell; CSP + no-cache + nosniff)
+    GET    /assets/{hashed}  -> 200            (every asset the shell references; immutable)
+    GET    /no-such-page     -> 404            (no SPA catch-all)
+    GET    /api/               -> 200            (control-plane manifest; vms node)
+    GET    /api/vms            -> 200            (list; id=1 present)
+    GET    /api/vms/1          -> 200 ready      (detail; id/name/cpu_num/vcpu_states/guest_entry_count)
+    GET    /api/vms/not-an-id  -> 404            (non-numeric id)
+    GET    /api/vms/999        -> 404            (unknown VM)
+    POST   /api/vms/create     -> 401            (no token)
+    POST   /api/vms/1/start    -> 401            (no token)
+    POST   /api/vms/1/stop     -> 401            (no token)
+    POST   /api/vms/1/pause    -> 401            (no token)
+    POST   /api/vms/1/resume   -> 401            (no token)
+    DELETE /api/vms/1          -> 401            (no token)
+    POST   /api/vms/create {}  -> 400            (missing toml)
+    POST   /api/vms/create <bad toml> -> 400     (invalid TOML)
+    POST   /api/vms/999/start  -> 404            (auth'd unknown VM)
+    POST   /api/vms/999/stop   -> 404            (auth'd unknown VM)
+    POST   /api/vms/999/pause  -> 404            (auth'd unknown VM)
+    POST   /api/vms/999/resume -> 404            (auth'd unknown VM)
+    DELETE /api/vms/999        -> 404            (auth'd unknown VM)
+    POST   /api/vms/create     -> 409            (id=1 already registered)
+    POST   /api/vms/1/pause    -> 409            (pause from Ready)
+    POST   /api/vms/1/resume   -> 409            (resume from Ready)
+    POST   /api/vms/1/start    -> 200 -> running (async=false)
+    POST   /api/vms/1/start    -> 409            (already running)
+    POST   /api/vms/1/resume   -> 409            (resume from Running)
+    POST   /api/vms/1/pause    -> 200 -> paused  (async=true)
+    POST   /api/vms/1/pause    -> 409            (already paused)
+    POST   /api/vms/1/resume   -> 200 -> running (async=false; guest re-entered)
+    POST   /api/vms/1/resume   -> 409            (already running)
+    POST   /api/vms/1/pause    -> 200 -> paused  (second suspend/wake cycle)
+    POST   /api/vms/1/resume   -> 200 -> running (guest re-entered)
+    POST   /api/vms/1/stop     -> 200 -> stopped (async=true)
+    POST   /api/vms/1/start    -> 409            (restart-after-stop)
+    DELETE /api/vms/1          -> 204 -> 404     (gone)
+    POST   /api/vms/create     -> 200 {id:1}     (recreate after delete)
+    POST   /api/vms/create     -> 409            (id=1 re-registered)
+    POST   /api/vms/1/start    -> 200 -> running (recreated VM usable)
+    POST   /api/vms/1/stop     -> 200 -> stopped
+    DELETE /api/vms/1          -> 204 -> 404     (cleanup)
+
+The fixture pins the vCPU to Core 1 (`phys_cpu_ids = [1]`) with the management
+console on Core 0, so a resume must wake a vCPU parked on a *non-primary*
+pinned CPU. A status flip is not enough evidence that a pause/resume actually
+worked: a broken wake path could flip the status back to `running` without the
+vCPU ever re-entering the guest. To distinguish a genuine wake from a status
+flip, the probe reads the HTTP-exposed `guest_entry_count` field of the VM
+detail: the hypervisor's vCPU run loop increments it after every guest
+(re-)entry (once the guest has actually entered and exited), so it is
+independent re-execution evidence. The probe therefore asserts, after *every*
+resume, that
+`guest_entry_count` strictly advanced — so a wake that only flips status makes
+the probe exit nonzero and fails the case.
+
+The same `Paused` status has the dual problem on the *pause* side: the status
+flips to `paused` synchronously while the vCPU parks asynchronously at its next
+run-loop iteration, so a resume sent while the vCPU is still running the guest
+is absorbed — the vCPU never parked, so it never re-enters either, and the
+resume re-entry check above would be meaningless. To make each resume a genuine
+wake from a parked vCPU, the probe also reads the HTTP-exposed
+`guest_park_count`: the hypervisor increments it once each time a vCPU actually
+observes the suspended state and parks. (This *observes* a vCPU park — it is a
+VM-level aggregate, not a per-vCPU value, and is **not** a pause-completion API:
+it does not prove every vCPU/device/timer has quiesced.) After *every* pause,
+the probe polls until `guest_park_count` strictly advanced before sending the
+resume, so a pause that never completes (or a status-only pause) makes the probe
+exit nonzero and fail the case. Because `guest_entry_count` is published only
+after a *successful* guest (re-)entry, a broken wake path or a faulting resume
+that never re-enters the guest cannot advance it — making this probe the
+deterministic regression for the failed-entry path as well.
+
+The last recreate -> start -> stop -> delete block is the resource re-acquire
+regression: it proves destroy freed guest memory, vCPUs, devices, and the
+registry entry so a fresh VM can be rebuilt from the same embedded image.
+`vm-memory.toml` is matched by `base.id` against the build-time embedded
+images, so the create body carries that file verbatim (the `kernel_path` /
+`ramdisk_path` `${workspace}` placeholders are unused at runtime for memory
+images).
+"""
+
+import json
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.request
+
+BASE = os.environ.get("AXVISOR_HTTP_BASE", "http://127.0.0.1:8080").rstrip("/")
+TOKEN = os.environ.get("AXVISOR_HTTP_TOKEN", "")
+CASE_DIR = os.environ.get(
+    "AXVISOR_HTTP_CASE_DIR", os.path.dirname(os.path.abspath(__file__))
+)
+CONNECT_TIMEOUT = float(os.environ.get("AXVISOR_HTTP_CONNECT_TIMEOUT", "120"))
+REQUEST_TIMEOUT = float(os.environ.get("AXVISOR_HTTP_REQUEST_TIMEOUT", "5"))
+# Deadline for VM state transitions (boot, stop, delete): must stay well below
+# the case `timeout` (600s) so a stuck transition fails on the probe, not on
+# the QEMU timeout.
+POLL_DEADLINE = 120.0
+POLL_INTERVAL = 1.0
+
+
+def request(method, path, token=None, body=None):
+    """One HTTP request; returns (status, parsed JSON or None).
+
+    `token` defaults to `None`: the unauthenticated steps assert the 401
+    rejections, and the poll loops mirror the runner's no-token GETs. The
+    authenticated steps pass `token=TOKEN` explicitly.
+
+    A JSON `body` is sent with `Content-Type: application/json`. A non-2xx
+    response is not an error here — the caller asserts the status. A transport
+    error (connection refused/reset/timeout while the guest server is coming up
+    or mid-transition) raises RuntimeError for the caller to retry or fail.
+    """
+    headers = {}
+    if token:
+        headers["Authorization"] = "Bearer " + token
+    data = None
+    if body is not None:
+        headers["Content-Type"] = "application/json"
+        data = body.encode("utf-8")
+    req = urllib.request.Request(BASE + path, data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT) as resp:
+            status = resp.status
+            raw = resp.read()
+    except urllib.error.HTTPError as err:
+        status = err.code
+        raw = err.read()
+    except urllib.error.URLError as err:
+        raise RuntimeError("request %s %s failed: %s" % (method, path, err.reason))
+    except OSError as err:
+        # `resp.read()` raises a bare `socket.timeout` (an OSError) that the
+        # URLError handler above does not wrap. QEMU's user-mode hostfwd accepts
+        # the host-side connection as soon as QEMU starts, before the in-guest
+        # management server binds, so a first request can stall to the request
+        # timeout. Converting it to a retryable RuntimeError here lets the poll
+        # loops retry instead of crashing the probe in the boot window.
+        raise RuntimeError("request %s %s failed: %s" % (method, path, err))
+    if not raw:
+        return status, None
+    return status, json.loads(raw.decode("utf-8"))
+
+
+def check(label, actual, expected):
+    """Assert a status code, printing a progress line."""
+    if actual != expected:
+        raise AssertionError("%s returned %s, expected %s" % (label, actual, expected))
+    print("  http probe: %s -> %s (expect %s)" % (label, actual, expected))
+
+
+def vm_status(body):
+    """Extract the top-level `status` string of a VM detail body."""
+    if not isinstance(body, dict):
+        raise AssertionError("VM detail response was not a JSON object")
+    status = body.get("status")
+    if not isinstance(status, str):
+        raise AssertionError("VM detail response had no status string: %r" % (body,))
+    return status
+
+
+def check_vm_status(label, body, expected):
+    status = vm_status(body)
+    print("  http probe: %s -> status %s (expect %s)" % (label, status, expected))
+    if status != expected:
+        raise AssertionError(
+            "%s reported status %s, expected %s" % (label, status, expected)
+        )
+
+
+def guest_entry_count(body):
+    """Extract the hypervisor's VM-level monotonic guest (re-)entry count.
+
+    The vCPU run loop increments this *only* after a successful guest
+    (re-)entry (once the guest has actually entered and exited); a failed entry
+    that returns `Err` before the guest runs does not advance it. It is a VM-level
+    aggregate (shared by every vCPU task, not per-vCPU), so it proves at least
+    one vCPU re-executed — independent proof that the guest actually
+    re-executed.
+    """
+    if not isinstance(body, dict):
+        raise AssertionError("VM detail response was not a JSON object")
+    count = body.get("guest_entry_count")
+    if not isinstance(count, int):
+        raise AssertionError(
+            "VM detail response had no integer guest_entry_count: %r" % (body,)
+        )
+    return count
+
+
+def poll_guest_entries(vm_id, expected_min):
+    """Poll `GET /api/vms/{id}` until `guest_entry_count >= expected_min`.
+
+    Used to confirm the guest actually re-entered after a resume, not merely
+    that the HTTP status flipped. Fails on the poll deadline so a broken wake
+    path makes the probe exit nonzero.
+    """
+    start = time.monotonic()
+    while True:
+        if time.monotonic() - start > POLL_DEADLINE:
+            raise AssertionError(
+                "VM[%d] guest_entry_count never reached >= %d within %.0fs"
+                % (vm_id, expected_min, POLL_DEADLINE)
+            )
+        try:
+            status, body = request("GET", "/api/vms/%d" % vm_id)
+            if status == 200 and guest_entry_count(body) >= expected_min:
+                print(
+                    "  http probe: VM[%d] -> guest_entry_count %d (>= %d)"
+                    % (vm_id, guest_entry_count(body), expected_min)
+                )
+                return
+        except (RuntimeError, AssertionError):
+            pass
+        time.sleep(POLL_INTERVAL)
+
+
+def guest_park_count(body):
+    """Extract the hypervisor's VM-level count of vCPU park events.
+
+    The status flips to `Paused` synchronously while each vCPU parks
+    asynchronously at its next run-loop iteration, so the probe must wait for
+    this counter to advance after a pause before resuming: a resume sent while
+    the vCPU is still running the guest is absorbed (the vCPU never parked, so
+    it never re-enters either) and would make the resume re-entry evidence
+    ambiguous. This counter *observes* a vCPU park — it is a VM-level aggregate
+    (not per-vCPU) and is not a pause-completion API: it does not prove every
+    vCPU/device/timer has quiesced.
+    """
+    if not isinstance(body, dict):
+        raise AssertionError("VM detail response was not a JSON object")
+    count = body.get("guest_park_count")
+    if not isinstance(count, int):
+        raise AssertionError(
+            "VM detail response had no integer guest_park_count: %r" % (body,)
+        )
+    return count
+
+
+def poll_guest_parks(vm_id, expected_min):
+    """Poll `GET /api/vms/{id}` until `guest_park_count >= expected_min`.
+
+    Confirms the vCPU actually observed the paused state and parked — not merely
+    that the HTTP status flipped to `paused` — so the subsequent resume is a
+    genuine wake from a parked vCPU. Fails on the poll deadline so a pause that
+    never completes (or a status-only pause) makes the probe exit nonzero.
+    """
+    start = time.monotonic()
+    while True:
+        if time.monotonic() - start > POLL_DEADLINE:
+            raise AssertionError(
+                "VM[%d] guest_park_count never reached >= %d within %.0fs"
+                % (vm_id, expected_min, POLL_DEADLINE)
+            )
+        try:
+            status, body = request("GET", "/api/vms/%d" % vm_id)
+            if status == 200 and guest_park_count(body) >= expected_min:
+                print(
+                    "  http probe: VM[%d] -> guest_park_count %d (>= %d)"
+                    % (vm_id, guest_park_count(body), expected_min)
+                )
+                return
+        except (RuntimeError, AssertionError):
+            pass
+        time.sleep(POLL_INTERVAL)
+
+
+def check_action(label, body, ok_expected, async_expected):
+    """Assert a lifecycle action response's `ok` and `async` markers."""
+    if not isinstance(body, dict):
+        raise AssertionError("%s had no JSON body" % (label,))
+    ok = body.get("ok")
+    is_async = body.get("async")
+    print(
+        "  http probe: %s -> ok=%r async=%r (expect ok=%r async=%r)"
+        % (label, ok, is_async, ok_expected, async_expected)
+    )
+    if ok != ok_expected:
+        raise AssertionError(
+            "%s reported ok=%r, expected %r" % (label, ok, ok_expected)
+        )
+    if is_async != async_expected:
+        raise AssertionError(
+            "%s reported async=%r, expected %r" % (label, is_async, async_expected)
+        )
+
+
+def list_has_vm(body, vm_id):
+    """Whether a `GET /api/vms` body lists a VM with the given id."""
+    return isinstance(body, list) and any(
+        isinstance(item, dict) and item.get("id") == vm_id for item in body
+    )
+
+
+def poll_ready():
+    """Poll `GET /api/vms` until it returns 200 or the connect deadline passes.
+
+    The runner's TCP port wait proves the guest is listening, but the axum
+    router may still be wiring up, so the first request is retried here.
+    """
+    start = time.monotonic()
+    while True:
+        if time.monotonic() - start > CONNECT_TIMEOUT:
+            raise AssertionError(
+                "guest management HTTP server never became reachable within %.0fs"
+                % CONNECT_TIMEOUT
+            )
+        try:
+            status, _ = request("GET", "/api/vms")
+            if status == 200:
+                return
+        except RuntimeError:
+            pass
+        time.sleep(POLL_INTERVAL)
+
+
+def poll_vm_status(vm_id, expected):
+    """Poll `GET /api/vms/{id}` until its status equals `expected`."""
+    start = time.monotonic()
+    while True:
+        if time.monotonic() - start > POLL_DEADLINE:
+            raise AssertionError(
+                "VM[%d] never became %s within %.0fs" % (vm_id, expected, POLL_DEADLINE)
+            )
+        try:
+            status, body = request("GET", "/api/vms/%d" % vm_id)
+            if status == 200 and vm_status(body) == expected:
+                print("  http probe: VM[%d] -> %s" % (vm_id, expected))
+                return
+        except (RuntimeError, AssertionError):
+            # A non-200 or transport error during a transition (e.g. the VM is
+            # being torn down) is transient; keep polling until the deadline.
+            pass
+        time.sleep(POLL_INTERVAL)
+
+
+def poll_vm_gone(vm_id):
+    """Poll `GET /api/vms/{id}` until it returns 404 (the VM was deleted)."""
+    start = time.monotonic()
+    while True:
+        if time.monotonic() - start > POLL_DEADLINE:
+            raise AssertionError(
+                "VM[%d] never disappeared within %.0fs" % (vm_id, POLL_DEADLINE)
+            )
+        try:
+            status, _ = request("GET", "/api/vms/%d" % vm_id)
+            if status == 404:
+                print("  http probe: VM[%d] -> gone" % vm_id)
+                return
+        except RuntimeError:
+            pass
+        time.sleep(POLL_INTERVAL)
+
+
+def lower_headers(headers):
+    """Header name -> value, with names lowercased."""
+    return {name.lower(): value for name, value in headers.items()}
+
+
+def raw_request(path, token=None):
+    """GET without JSON parsing; returns (status, headers, body bytes).
+
+    The dashboard serves HTML and JavaScript and its response headers are part
+    of the contract this case asserts, so this bypasses the JSON helper above.
+    Header names are lowercased: HTTP header names are case-insensitive and the
+    server (hyper) writes them lowercase.
+    """
+    headers = {}
+    if token:
+        headers["Authorization"] = "Bearer " + token
+    req = urllib.request.Request(BASE + path, headers=headers, method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT) as resp:
+            return resp.status, lower_headers(resp.headers), resp.read()
+    except urllib.error.HTTPError as err:
+        return err.code, lower_headers(err.headers), err.read()
+    except (urllib.error.URLError, OSError) as err:
+        raise RuntimeError("request GET %s failed: %s" % (path, err))
+
+
+IMMUTABLE_CACHE = "public, max-age=31536000, immutable"
+
+
+def check_dashboard():
+    """The dashboard shell, its hashed assets, and the headers around them.
+
+    The assets are compiled into the hypervisor and served from memory, so this
+    is also the regression that a build without the bundle cannot pass: the
+    shell either resolves its assets or the case fails.
+    """
+    status, headers, page = raw_request("/")
+    check("GET /", status, 200)
+    for marker in (b'<div id="root">', b"<title>Axvisor</title>"):
+        if marker not in page:
+            raise AssertionError("dashboard shell is missing %r" % marker)
+    if "text/html" not in headers.get("content-type", ""):
+        raise AssertionError("GET / served %r" % headers.get("content-type"))
+    if headers.get("cache-control") != "no-cache":
+        raise AssertionError("GET / Cache-Control=%r" % headers.get("cache-control"))
+    if headers.get("x-content-type-options") != "nosniff":
+        raise AssertionError("GET / is missing nosniff")
+    csp = headers.get("content-security-policy", "")
+    if "default-src 'self'" not in csp or "frame-ancestors 'none'" not in csp:
+        raise AssertionError("GET / Content-Security-Policy=%r" % csp)
+
+    # Every asset the shell references must resolve, and a content-hashed name
+    # may be cached forever.
+    references = sorted(set(re.findall(rb"/assets/[A-Za-z0-9._-]+", page)))
+    if not references:
+        raise AssertionError("dashboard shell references no assets")
+    for reference in references:
+        path = reference.decode("utf-8")
+        status, headers, payload = raw_request(path)
+        check("GET %s" % path, status, 200)
+        if not payload:
+            raise AssertionError("%s served an empty body" % path)
+        if headers.get("cache-control") != IMMUTABLE_CACHE:
+            raise AssertionError(
+                "%s Cache-Control=%r" % (path, headers.get("cache-control"))
+            )
+        if headers.get("x-content-type-options") != "nosniff":
+            raise AssertionError("%s is missing nosniff" % path)
+
+    # No SPA catch-all: an unknown path keeps the router's 404 instead of being
+    # swallowed by the dashboard.
+    status, _, _ = raw_request("/no-such-dashboard-page")
+    check("GET /no-such-dashboard-page", status, 404)
+
+
+def main():
+    with open(os.path.join(CASE_DIR, "vm-memory.toml"), "r", encoding="utf-8") as f:
+        vm_config = f.read()
+    create_body = json.dumps({"toml": vm_config})
+    bad_body = json.dumps({"toml": "this is not [[ valid toml {{{"})
+
+    # 1. Readiness: the runner already waited for the TCP port; retry the first
+    #    request briefly in case the axum router is still binding.
+    poll_ready()
+    print("  http probe: guest management server reachable")
+
+    # 0. The dashboard of this case is served from the embedded bundle: the
+    #    shell, its hashed assets, and the headers around them.
+    check_dashboard()
+
+    # 1b. Control-plane manifest: the capability list a dashboard shell
+    #     navigates by. The shape is asserted, not just the status, because the
+    #     shell follows `href` instead of hardcoding routes.
+    status, body = request("GET", "/api/")
+    check("GET /api/", status, 200)
+    if body.get("proto") != 1:
+        raise AssertionError("GET /api/ reported proto=%r" % (body.get("proto"),))
+    resources = body.get("resources")
+    if not isinstance(resources, list):
+        raise AssertionError("GET /api/ reported no resources array: %r" % (body,))
+    vms_nodes = [node for node in resources if node.get("kind") == "vms"]
+    if len(vms_nodes) != 1:
+        raise AssertionError(
+            "GET /api/ did not report exactly one vms node: %r" % (body,)
+        )
+    vms_node = vms_nodes[0]
+    if vms_node.get("href") != "/api/vms":
+        raise AssertionError("GET /api/ vms node href=%r" % (vms_node.get("href"),))
+    if "read" not in vms_node.get("verbs", []) or "write" not in vms_node.get(
+        "verbs", []
+    ):
+        raise AssertionError("GET /api/ vms node verbs=%r" % (vms_node.get("verbs"),))
+
+    # 2. List: the default VM (id 1) is registered and `Ready`.
+    status, body = request("GET", "/api/vms")
+    check("GET /api/vms", status, 200)
+    if not list_has_vm(body, 1):
+        raise AssertionError("GET /api/vms did not list the default VM id=1")
+
+    # 3. Detail of the default VM: identity, shape, and ready status.
+    status, body = request("GET", "/api/vms/1")
+    check("GET /api/vms/1", status, 200)
+    check_vm_status("GET /api/vms/1", body, "ready")
+    if body.get("id") != 1:
+        raise AssertionError("GET /api/vms/1 did not report id=1")
+    if body.get("name") != "linux-web-ui":
+        raise AssertionError("GET /api/vms/1 did not report the fixture name")
+    if body.get("cpu_num") != 1:
+        raise AssertionError("GET /api/vms/1 did not report cpu_num=1")
+    if not isinstance(body.get("vcpu_states"), list) or not body["vcpu_states"]:
+        raise AssertionError("GET /api/vms/1 reported an empty vcpu_states array")
+    # The re-execution and pause-park evidence fields must be present on the
+    # Ready VM too (counts 0 until the first guest entry / first pause).
+    if not isinstance(body.get("guest_entry_count"), int):
+        raise AssertionError(
+            "GET /api/vms/1 reported no integer guest_entry_count: %r" % (body,)
+        )
+    if not isinstance(body.get("guest_park_count"), int):
+        raise AssertionError(
+            "GET /api/vms/1 reported no integer guest_park_count: %r" % (body,)
+        )
+
+    # 4-5. Error path: non-numeric and unknown ids are 404.
+    status, _ = request("GET", "/api/vms/not-an-id")
+    check("GET /api/vms/not-an-id", status, 404)
+    status, _ = request("GET", "/api/vms/999")
+    check("GET /api/vms/999", status, 404)
+
+    # 6-11. Auth: every mutating route rejects an unauthenticated write with
+    #        401, before any VM lookup or body parse.
+    status, _ = request("POST", "/api/vms/create")
+    check("POST /api/vms/create (no auth)", status, 401)
+    status, _ = request("POST", "/api/vms/1/start")
+    check("POST /api/vms/1/start (no auth)", status, 401)
+    status, _ = request("POST", "/api/vms/1/stop")
+    check("POST /api/vms/1/stop (no auth)", status, 401)
+    status, _ = request("POST", "/api/vms/1/pause")
+    check("POST /api/vms/1/pause (no auth)", status, 401)
+    status, _ = request("POST", "/api/vms/1/resume")
+    check("POST /api/vms/1/resume (no auth)", status, 401)
+    status, _ = request("DELETE", "/api/vms/1")
+    check("DELETE /api/vms/1 (no auth)", status, 401)
+
+    # 12-13. Create validates its body: a missing `toml` and an invalid TOML
+    #        document both reject with 400.
+    status, _ = request("POST", "/api/vms/create", token=TOKEN, body="{}")
+    check("POST /api/vms/create (missing toml)", status, 400)
+    status, _ = request("POST", "/api/vms/create", token=TOKEN, body=bad_body)
+    check("POST /api/vms/create (invalid toml)", status, 400)
+
+    # 14-17. Authenticated writes to an unknown VM are 404.
+    status, _ = request("POST", "/api/vms/999/start", token=TOKEN)
+    check("POST /api/vms/999/start (auth'd)", status, 404)
+    status, _ = request("POST", "/api/vms/999/stop", token=TOKEN)
+    check("POST /api/vms/999/stop (auth'd)", status, 404)
+    status, _ = request("POST", "/api/vms/999/pause", token=TOKEN)
+    check("POST /api/vms/999/pause (auth'd)", status, 404)
+    status, _ = request("POST", "/api/vms/999/resume", token=TOKEN)
+    check("POST /api/vms/999/resume (auth'd)", status, 404)
+    status, _ = request("DELETE", "/api/vms/999", token=TOKEN)
+    check("DELETE /api/vms/999 (auth'd)", status, 404)
+
+    # 18. Duplicate create while id=1 is registered conflicts.
+    status, _ = request("POST", "/api/vms/create", token=TOKEN, body=create_body)
+    check("POST /api/vms/create (duplicate id=1)", status, 409)
+
+    # 19-20. Pause/resume are only valid from Running/Paused respectively; a
+    #        `Ready` (not started) VM rejects both with 409.
+    status, _ = request("POST", "/api/vms/1/pause", token=TOKEN)
+    check("POST /api/vms/1/pause (from Ready)", status, 409)
+    status, _ = request("POST", "/api/vms/1/resume", token=TOKEN)
+    check("POST /api/vms/1/resume (from Ready)", status, 409)
+
+    # 21. Start the default VM: accepted synchronously (`async=false`), then
+    #     poll the detail into `running`.
+    status, body = request("POST", "/api/vms/1/start", token=TOKEN)
+    check("POST /api/vms/1/start", status, 200)
+    check_action("POST /api/vms/1/start", body, True, False)
+    poll_vm_status(1, "running")
+    # The guest must have actually entered: the vCPU run loop increments
+    # `guest_entry_count` on its first guest entry, independent of the status.
+    poll_guest_entries(1, 1)
+    status, body = request("GET", "/api/vms/1")
+    # `guest_entry_count` advances on every guest exit while the VM runs, so the
+    # re-entry baseline is read after the vCPU parks (in the pause blocks
+    # below): only a resume that re-enters the guest moves the counter past the
+    # frozen value, so a status-only resume fails the assertion.
+    parks = guest_park_count(body)
+
+    # 22. Re-starting an already-running VM conflicts.
+    status, _ = request("POST", "/api/vms/1/start", token=TOKEN)
+    check("POST /api/vms/1/start (already running)", status, 409)
+
+    # 23. Resume is only valid from Paused; a running VM rejects it.
+    status, _ = request("POST", "/api/vms/1/resume", token=TOKEN)
+    check("POST /api/vms/1/resume (from Running)", status, 409)
+
+    # 24. Pause is a request (`async=true`): the status flips to `Paused`
+    #     synchronously while the vCPU parks at its next run-loop iteration.
+    status, body = request("POST", "/api/vms/1/pause", token=TOKEN)
+    check("POST /api/vms/1/pause", status, 200)
+    check_action("POST /api/vms/1/pause", body, True, True)
+    poll_vm_status(1, "paused")
+    # Pause-completion: the status flipped synchronously, but the vCPU parks
+    # asynchronously. Wait until the vCPU has actually observed the paused
+    # state, so the resume below is a genuine wake from a parked vCPU — not a
+    # resume absorbed while the vCPU is still running the guest.
+    poll_guest_parks(1, parks + 1)
+    parks = parks + 1
+    # Sample the re-entry counter now that the vCPU has parked and the value is
+    # frozen. The resume assertion requires the counter to advance past this
+    # baseline, so a status-only resume (no re-entry) makes the poll time out.
+    status, body = request("GET", "/api/vms/1")
+    entries = guest_entry_count(body)
+
+    # 25. Pausing an already-paused VM conflicts.
+    status, _ = request("POST", "/api/vms/1/pause", token=TOKEN)
+    check("POST /api/vms/1/pause (already paused)", status, 409)
+
+    # 26. Resume is synchronous (`async=false`): the status flips back to
+    #     `Running` and the parked vCPU is woken to re-enter the guest.
+    status, body = request("POST", "/api/vms/1/resume", token=TOKEN)
+    check("POST /api/vms/1/resume", status, 200)
+    check_action("POST /api/vms/1/resume", body, True, False)
+    poll_vm_status(1, "running")
+    # Genuine wake: the parked vCPU re-entered the guest, advancing
+    # `guest_entry_count`. A status flip without re-entry would not advance it
+    # and make this poll hit its deadline.
+    poll_guest_entries(1, entries + 1)
+    entries = entries + 1
+
+    # 27. Resuming an already-running VM conflicts.
+    status, _ = request("POST", "/api/vms/1/resume", token=TOKEN)
+    check("POST /api/vms/1/resume (already running)", status, 409)
+
+    # 28-29. Second suspend/wake cycle: a parked vCPU is woken and re-parked
+    #        repeatedly, so the resume wake path must converge every time.
+    status, body = request("POST", "/api/vms/1/pause", token=TOKEN)
+    check("POST /api/vms/1/pause (cycle 2)", status, 200)
+    check_action("POST /api/vms/1/pause (cycle 2)", body, True, True)
+    poll_vm_status(1, "paused")
+    # Pause-completion on the second cycle too: wait for the vCPU to actually
+    # park before resuming.
+    poll_guest_parks(1, parks + 1)
+    parks = parks + 1
+    # Re-sample the frozen re-entry baseline for the second cycle.
+    status, body = request("GET", "/api/vms/1")
+    entries = guest_entry_count(body)
+    status, body = request("POST", "/api/vms/1/resume", token=TOKEN)
+    check("POST /api/vms/1/resume (cycle 2)", status, 200)
+    check_action("POST /api/vms/1/resume (cycle 2)", body, True, False)
+    poll_vm_status(1, "running")
+    # The wake path must converge every cycle: re-entry advances the count.
+    poll_guest_entries(1, entries + 1)
+    entries = entries + 1
+
+    # 30. Stop is a request (`async=true`): the `stopped` state arrives
+    #     asynchronously once the vCPU observes it and exits.
+    status, body = request("POST", "/api/vms/1/stop", token=TOKEN)
+    check("POST /api/vms/1/stop", status, 200)
+    check_action("POST /api/vms/1/stop", body, True, True)
+    poll_vm_status(1, "stopped")
+
+    # 31. Restart-after-stop is a known scheduling limitation; the contract
+    #     rejects it with 409 rather than hanging the VM in `running`.
+    status, _ = request("POST", "/api/vms/1/start", token=TOKEN)
+    check("POST /api/vms/1/start (restart-after-stop)", status, 409)
+
+    # 32. Delete the stopped VM, then poll until it is gone.
+    status, _ = request("DELETE", "/api/vms/1", token=TOKEN)
+    check("DELETE /api/vms/1", status, 204)
+    poll_vm_gone(1)
+
+    # 33. Recreate after delete: the embedded image is matched by id, so a
+    #     fresh create with the same config succeeds and registers id 1 again.
+    status, body = request("POST", "/api/vms/create", token=TOKEN, body=create_body)
+    check("POST /api/vms/create (recreate)", status, 200)
+    if not isinstance(body, dict) or body.get("id") != 1:
+        raise AssertionError("recreate did not return id=1")
+    poll_vm_status(1, "ready")
+
+    # 34. The re-registered id conflicts with a second create.
+    status, _ = request("POST", "/api/vms/create", token=TOKEN, body=create_body)
+    check("POST /api/vms/create (recreate duplicate)", status, 409)
+
+    # 35-36. The recreated VM must be fully usable, not merely re-registered:
+    #        destroy must have freed guest memory, vCPUs, devices, and the
+    #        registry entry so a fresh VM can be rebuilt and run from the same
+    #        embedded image. This is the resource re-acquire regression.
+    status, _ = request("POST", "/api/vms/1/start", token=TOKEN)
+    check("POST /api/vms/1/start (recreated)", status, 200)
+    poll_vm_status(1, "running")
+    # The recreated runtime's vCPU must actually enter the guest, proving the
+    # fresh build is runnable (not just registered as `Running`).
+    poll_guest_entries(1, 1)
+    status, _ = request("POST", "/api/vms/1/stop", token=TOKEN)
+    check("POST /api/vms/1/stop (recreated)", status, 200)
+    poll_vm_status(1, "stopped")
+
+    # 37. Cleanup: leave the hypervisor without a registered VM.
+    status, _ = request("DELETE", "/api/vms/1", token=TOKEN)
+    check("DELETE /api/vms/1 (cleanup)", status, 204)
+    poll_vm_gone(1)
+
+    print("  http probe: full control-plane contract passed")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except AssertionError as exc:
+        print("  http probe: FAILED: %s" % exc, file=sys.stderr)
+        sys.exit(1)
+    except Exception as exc:
+        print("  http probe: ERROR: %s" % exc, file=sys.stderr)
+        sys.exit(2)

--- a/test-suit/axvisor/normal/qemu-web-ui/web-ui/http_probe.py
+++ b/test-suit/axvisor/normal/qemu-web-ui/web-ui/http_probe.py
@@ -21,6 +21,7 @@ Environment (set by the generic runner):
                                  (default: this file's directory)
     AXVISOR_HTTP_CONNECT_TIMEOUT seconds for the initial reachability wait
     AXVISOR_HTTP_REQUEST_TIMEOUT seconds per HTTP request
+    AXVISOR_HTTP_CREATE_TIMEOUT  seconds for the VM create request
 
 The probe drives the whole `/api/vms` lifecycle contract in one boot —
 auth/error mapping, start/stop, pause/resume, and the destroy-then-recreate
@@ -128,9 +129,15 @@ REQUEST_TIMEOUT = float(os.environ.get("AXVISOR_HTTP_REQUEST_TIMEOUT", "5"))
 # the QEMU timeout.
 POLL_DEADLINE = 120.0
 POLL_INTERVAL = 1.0
+# Creating a VM parses the config, loads the embedded images and builds the
+# runtime, so its latency is not comparable to a status read and REQUEST_TIMEOUT
+# is too tight for it. A create that returns but never settles is still caught by
+# the `ready` poll that follows, so a longer budget here does not weaken the
+# probe.
+CREATE_TIMEOUT = float(os.environ.get("AXVISOR_HTTP_CREATE_TIMEOUT", "60"))
 
 
-def request(method, path, token=None, body=None):
+def request(method, path, token=None, body=None, timeout=None):
     """One HTTP request; returns (status, parsed JSON or None).
 
     `token` defaults to `None`: the unauthenticated steps assert the 401
@@ -141,6 +148,9 @@ def request(method, path, token=None, body=None):
     response is not an error here — the caller asserts the status. A transport
     error (connection refused/reset/timeout while the guest server is coming up
     or mid-transition) raises RuntimeError for the caller to retry or fail.
+
+    `timeout` overrides REQUEST_TIMEOUT for a single request; it is meant for
+    the few requests whose cost is legitimately higher than a status read.
     """
     headers = {}
     if token:
@@ -151,7 +161,9 @@ def request(method, path, token=None, body=None):
         data = body.encode("utf-8")
     req = urllib.request.Request(BASE + path, data=data, headers=headers, method=method)
     try:
-        with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT) as resp:
+        with urllib.request.urlopen(
+            req, timeout=REQUEST_TIMEOUT if timeout is None else timeout
+        ) as resp:
             status = resp.status
             raw = resp.read()
     except urllib.error.HTTPError as err:
@@ -677,7 +689,9 @@ def main():
 
     # 33. Recreate after delete: the embedded image is matched by id, so a
     #     fresh create with the same config succeeds and registers id 1 again.
-    status, body = request("POST", "/api/vms/create", token=TOKEN, body=create_body)
+    status, body = request(
+        "POST", "/api/vms/create", token=TOKEN, body=create_body, timeout=CREATE_TIMEOUT
+    )
     check("POST /api/vms/create (recreate)", status, 200)
     if not isinstance(body, dict) or body.get("id") != 1:
         raise AssertionError("recreate did not return id=1")

--- a/test-suit/axvisor/normal/qemu-web-ui/web-ui/qemu-aarch64.toml
+++ b/test-suit/axvisor/normal/qemu-web-ui/web-ui/qemu-aarch64.toml
@@ -1,0 +1,42 @@
+args = [
+  "-nographic",
+  "-cpu",
+  "cortex-a72",
+  "-machine",
+  "virt,virtualization=on,gic-version=3",
+  "-smp",
+  "2",
+  # The memory-backed guest boots its embedded kernel + BusyBox initramfs; the
+  # initramfs is the guest rootfs (`rdinit=/init`), so no NVMe disk is needed.
+  "-append",
+  "console=ttyAMA0 rdinit=/init devtmpfs.mount=1 loglevel=7",
+  # `-m 1g`: the guest uses a 256M MAP_ALLOC region, and the hypervisor plus
+  # that region must both fit in QEMU's total RAM (same sizing as the previous
+  # HTTP control case).
+  "-m",
+  "1g",
+]
+# Dashboard + full lifecycle verification via the case's host-side probe asset.
+# `[host_http_probe]` makes the runner append hostfwd netdev + virtio-net-pci
+# device and execute the probe asset (`http_probe.py`, next to this file) over
+# real TCP. The asset first asserts the dashboard served from the embedded
+# bundle (shell, hashed assets, CSP/cache headers, no SPA catch-all), then
+# drives the default VM (id 1, `vm-memory.toml`, kept `Ready` by
+# `no-auto-start`) through the whole control-plane contract —
+# list/detail/auth/error/start/pause/resume/stop/delete/recreate — with
+# polling, then quits QEMU over QMP; the runner collects the asset's exit code
+# as the verdict. The test content is owned by this case and can evolve here
+# without touching the axbuild runner.
+# `success_regex` is empty because the probe result, not serial output, is the
+# verdict; a guest panic still fails via `fail_regex`.
+fail_regex = [
+  "(?i)\\bpanic(?:ked)?\\b",
+  "(?i)kernel panic",
+]
+success_regex = []
+timeout = 600
+to_bin = true
+uefi = false
+
+[host_http_probe]
+token = "axvisor-http-test-token"

--- a/test-suit/axvisor/normal/qemu-web-ui/web-ui/vm-memory.toml
+++ b/test-suit/axvisor/normal/qemu-web-ui/web-ui/vm-memory.toml
@@ -1,0 +1,63 @@
+# Memory-backed guest fixture for the qemu-web-ui dashboard test.
+# The kernel and its BusyBox initramfs are embedded into the hypervisor binary
+# at build time (`image_location = "memory"`, see os/axvisor/build.rs) and
+# matched at runtime only by `base.id` — the `${workspace}` paths below are
+# resolved by axbuild at build time and ignored by the runtime create handler.
+#
+# `id = 1`: the runtime can only realize guest images baked into the hypervisor,
+# so the typed probe's `POST /api/vms/create` body uses this same config, whose
+# `base.id` re-matches the embedded image. `phys_cpu_ids = [1]` keeps the vCPU on
+# Core 1 while the management console runs on Core 0 — the exact configuration
+# that makes a resume wake (parked vCPU on a pinned non-primary CPU) observable.
+[base]
+id = 1
+name = "linux-web-ui"
+guest_type = "passthrough"
+cpu_num = 1
+phys_cpu_ids = [1]
+
+#
+# Vm kernel configs
+#
+[kernel]
+# The entry point of the kernel image.
+entry_point = 0x8020_0000
+# The location of image: "memory" | "fs". Memory embeds the image at build time.
+image_location = "memory"
+# The file path of the kernel image (build-time only for memory images).
+kernel_path = "${workspace}/tmp/axbuild/images/qemu-aarch64/linux/linux-qemu"
+# The load address of the kernel image.
+kernel_load_addr = 0x8020_0000
+# The load address of the device tree blob (DTB).
+dtb_load_addr = 0x8000_0000
+# BusyBox initramfs generated from the managed rootfs (the guest rootfs; the
+# QEMU case appends `rdinit=/init`).
+ramdisk_path = "${workspace}/tmp/axbuild/axvisor/qemu-web-ui/initramfs-aarch64.cpio.gz"
+ramdisk_load_addr = 0x8400_0000
+
+# Memory regions with format (`base_paddr`, `size`, `flags`, `map_type`).
+# For `map_type`, 0 means `MAP_ALLOC`, 1 means `MAP_IDENTICAL`, 2 means `MAP_RESERVED`.
+# MAP_ALLOC maps guest GPA 0x80000000 to hypervisor-allocated host pages; the
+# QEMU virt host RAM is 0x40000000..0x80000000, so an identity-mapped region
+# would land at the host heap address rather than the configured 0x80000000 and
+# the guest images at 0x80200000 would not resolve.
+memory_regions = [
+  [0x8000_0000, 0x1000_0000, 0x7, 0], # System RAM 256M MAP_ALLOC
+]
+
+#
+# Device specifications
+#
+
+# Physical-device selection. Virtual platform devices are machine-owned.
+[devices]
+passthrough = []
+# The QEMU virt PCI host bridge must stay with the host. `guest_type =
+# "passthrough"` with an empty `passthrough` list auto-assigns every host
+# device (the machine's default passthrough root is "/"), which would hand the
+# guest the host's own virtio-net-pci (host eth0). The guest Linux would then
+# enumerate and initialize it, destroying the host's vrings and killing the
+# management network path this test drives through. Excluding the PCI bridge
+# removes it from the guest DTB and punches its ECAM/MMIO ranges out of the
+# guest address space; the guest still boots its BusyBox initramfs without a NIC.
+disabled = [{ path = "/pcie@10000000" }]


### PR DESCRIPTION
## 背景与目标

把 axvisor 的 VM 管理从「串口 shell + curl 直达 HTTP API」推进到「浏览器 React 管理页」，后端 API 语义零改动。本 PR 合并了原控制面契约 PR #2350（现已转 draft）与 React 仪表盘工作，作为单一合并入口。

目标分三步，本 PR 覆盖前两步：

1. 后端契约：新增能力发现端点、整理路由装配点、定下 web-ui 占用的 URL 归属与旧终端页让位规则。
2. 前端 React 仪表盘：构建产物编译期内嵌、运行时纯内存直服（cargo 不调用 npm），VM 面板接真实 API 完成完整生命周期。
3. （下一步）终端面板：把现有 `/ws/*` 终端流接进同一个页面——不在本 PR。

## 改动概述

- **后端（os/axvisor/src/http/）**：新增 `GET /api/` 能力清单与 `GET /api/auth` token 探测（只读、开放，与既有 GET 路由一致）；mutating 路由经 `ApiToken` 提取器默认拒绝，需构建期 `AXVM_HTTP_TOKEN`；路由装配拆为 `api_router` / `console_router` / `ui_router` 三个命名根；`web-ui` feature 开启时旧终端页整棵子树让位到 `/console/`。编译期把 `web-ui/dist` 经 `build.rs` 生成 `ui_assets.rs` 内嵌，运行时纯内存服务，无文件系统读取。
- **前端（os/axvisor/web-ui/）**：manifest 驱动的壳（不硬编码端点），面板按 kind 注册；token 门在进入时校验、危险操作（创建/删除）重输 token 再执行；生命周期收口以「轮询到真实终态」为准（guest_entry_count / guest_park_count 增长、404 判定删除）。OCR（open-code-review）委托审查发现的 M1/L1/L2/L3 已在本分支收口。
- **测试与 CI**：新增 `test-suit/axvisor/normal/qemu-web-ui` 夹具与 probe 断言；`axvisor.toml` 在 web-ui case 前加 `npm ci && npm run build`，超时 30→40。

## 验证

- `cargo xtask axvisor test qemu --test-case http-control-plane` PASS：既有 `/api/vms*` 契约零回归，新增 `/api/` 形状与 `/api/auth` 401/200 断言（含小写 scheme）。
- `cargo xtask axvisor test qemu --test-case web-ui` PASS：仪表盘创建/删除/启动等生命周期断言。
- 前端 `tsc --noEmit` 通过。
- OCR（open-code-review）委托审查：43/50 文件范围，规则违例 M1（硬编码 URL）、L1（嵌套三元）、L2（kind 字面量）、L3（scheme 写死）已全部修复并合入。

## 与原 PR #2350 的关系

原控制面契约 PR #2350 已转为 draft；本 PR 取代它成为合并到 `rcore-os:dev` 的入口，diff 已包含其全部内容，无需再单独合并 #2350。
