### PR TITLE
fix(release): restore semver checks after repairing published dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1650,7 +1650,7 @@ dependencies = [
 
 [[package]]
 name = "axvm"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "aarch64-cpu 11.2.0",
  "aarch64-cpu-ext",
@@ -7239,7 +7239,7 @@ dependencies = [
 
 [[package]]
 name = "scope-local"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "ax-lazyinit",
  "ax-percpu",

--- a/components/scope-local/Cargo.toml
+++ b/components/scope-local/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scope-local"
-version = "0.6.0"
+version = "0.6.1"
 edition.workspace = true
 description = "Scope local storage"
 authors = ["朝倉水希 <asakuramizu111@gmail.com>"]

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -4,33 +4,3 @@ publish_no_verify = true
 # Publish the coordinated versions and dependency requirements from the release
 # PR, rather than publishing new crates before their dependencies are released.
 release_always = false
-
-# Published baselines still reject the tls/uspace feature union. Current sources
-# select userspace ownership when both are enabled. Re-enable these checks after
-# the new baselines are published and validated against the registry.
-[[package]]
-name = "ax-cpu"
-semver_check = false
-
-[[package]]
-name = "ax-hal"
-semver_check = false
-
-[[package]]
-name = "axplat-dyn"
-semver_check = false
-
-[[package]]
-name = "ax-runtime"
-semver_check = false
-
-[[package]]
-name = "ax-std"
-semver_check = false
-
-# starry-kernel 0.9.0 resolves axplat-dyn 0.9.1, whose direct cpu-local 0.3
-# dependency conflicts with ax-percpu 0.4.19's published cpu-local 0.2
-# requirement. Re-enable this check after ax-percpu 0.4.20 is published.
-[[package]]
-name = "starry-kernel"
-semver_check = false

--- a/virtualization/axvm/Cargo.toml
+++ b/virtualization/axvm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axvm"
 authors = ["aarkegz <aarkegz@gmail.com>"]
-version = "0.7.0"
+version = "0.7.1"
 edition.workspace = true
 categories = ["virtualization"]
 description = "Virtual Machine resource management crate for ArceOS's hypervisor variant."


### PR DESCRIPTION
Release-plz 在计算下一轮版本前，需要编译 crates.io 上的历史基线。此次失败的依赖图同时出现 `cpu-local 0.2` 和 `0.3`，导致 `CpuIndex`、`CpuPin` 等同名类型不能互传，版本 PR 因而无法生成。单纯补充重导出不能统一不同版本的类型身份。

本 PR 移除 `ax-cpu`、`ax-hal`、`axplat-dyn`、`ax-runtime`、`ax-std`、`starry-kernel` 的六项 `semver_check = false`，恢复默认检查；同步已手动发布的 `scope-local 0.6.1`、`axvm 0.7.1` 及锁文件。根工作区的依赖仍保持 `"0.4"`、`"0.6"`、`"0.7"` 等现有范围，不增加补丁版本下限，也不新增 CI 工作流、验证脚本或版本编排工具。

### 为什么原来关闭检查

前五个库最初因 `tls` 与 `uspace` 的功能并集不能编译而关闭检查。#2339 已修复功能组合，但配置仍保留“等待新基线发布”的例外。`starry-kernel` 则在 #2355 中因 `ax-percpu` 的已发布依赖不一致而被临时跳过。现在已修复注册表依赖并验证基线，这些例外可以删除。

### 已完成的前置发布

已经手动发布并确认 crates.io 可解析以下修复版本，它们均依赖 `cpu-local ^0.3.0`：

- `ax-percpu 0.4.20`：修复原 `0.4.19` 仍依赖 `cpu-local ^0.2` 的问题。
- `scope-local 0.6.1`：修复原 `0.6.0` 在 `cpu_local::current_context` 中与 `ax-percpu` 类型不一致的问题。
- `axvm 0.7.1`：修复原 `0.7.0` 遗留的 `cpu-local ^0.2` 依赖。

这些前置版本从已合入的源码准备；核对过 Rust 源码与原发布包一致，发布前通过打包内容检查和带编译验证的 `cargo publish --dry-run`。

### 验证

- 独立消费者固定 `ax-percpu =0.4.19` 与 `cpu-local =0.3.0` 时，调用 `ax_percpu::area` 确定性触发 E0308；同一消费者改用注册表中的 `ax-percpu =0.4.20` 后通过，依赖图只剩 `cpu-local 0.3.0`。
- 使用 `release-plz 0.3.165`、`cargo-semver-checks 0.50.0`，在独立检出中移除全部六项关闭配置，完整 `release-plz update` 成功；能够正常识别 `SignalFpState::new` 移除 `const` 等真实破坏性改动。
- `cargo publish --workspace --dry-run --no-verify` 通过。
- `cargo metadata --locked --no-deps --format-version 1`、`git diff --check` 通过。
- 前置发布完成后的 [dev Release-plz 运行](https://github.com/rcore-os/tgoskits/actions/runs/34554961477) 已完成且成功，并自动更新了 [发布 PR #2348](https://github.com/rcore-os/tgoskits/pull/2348)。
