### PR TITLE
feat(axvisor): validate AArch64 virtio-blk with Linux smoke

### DIFF
--- a/os/axvisor/configs/board/qemu-aarch64-virtio-blk-test.toml
+++ b/os/axvisor/configs/board/qemu-aarch64-virtio-blk-test.toml
@@ -1,4 +1,4 @@
-features = []
+features = ["ax-driver/nvme", "fs"]
 log = "Info"
 target = "aarch64-unknown-none-softfloat"
 vm_configs = [

--- a/os/axvisor/configs/qemu/qemu-aarch64-virtio-blk-test.toml
+++ b/os/axvisor/configs/qemu/qemu-aarch64-virtio-blk-test.toml
@@ -1,16 +1,21 @@
 args = [
   "-nographic",
+  # The guest overwrites a raw sector; discard all host-disk writes on exit.
+  "-snapshot",
   "-cpu", "cortex-a72",
   "-machine", "virt,virtualization=on,gic-version=3",
   "-smp", "4",
+  "-device", "nvme,drive=disk0,serial=tgoskits,max_ioqpairs=64,msix_qsize=65",
+  "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-aarch64-alpine.img",
+  "-append", "root=/dev/nvme0n1 rw init=/bin/sh",
   "-m", "4g",
 ]
 fail_regex = ["ARCEOS_VIRTIO_BLK_FAIL", "(?i)panic"]
-timeout = 120
+timeout = 180
 to_bin = true
 uefi = false
 
 [[shell_check_steps]]
-shell_prefix = "axvisor:$"
+shell_prefix = "axvisor:/$"
 shell_cmd = "vm console 1"
 success_regex = ["ARCEOS_VIRTIO_BLK_PASS"]

--- a/os/axvisor/configs/vms/qemu/aarch64/linux-virtio-blk.toml
+++ b/os/axvisor/configs/vms/qemu/aarch64/linux-virtio-blk.toml
@@ -1,19 +1,21 @@
 [base]
 id = 1
-name = "arceos-virtio-blk-test"
+name = "linux-virtio-blk-mount-aarch64"
 guest_type = "virtualized"
 cpu_num = 1
 phys_cpu_ids = [1]
-phys_cpu_sets = [1]
 
 [kernel]
 entry_point = 0x8020_0000
 image_location = "memory"
-kernel_path = "${workspace}/target/aarch64-unknown-linux-musl/release/arceos-virtio-blk-test.bin"
+kernel_path = "${workspace}/tmp/axbuild/images/qemu-aarch64/linux/linux-qemu"
 kernel_load_addr = 0x8020_0000
 dtb_load_addr = 0x8000_0000
+ramdisk_path = "${workspace}/tmp/axbuild/images/initramfs-aarch64-busybox.cpio.gz/initramfs-aarch64-busybox.cpio.gz"
+ramdisk_load_addr = 0x8400_0000
+cmdline = "console=ttyAMA0 earlycon rdinit=/init devtmpfs.mount=1"
 memory_regions = [
-  [0x8000_0000, 0x2000_0000, 0x7, 0],
+    [0x8000_0000, 0x4000_0000, 0x7, 0],
 ]
 
 [devices]

--- a/scripts/axbuild/src/axvisor/rootfs.rs
+++ b/scripts/axbuild/src/axvisor/rootfs.rs
@@ -31,6 +31,7 @@ struct VmRootfsProbe {
 #[derive(Deserialize)]
 struct VmKernelRootfsProbe {
     kernel_path: Option<String>,
+    ramdisk_path: Option<String>,
 }
 
 pub(super) async fn qemu(axvisor: &mut Axvisor, args: super::ArgsQemu) -> anyhow::Result<()> {
@@ -190,42 +191,47 @@ fn guest_image_references(
         let probe: VmRootfsProbe = toml::from_str(&content).map_err(|error| {
             anyhow!("failed to parse vm config {}: {error}", vmconfig.display())
         })?;
-        let Some(kernel_path) = probe.kernel.and_then(|kernel| kernel.kernel_path) else {
+        let Some(kernel) = probe.kernel else {
             continue;
         };
-        let required_path = resolve_vm_asset_path(vmconfig, workspace_root, &kernel_path);
-        let Ok(relative) = required_path.strip_prefix(&image_dir) else {
-            continue;
-        };
-        let components = relative.components().collect::<Vec<_>>();
-        if components.is_empty()
-            || components
-                .iter()
-                .any(|component| !matches!(component, Component::Normal(_)))
+        for kernel_path in [kernel.kernel_path, kernel.ramdisk_path]
+            .into_iter()
+            .flatten()
         {
-            bail!(
-                "invalid managed Axvisor guest image path `{}` in {}",
-                kernel_path,
-                vmconfig.display()
-            );
-        }
-        let image_name = components[0]
-            .as_os_str()
-            .to_str()
-            .ok_or_else(|| {
-                anyhow!(
-                    "Axvisor guest image name in {} is not valid UTF-8",
+            let required_path = resolve_vm_asset_path(vmconfig, workspace_root, &kernel_path);
+            let Ok(relative) = required_path.strip_prefix(&image_dir) else {
+                continue;
+            };
+            let components = relative.components().collect::<Vec<_>>();
+            if components.is_empty()
+                || components
+                    .iter()
+                    .any(|component| !matches!(component, Component::Normal(_)))
+            {
+                bail!(
+                    "invalid managed Axvisor guest image path `{}` in {}",
+                    kernel_path,
                     vmconfig.display()
-                )
-            })?
-            .to_string();
-        references
-            .entry(image_name)
-            .or_default()
-            .push(GuestImageReference {
-                vmconfig: vmconfig.clone(),
-                required_path,
-            });
+                );
+            }
+            let image_name = components[0]
+                .as_os_str()
+                .to_str()
+                .ok_or_else(|| {
+                    anyhow!(
+                        "Axvisor guest image name in {} is not valid UTF-8",
+                        vmconfig.display()
+                    )
+                })?
+                .to_string();
+            references
+                .entry(image_name)
+                .or_default()
+                .push(GuestImageReference {
+                    vmconfig: vmconfig.clone(),
+                    required_path,
+                });
+        }
     }
     Ok(references)
 }

--- a/test-suit/axvisor/normal/qemu/build-aarch64-unknown-none-softfloat.toml
+++ b/test-suit/axvisor/normal/qemu/build-aarch64-unknown-none-softfloat.toml
@@ -4,4 +4,4 @@ features = [
 ]
 log = "Info"
 target = "aarch64-unknown-none-softfloat"
-vm_configs = []
+vm_configs = ["os/axvisor/configs/vms/qemu/aarch64/linux-virtio-blk.toml"]

--- a/test-suit/axvisor/normal/qemu/smoke/qemu-aarch64.toml
+++ b/test-suit/axvisor/normal/qemu/smoke/qemu-aarch64.toml
@@ -1,5 +1,6 @@
 args = [
   "-nographic",
+  "-snapshot",
   "-cpu",
   "cortex-a72",
   "-machine",
@@ -16,20 +17,60 @@ args = [
   "8g",
 ]
 fail_regex = [
-  "(?i)\\bpanic(?:ked)?\\b",
-  "(?i)kernel panic",
-  "(?i)login incorrect",
-  "(?i)permission denied",
-  "(?m)^(?:echo|cat|rm): (?:can't (?:open|remove) |cannot remove |/tmp/axvisor-nvme-rw:)",
+    "(?m)^VIRTIO_BLK_MOUNT_FAIL:",
+    "(?i)\\bpanic(?:ked)?\\b",
+    "(?i)login incorrect",
+    "(?i)permission denied",
+    "(?m)^(?:echo|cat|rm): (?:can't (?:open|remove) |cannot remove |/tmp/axvisor-nvme-rw:)",
 ]
-shell_check_steps = [{ shell_prefix = "axvisor:/$", shell_cmd = """
-echo 'AXVISOR SHLEX' "" EMPTY
-'help' vm start
-echo "unterminated
-echo AXVISOR_NVME_RW_PAYLOAD > /tmp/axvisor-nvme-rw
-cat /tmp/axvisor-nvme-rw
-rm -f /tmp/axvisor-nvme-rw
-echo AXVISOR_NVME_ROOTFS_RW_PASSED
-""", success_regex = ["(?m)^AXVISOR SHLEX  EMPTY\\s*$", "(?m)^Command: vm start\\s*$", "(?m)^Error: Invalid command syntax\\s*$", "(?m)^AXVISOR_NVME_RW_PAYLOAD\\s*$", "(?m)^AXVISOR_NVME_ROOTFS_RW_PASSED\\s*$"] }]
+timeout = 300
 to_bin = true
 uefi = false
+
+[[shell_check_steps]]
+shell_prefix = "axvisor:/$"
+shell_cmd = """echo 'AXVISOR SHLEX' "" EMPTY"""
+success_regex = ['(?m)^AXVISOR SHLEX  EMPTY\s*$']
+
+[[shell_check_steps]]
+shell_cmd = "'help' vm start"
+success_regex = ['(?m)^Command: vm start\s*$']
+
+[[shell_check_steps]]
+shell_cmd = 'echo "unterminated'
+success_regex = ['(?m)^Error: Invalid command syntax\s*$']
+
+[[shell_check_steps]]
+shell_cmd = "echo AXVISOR_NVME_RW_PAYLOAD > /tmp/axvisor-nvme-rw"
+
+[[shell_check_steps]]
+shell_cmd = "cat /tmp/axvisor-nvme-rw"
+success_regex = ['(?m)^AXVISOR_NVME_RW_PAYLOAD\s*$']
+
+[[shell_check_steps]]
+shell_cmd = "rm -f /tmp/axvisor-nvme-rw"
+
+[[shell_check_steps]]
+shell_cmd = "echo AXVISOR_NVME_ROOTFS_RW_PASSED"
+success_regex = ['(?m)^AXVISOR_NVME_ROOTFS_RW_PASSED\s*$']
+
+[[shell_check_steps]]
+shell_prefix = "axvisor:/$"
+shell_cmd = "vm console 1"
+success_regex = ['(?m)^test pass!\s*$']
+
+[[shell_check_steps]]
+shell_prefix = "~ #"
+shell_cmd = "mkdir -p /mnt/v"
+
+[[shell_check_steps]]
+shell_cmd = "mount -t ext4 -o ro /dev/vda /mnt/v"
+success_regex = ['EXT4-fs \(vda\): mounted filesystem .* ro ']
+fail_regex = ['mount:']
+timeout = 60
+
+[[shell_check_steps]]
+shell_cmd = "cat /mnt/v/etc/alpine-release"
+success_regex = ['(?m)^3\.23\.5\s*$']
+fail_regex = ['cat:']
+timeout = 60


### PR DESCRIPTION
## 改动内容

- 扩展 AArch64 smoke：保留宿主 shell 命令解析和 NVMe 文件读写检查，再进入 Linux，验证 virtio-blk 的 ext4 只读挂载及文件读取。检查拆为独立步骤，避免匹配到任一成功标记就提前通过。
- 新增 Linux 客户机配置，使用 memory 加载内核和 initramfs，将宿主 rootfs 内已有的客户机镜像作为 virtio-blk 后端。
- ArceOS virtio-blk 测例从 ramdisk 切换到已有 ext4 文件镜像，移除固定容量，通过 QEMU 快照隔离测试写入。
- axbuild 同时扫描 kernel_path 和 ramdisk_path，自动准备内核与 initramfs，避免缺少文件导致构建失败。