### PR TITLE
fix(ax-task): drain idle scheduler work before offline probes

### DIFF
--- a/components/ax-task/src/runtime/cpu.rs
+++ b/components/ax-task/src/runtime/cpu.rs
@@ -269,34 +269,13 @@ pub fn probe_idle_cpu_round_trip(publish_work_after_drain: bool) -> Result<(), T
     if cpu.remote().current_thread() != cpu.remote().idle_thread() {
         return Err(TaskError::NotReady);
     }
-    // Linux drains pending wakeups before its final sched_cpu_dying checks.
-    // Idle's preceding schedule is not a quiescence guarantee: owner work can
-    // arrive after it returns. Keep the request pending until the normal idle
-    // scheduler consumes that work, without entering the offline transaction.
-    // The IRQ guard closes the local interrupt window through admission.
-    if !publish_work_after_drain && (cpu.needs_reschedule() || cpu.has_remote_work()) {
-        return Err(TaskError::NotReady);
-    }
     if publish_work_after_drain {
-        // Force the remote-arrival window after the optimistic work recheck.
-        // Admission must still classify it while its publication gate is shut.
+        // Force work published after idle's normal scheduler drain.
+        // The lifecycle owner must close placement before draining this work.
         cpu.request_scheduler_work();
     }
     record_idle_offline_rejection(IdleOfflineRejection::Unclassified);
-    match system.take_cpu_offline(cpu.as_mut()) {
-        Err(TaskError::CpuNotQuiescent(_))
-            if matches!(
-                idle_offline_rejection(),
-                IdleOfflineRejection::SchedulerWork
-            ) =>
-        {
-            // A remote producer can win after the initial recheck. The
-            // transaction classified that work with publication closed and
-            // rolled admission back; drain it through the normal idle loop.
-            return Err(TaskError::NotReady);
-        }
-        result => result?,
-    }
+    system.take_cpu_offline(cpu.as_mut())?;
     assert_eq!(cpu.remote().lifecycle_state(), CpuLifecycleState::Offline);
     assert!(system.cpu_remote(cpu.owner()).is_none());
     // Returning an error here would strand the executing idle owner offline.
@@ -318,5 +297,55 @@ pub fn notify_idle_cpu_probe(cpu: RuntimeCpuId) -> Result<(), TaskError> {
         Ok(())
     } else {
         Err(TaskError::CpuOffline(cpu.as_u32()))
+    }
+}
+
+/// Actual scheduler readers retained by the cross-CPU offline regression.
+#[cfg(feature = "fault-injection")]
+#[derive(Clone, Copy, Debug)]
+pub enum IdleOfflineReader {
+    /// A remote control publisher between admission and completion.
+    OwnerDelivery,
+    /// A source CPU still finishing a committed idle-balance claim.
+    IdleBalance,
+}
+
+/// Retains a real scheduler reader across a controlled cross-CPU test.
+/// No IRQ or rq guard is held across the callback, so the target can run its
+/// ordinary idle lifecycle protocol while the callback observes the transition.
+#[cfg(feature = "fault-injection")]
+pub fn with_idle_offline_reader<T>(
+    cpu: RuntimeCpuId,
+    reader: IdleOfflineReader,
+    action: impl FnOnce(&CpuRemote) -> T,
+) -> Result<T, TaskError> {
+    crate::thread::current::validate_blocking_context()?;
+    let system = crate::runtime::context::runtime_task_system()?;
+    let remote = system
+        .cpu_remote(crate::sched::CpuId::new(cpu.as_u32()))
+        .ok_or(TaskError::CpuOffline(cpu.as_u32()))?;
+    record_idle_offline_rejection(IdleOfflineRejection::Unclassified);
+    match reader {
+        IdleOfflineReader::OwnerDelivery => {
+            let _publication = remote
+                .begin_owner_delivery()
+                .ok_or(TaskError::CpuOffline(cpu.as_u32()))?;
+            Ok(action(remote))
+        }
+        IdleOfflineReader::IdleBalance => {
+            let crate::sched::system::IdlePullReservation::Started(reservation) =
+                remote.begin_idle_pull()
+            else {
+                return Err(TaskError::NotReady);
+            };
+            let Some(mut claim) = remote.claim_idle_pull(reservation) else {
+                remote.cancel_idle_pull(reservation);
+                return Err(TaskError::NotReady);
+            };
+            if !claim.commit() {
+                return Err(TaskError::NotReady);
+            }
+            Ok(action(remote))
+        }
     }
 }

--- a/components/ax-task/src/runtime/cpu.rs
+++ b/components/ax-task/src/runtime/cpu.rs
@@ -226,6 +226,8 @@ pub enum IdleOfflineRejection {
     CpuState             = 4,
     /// A thread retains CPU ownership or a migration pin.
     ThreadOwnership      = 5,
+    /// Scheduler work arrived before owner publication was closed.
+    SchedulerWork        = 6,
 }
 
 #[cfg(feature = "fault-injection")]
@@ -245,6 +247,7 @@ pub fn idle_offline_rejection() -> IdleOfflineRejection {
         3 => IdleOfflineRejection::OwnerPublication,
         4 => IdleOfflineRejection::CpuState,
         5 => IdleOfflineRejection::ThreadOwnership,
+        6 => IdleOfflineRejection::SchedulerWork,
         _ => IdleOfflineRejection::Unclassified,
     }
 }
@@ -254,8 +257,10 @@ pub fn idle_offline_rejection() -> IdleOfflineRejection {
 /// This test-only transaction retains IRQ exclusion and the exclusive owner
 /// borrow across both transitions. It never returns to scheduling while offline
 /// and does not implement platform power-off or an externally parked CPU.
+/// Returns `NotReady` while ordinary scheduler work must be drained first.
+/// `publish_work_after_drain` injects that real publication once for a regression.
 #[cfg(feature = "fault-injection")]
-pub fn probe_idle_cpu_round_trip() -> Result<(), TaskError> {
+pub fn probe_idle_cpu_round_trip(publish_work_after_drain: bool) -> Result<(), TaskError> {
     use crate::runtime::context::{RuntimeIrqGuard, runtime_current_cpu_mut, runtime_task_system};
     validate_schedule_context(RuntimeScheduleOrigin::Preempt)?;
     let system = runtime_task_system()?;
@@ -264,8 +269,34 @@ pub fn probe_idle_cpu_round_trip() -> Result<(), TaskError> {
     if cpu.remote().current_thread() != cpu.remote().idle_thread() {
         return Err(TaskError::NotReady);
     }
+    // Linux drains pending wakeups before its final sched_cpu_dying checks.
+    // Idle's preceding schedule is not a quiescence guarantee: owner work can
+    // arrive after it returns. Keep the request pending until the normal idle
+    // scheduler consumes that work, without entering the offline transaction.
+    // The IRQ guard closes the local interrupt window through admission.
+    if !publish_work_after_drain && (cpu.needs_reschedule() || cpu.has_remote_work()) {
+        return Err(TaskError::NotReady);
+    }
+    if publish_work_after_drain {
+        // Force the remote-arrival window after the optimistic work recheck.
+        // Admission must still classify it while its publication gate is shut.
+        cpu.request_scheduler_work();
+    }
     record_idle_offline_rejection(IdleOfflineRejection::Unclassified);
-    system.take_cpu_offline(cpu.as_mut())?;
+    match system.take_cpu_offline(cpu.as_mut()) {
+        Err(TaskError::CpuNotQuiescent(_))
+            if matches!(
+                idle_offline_rejection(),
+                IdleOfflineRejection::SchedulerWork
+            ) =>
+        {
+            // A remote producer can win after the initial recheck. The
+            // transaction classified that work with publication closed and
+            // rolled admission back; drain it through the normal idle loop.
+            return Err(TaskError::NotReady);
+        }
+        result => result?,
+    }
     assert_eq!(cpu.remote().lifecycle_state(), CpuLifecycleState::Offline);
     assert!(system.cpu_remote(cpu.owner()).is_none());
     // Returning an error here would strand the executing idle owner offline.

--- a/components/ax-task/src/sched/system/cpu/remote/idle_pull.rs
+++ b/components/ax-task/src/sched/system/cpu/remote/idle_pull.rs
@@ -38,6 +38,8 @@ pub(crate) enum IdlePullReservation {
 pub(crate) struct IdlePullClaim<'remote> {
     remote: &'remote CpuRemote,
     state: u64,
+    // Drop clears the claim before this lease allows final CPU draining.
+    _publication: CpuRemotePublication<'remote>,
 }
 
 impl IdlePullClaim<'_> {
@@ -104,6 +106,9 @@ impl Drop for IdlePullWorkPublication<'_> {
 
 impl CpuRemote {
     pub(crate) fn begin_idle_pull(&self) -> IdlePullReservation {
+        let Some(_publication) = self.begin_publication() else {
+            return IdlePullReservation::Busy;
+        };
         let mut current = self.idle_pull.state.load(Ordering::Acquire);
         loop {
             if current & IDLE_PULL_PUBLISHER_MASK != 0 {
@@ -123,7 +128,16 @@ impl CpuRemote {
                 Ordering::AcqRel,
                 Ordering::Acquire,
             ) {
-                Ok(_) => return IdlePullReservation::Started(pending),
+                Ok(_) => {
+                    // Inactivation can win after the read-side lease starts.
+                    // Withdraw a late reservation before releasing the lease;
+                    // one published earlier is cancelled by try_deactivate.
+                    if !self.accepts_placement() {
+                        self.cancel_idle_pull(pending);
+                        return IdlePullReservation::Busy;
+                    }
+                    return IdlePullReservation::Started(pending);
+                }
                 Err(actual) => current = actual,
             }
         }
@@ -202,6 +216,10 @@ impl CpuRemote {
     }
 
     pub(crate) fn claim_idle_pull(&self, reservation: u64) -> Option<IdlePullClaim<'_>> {
+        // Linux's CPU-deactivate grace period covers source-side balancing
+        // readers through their complete rq transaction. Keep the destination
+        // protected even after migration publication itself has completed.
+        let publication = self.begin_publication()?;
         if reservation & (IDLE_PULL_PHASE_MASK | IDLE_PULL_PUBLISHER_MASK) != IDLE_PULL_PENDING {
             return None;
         }
@@ -213,6 +231,7 @@ impl CpuRemote {
             .map(|_| IdlePullClaim {
                 remote: self,
                 state: claimed,
+                _publication: publication,
             })
     }
 

--- a/components/ax-task/src/sched/system/cpu/remote/lifecycle.rs
+++ b/components/ax-task/src/sched/system/cpu/remote/lifecycle.rs
@@ -89,23 +89,31 @@ impl CpuRemote {
     }
 
     pub(crate) fn try_deactivate(&self) -> bool {
-        // Matching the exact zero-valued Online state proves that no target-rq
-        // placement transaction spans the transition. Owner-directed control
-        // delivery remains allowed until final draining.
+        // Linux clears cpu_active before synchronizing prior placement readers.
+        // Preserve their leases while closing admission to new placement.
         let inactive = self
             .publication
             .state
-            .compare_exchange(
-                0,
-                CPU_LIFECYCLE_INACTIVE,
-                Ordering::AcqRel,
-                Ordering::Acquire,
-            )
+            .try_update(Ordering::AcqRel, Ordering::Acquire, |state| {
+                (state & CPU_LIFECYCLE_MASK == 0).then_some(state | CPU_LIFECYCLE_INACTIVE)
+            })
             .is_ok();
         if inactive {
             self.cancel_idle_pull_if_uncommitted();
         }
         inactive
+    }
+
+    pub(crate) fn resume_owner_drain(&self) {
+        self.publication
+            .state
+            .compare_exchange(
+                CPU_LIFECYCLE_DRAINING,
+                CPU_LIFECYCLE_INACTIVE,
+                Ordering::Release,
+                Ordering::Acquire,
+            )
+            .expect("owner drain resumes only from a closed publication gate");
     }
 
     pub(crate) fn cancel_deactivation(&self) {

--- a/components/ax-task/src/sched/system/task_system/cpu_lifecycle.rs
+++ b/components/ax-task/src/sched/system/task_system/cpu_lifecycle.rs
@@ -170,8 +170,10 @@ impl TaskSystem {
     ///
     /// The caller must first migrate or retire every non-idle thread, cancel
     /// local task deadlines, and consume the CPU's scheduler IPI. The packed
-    /// remote lifecycle closes publication only when its active publisher count
-    /// is zero, so a successful transition cannot strand an inbox node between
+    /// remote lifecycle first closes placement, then waits for prior publishers
+    /// before closing owner delivery. `NotReady` retains `Inactive`: the owner
+    /// must service normal scheduler work and continue this operation. Other
+    /// errors roll back admission. Success cannot strand an inbox node between
     /// queue insertion and its doorbell.
     pub fn take_cpu_offline(&self, mut cpu: Pin<&mut CpuLocal>) -> Result<(), TaskError> {
         self.ensure_owner_cpu_context(&cpu)?;
@@ -183,98 +185,134 @@ impl TaskSystem {
         if !Arc::ptr_eq(&remote, cpu.remote()) {
             return Err(TaskError::InvalidRuntimeHandle);
         }
-        match remote.lifecycle_state() {
-            crate::runtime::cpu::CpuLifecycleState::Offline => {
-                return Err(TaskError::CpuOffline(id.as_u32()));
+        let result = (|| {
+            match remote.lifecycle_state() {
+                crate::runtime::cpu::CpuLifecycleState::Offline => {
+                    return Err(TaskError::CpuOffline(id.as_u32()));
+                }
+                crate::runtime::cpu::CpuLifecycleState::Draining => {
+                    return Err(TaskError::CpuNotQuiescent(id.as_u32()));
+                }
+                crate::runtime::cpu::CpuLifecycleState::Online
+                | crate::runtime::cpu::CpuLifecycleState::Inactive => {}
             }
-            crate::runtime::cpu::CpuLifecycleState::Inactive
-            | crate::runtime::cpu::CpuLifecycleState::Draining => {
+            // A staged first activation is a persistent admission reservation, not
+            // an in-flight publication reader. Registry ownership serializes this
+            // check with stage/activate/cancel, before placement is closed.
+            if state
+                .slots
+                .iter()
+                .filter_map(|slot| slot.record.as_ref())
+                .any(|record| {
+                    record
+                        .activation
+                        .as_ref()
+                        .is_some_and(|activation| activation.target() == id)
+                })
+            {
+                #[cfg(feature = "fault-injection")]
+                crate::runtime::cpu::record_idle_offline_rejection(
+                    crate::runtime::cpu::IdleOfflineRejection::PlacementPublication,
+                );
                 return Err(TaskError::CpuNotQuiescent(id.as_u32()));
             }
-            crate::runtime::cpu::CpuLifecycleState::Online => {}
-        }
-        if root_domain.online.count() <= 1 {
-            return Err(TaskError::LastOnlineCpu(id.as_u32()));
-        }
-        if !root_domain.can_deactivate_cpu(id) {
-            return Err(TaskError::DeadlineAdmission);
-        }
-        let remaining_online = root_domain
-            .online
-            .count()
-            .checked_sub(1)
-            .ok_or(TaskError::InvalidConfiguration)?;
-        let deadline_rebuild = state.deadline_bandwidth_rebuild(remaining_online)?;
-        let rt_period_replacement = (0..root_domain.online.topology_len())
-            .map(|index| CpuId::new(index as u32))
-            .find(|candidate| *candidate != id && root_domain.online.contains(*candidate))
-            .ok_or(TaskError::LastOnlineCpu(id.as_u32()))?;
-
-        self.migrate_dormant_deadline_bandwidth_for_cpu_offline(&state, &root_domain, id)?;
-
-        if !remote.try_deactivate() {
-            #[cfg(feature = "fault-injection")]
-            crate::runtime::cpu::record_idle_offline_rejection(
-                crate::runtime::cpu::IdleOfflineRejection::PlacementPublication,
-            );
-            Err(TaskError::CpuNotQuiescent(id.as_u32()))
-        } else if !Self::prepare_thread_targets_for_cpu_offline(&state, &root_domain, id) {
-            #[cfg(feature = "fault-injection")]
-            crate::runtime::cpu::record_idle_offline_rejection(
-                crate::runtime::cpu::IdleOfflineRejection::ThreadTarget,
-            );
-            remote.cancel_deactivation();
-            Err(TaskError::CpuNotQuiescent(id.as_u32()))
-        } else if !remote.try_begin_draining() {
-            #[cfg(feature = "fault-injection")]
-            crate::runtime::cpu::record_idle_offline_rejection(
-                crate::runtime::cpu::IdleOfflineRejection::OwnerPublication,
-            );
-            remote.cancel_deactivation();
-            Err(TaskError::CpuNotQuiescent(id.as_u32()))
-        } else if !cpu.is_quiescent_for_offline() {
-            #[cfg(feature = "fault-injection")]
-            crate::runtime::cpu::record_idle_offline_rejection(
-                if cpu.needs_reschedule() || cpu.has_remote_work() {
-                    crate::runtime::cpu::IdleOfflineRejection::SchedulerWork
-                } else {
-                    crate::runtime::cpu::IdleOfflineRejection::CpuState
-                },
-            );
-            remote.cancel_draining();
-            Err(TaskError::CpuNotQuiescent(id.as_u32()))
-        } else if !Self::threads_allow_cpu_offline(&state, &root_domain, id) {
-            #[cfg(feature = "fault-injection")]
-            crate::runtime::cpu::record_idle_offline_rejection(
-                crate::runtime::cpu::IdleOfflineRejection::ThreadOwnership,
-            );
-            remote.cancel_draining();
-            Err(TaskError::CpuNotQuiescent(id.as_u32()))
-        } else if let Err(error) = ensure_runtime_success(task_runtime::prepare_cpu_offline(
-            RuntimeCpuId::new(id.as_u32()),
-        )) {
-            remote.cancel_draining();
-            Err(error)
-        } else if !root_domain.remove_online(id, deadline_rebuild) {
-            remote.cancel_draining();
-            Err(TaskError::InvalidConfiguration)
-        } else {
-            cpu.as_mut().clear_fair_balance();
-            self.root_domain.disable_rt_runtime(id);
-            remote.finish_offline();
-            remote
-                .lock_run_queue(RunQueueGuardSource::Lifecycle)
-                .invalidate_domain_publication();
-            self.root_domain.publish_offline(id);
-            if self
-                .root_domain
-                .rt_bandwidth()
-                .migrate_owner(id, rt_period_replacement)
-            {
-                self.cpu_remotes[rt_period_replacement.as_usize()].kick_scheduler_work();
+            if root_domain.online.count() <= 1 {
+                return Err(TaskError::LastOnlineCpu(id.as_u32()));
             }
-            Ok(())
+            if !root_domain.can_deactivate_cpu(id) {
+                return Err(TaskError::DeadlineAdmission);
+            }
+            let remaining_online = root_domain
+                .online
+                .count()
+                .checked_sub(1)
+                .ok_or(TaskError::InvalidConfiguration)?;
+            let deadline_rebuild = state.deadline_bandwidth_rebuild(remaining_online)?;
+            let rt_period_replacement = (0..root_domain.online.topology_len())
+                .map(|index| CpuId::new(index as u32))
+                .find(|candidate| *candidate != id && root_domain.online.contains(*candidate))
+                .ok_or(TaskError::LastOnlineCpu(id.as_u32()))?;
+
+            self.migrate_dormant_deadline_bandwidth_for_cpu_offline(&state, &root_domain, id)?;
+
+            if remote.lifecycle_state() == crate::runtime::cpu::CpuLifecycleState::Online
+                && !remote.try_deactivate()
+            {
+                #[cfg(feature = "fault-injection")]
+                crate::runtime::cpu::record_idle_offline_rejection(
+                    crate::runtime::cpu::IdleOfflineRejection::PlacementPublication,
+                );
+                Err(TaskError::CpuNotQuiescent(id.as_u32()))
+            } else if !remote.try_begin_draining() {
+                #[cfg(feature = "fault-injection")]
+                crate::runtime::cpu::record_idle_offline_rejection(
+                    crate::runtime::cpu::IdleOfflineRejection::OwnerPublication,
+                );
+                Err(TaskError::NotReady)
+            } else if !cpu.is_quiescent_for_offline() {
+                #[cfg(feature = "fault-injection")]
+                crate::runtime::cpu::record_idle_offline_rejection(
+                    if cpu.needs_reschedule() || cpu.has_remote_work() {
+                        crate::runtime::cpu::IdleOfflineRejection::SchedulerWork
+                    } else {
+                        crate::runtime::cpu::IdleOfflineRejection::CpuState
+                    },
+                );
+                if cpu.needs_reschedule() || cpu.has_remote_work() {
+                    Err(TaskError::NotReady)
+                } else {
+                    Err(TaskError::CpuNotQuiescent(id.as_u32()))
+                }
+            } else if !Self::prepare_thread_targets_for_cpu_offline(&state, &root_domain, id) {
+                #[cfg(feature = "fault-injection")]
+                crate::runtime::cpu::record_idle_offline_rejection(
+                    crate::runtime::cpu::IdleOfflineRejection::ThreadTarget,
+                );
+                Err(TaskError::CpuNotQuiescent(id.as_u32()))
+            } else if !Self::threads_allow_cpu_offline(&state, &root_domain, id) {
+                #[cfg(feature = "fault-injection")]
+                crate::runtime::cpu::record_idle_offline_rejection(
+                    crate::runtime::cpu::IdleOfflineRejection::ThreadOwnership,
+                );
+                Err(TaskError::CpuNotQuiescent(id.as_u32()))
+            } else if let Err(error) = ensure_runtime_success(task_runtime::prepare_cpu_offline(
+                RuntimeCpuId::new(id.as_u32()),
+            )) {
+                Err(error)
+            } else if !root_domain.remove_online(id, deadline_rebuild) {
+                Err(TaskError::InvalidConfiguration)
+            } else {
+                cpu.as_mut().clear_fair_balance();
+                self.root_domain.disable_rt_runtime(id);
+                remote.finish_offline();
+                remote
+                    .lock_run_queue(RunQueueGuardSource::Lifecycle)
+                    .invalidate_domain_publication();
+                self.root_domain.publish_offline(id);
+                if self
+                    .root_domain
+                    .rt_bandwidth()
+                    .migrate_owner(id, rt_period_replacement)
+                {
+                    self.cpu_remotes[rt_period_replacement.as_usize()].kick_scheduler_work();
+                }
+                Ok(())
+            }
+        })();
+        // Pending work resumes on an inactive CPU: placement stays closed
+        // across normal scheduling. Every terminal error reopens admission.
+        match (&result, remote.lifecycle_state()) {
+            (Err(TaskError::NotReady), crate::runtime::cpu::CpuLifecycleState::Draining) => {
+                remote.resume_owner_drain()
+            }
+            (Err(TaskError::NotReady), _) => {}
+            (Err(_), crate::runtime::cpu::CpuLifecycleState::Draining) => remote.cancel_draining(),
+            (Err(_), crate::runtime::cpu::CpuLifecycleState::Inactive) => {
+                remote.cancel_deactivation()
+            }
+            _ => {}
         }
+        result
     }
 
     /// Mirrors Linux `dl_task_offline_migration()` for blocked DL tasks.

--- a/components/ax-task/src/sched/system/task_system/cpu_lifecycle.rs
+++ b/components/ax-task/src/sched/system/task_system/cpu_lifecycle.rs
@@ -235,7 +235,11 @@ impl TaskSystem {
         } else if !cpu.is_quiescent_for_offline() {
             #[cfg(feature = "fault-injection")]
             crate::runtime::cpu::record_idle_offline_rejection(
-                crate::runtime::cpu::IdleOfflineRejection::CpuState,
+                if cpu.needs_reschedule() || cpu.has_remote_work() {
+                    crate::runtime::cpu::IdleOfflineRejection::SchedulerWork
+                } else {
+                    crate::runtime::cpu::IdleOfflineRejection::CpuState
+                },
             );
             remote.cancel_draining();
             Err(TaskError::CpuNotQuiescent(id.as_u32()))

--- a/docs/design/cpu-offline-publication.md
+++ b/docs/design/cpu-offline-publication.md
@@ -1,0 +1,60 @@
+# CPU 下线中的发布排空
+
+## 1. Linux 下线顺序
+
+本次修复以 Linux v7.1 提交 `8cd9520d35a6c38db6567e97dd93b1f11f185dc6` 的实际代码为依据。源码位于本地 `/home/zhourui/linux-src`；该目录现有 `.config` 未启用 `CONFIG_PREEMPT_RT`，本说明不把本地构建作为 RT 验证结果。
+
+### 1.1 停止接收新任务
+
+`kernel/sched/core.c::sched_cpu_deactivate` 先执行 `nohz_balance_exit_idle`、`set_cpu_active(cpu, false)` 和 `balance_push_set(cpu, true)`，随后执行 `synchronize_rcu`，等待此前使用 active 状态的读者退出。清除 active 状态必须发生在等待之前，否则新的投递仍能不断进入。
+
+TGOSKits 的 `CpuRemote::try_deactivate` 对应关闭 placement 准入：将同一原子字中的 `Online` 改为 `Inactive`，保留已有发布计数。`CpuPublicationClass::Placement` 随即拒绝新租约；已有 `CpuRemotePublication` 和 `OwnedCpuRemotePublication` 仍能完成发布并释放计数。只有生命周期所有者能改变阶段，发布者只能增减计数。`begin_idle_pull` 同样取得 placement 租约并在发布预约后重检 active 状态，避免其他 CPU 在关闭准入的同时重新建立 idle-pull 请求。
+
+### 1.2 排空与最终检查
+
+Linux 在 `sched_cpu_wait_empty` 中调用 `balance_hotplug_wait` 和 `sched_force_init_mm`。`balance_hotplug_wait` 通过 `rcuwait_wait_event` 等待运行队列及迁移禁止引用排空；PREEMPT_RT 的 `balance_push` 显式检查 `rq_has_pinned_tasks`。`sched_cpu_dying` 最后在 rq 锁和 IRQ 保护下检查剩余任务，而不是把一次调度返回当作静止证明。
+
+TGOSKits 的 `TaskSystem::take_cpu_offline` 仍要求调用方事先完成普通线程、设备服务和截止时间的清理。本次补齐的是发布读者与待调度工作的排空，不包含 Linux 的完整 smpboot、stopper、设备停放或物理 CPU 断电流程。普通非静止资源仍返回 `CpuNotQuiescent`，不把它们当作可以忽略的通知。
+
+## 2. 生命周期与所有权
+
+`TaskSystem::take_cpu_offline` 在登记表锁下区分持久预约和短暂发布，并由 CPU owner 推进现有四态生命周期。只有完成 `Draining` 的完整静止检查，才允许释放运行时 CPU 资源和提交 `Offline`。
+
+### 2.1 持久预约与在途发布
+
+`ThreadRecord::activation` 保存 staged 线程的 `PreparedMigrationDelivery`，其 `target()` 是必须保留的首次激活目标。stage、activate、cancel 与下线检查共用登记表锁，所以检查该字段不会遗漏尚未登记或并发取走的预约。存在目标 CPU 的 staged 预约时，下线立即拒绝，CPU 继续接受原预约的激活。
+
+除此之外，发布租约属于正在完成的操作。下线先停止新 placement，再以 `try_begin_draining` 的精确原子比较确认所有已有发布者已经退出。该比较把 `Inactive` 变为 `Draining`，同时关闭新的 owner delivery；之前的 release 递减与此处的 acquire 比较建立队列发布的可见性。普通 `Arc` 只保留端点内存，不承担这一发布宽限期证明。`IdlePullClaim` 也持有同一租约，直至源 CPU 完成调度事务并清除 claim：不能在迁移消息发布完成时就提前结束对目标 CPU 的读者保护。该协议覆盖本调度端点的租约读者，不声称替代 Linux 全部 RCU 使用者。
+
+### 2.2 待处理与回滚
+
+`NotReady` 表示下线仍在进行：发布租约未释放时保留 `Inactive`；关闭投递后发现待调度工作时，`resume_owner_drain` 从 `Draining` 回到 `Inactive`。调用者必须释放 IRQ 和 owner 借用，让正常调度路径处理工作，再继续同一次下线。期间 placement 始终关闭。
+
+其他错误由同一返回路径恢复 `Online`。成功则提交 `Offline`。运行时的 `probe_idle_cpu_round_trip` 直接处理这一真实返回值，`IdleOfflineRejection` 只提供诊断，不再决定是否继续排空。
+
+阶段变化可概括为：
+
+```mermaid
+stateDiagram-v2
+    Online --> Inactive: 无 staged 预约，关闭 placement
+    Inactive --> Inactive: 发布尚未结束，正常调度继续推进
+    Inactive --> Draining: 发布计数为零，关闭 owner delivery
+    Draining --> Inactive: 有待处理调度工作
+    Draining --> Offline: 静止与资源检查通过
+    Inactive --> Online: 终止性错误
+    Draining --> Online: 终止性错误
+```
+
+回到 `Inactive` 只开放 owner delivery，不重新开放 placement。最终失败和待处理结果分别保留，避免将预约冲突变成无限等待，也避免将正常在途发布变成测试失败。
+
+## 3. 回归验证
+
+现有 ArceOS `task-cpu-lifecycle` 用例通过真实 SMP 调度验证发布与下线之间的顺序，测试入口和 CI 配置保持不变。
+
+### 3.1 发布租约跨核交错
+
+`with_idle_offline_reader` 分别在 CPU 0 实际持有 CPU 1 的 owner-publication 租约和已提交的 `IdlePullClaim`。CPU 1 进入下线检查后，测试确认其处于 `Inactive`，且探针没有发布完成结果；释放租约后，原请求必须完成真实 offline/online。旧实现会在发布计数非零时直接返回 `PlacementPublication`，或者在 idle-balance claim 仍存活时提前进入 `Draining`，因此同一用例失败。测试不重新发送请求，也不增加失败重试。
+
+### 3.2 保留的相邻约束
+
+原用例继续验证 staged 预约拒绝下线、取消不执行入口、激活一次、执行资源回收后可下线、重上线后的线程运行及 WFI 边界通知。MM 锁回归仍在另一核持有全局 MM 锁期间注入待调度工作，并要求原请求完成下线，证明排空和 CPU 准备不依赖该锁。用例的两秒进展上限和成功断言不变。

--- a/os/arceos/modules/axruntime/src/thread/creation_probe.rs
+++ b/os/arceos/modules/axruntime/src/thread/creation_probe.rs
@@ -120,6 +120,7 @@ pub(super) fn record_mm_switch(previous_user: bool, next_user: bool) {
 }
 
 static IDLE_TARGET: AtomicU64 = AtomicU64::new(0);
+const IDLE_AFTER_DRAIN: u64 = 1 << 59;
 const IDLE_AT_WAIT: u64 = 1 << 60;
 const IDLE_ARMING: u64 = 1 << 61;
 const IDLE_DONE: u64 = 1 << 63;
@@ -130,6 +131,12 @@ const IDLE_SUCCESS: u64 = 1 << 62;
 /// the processor; IRQ delivery stays excluded until re-online completes.
 pub fn request_idle_cpu_round_trip(cpu: usize) -> Result<(), TaskError> {
     request_idle_probe(cpu, 0)
+}
+
+/// Publishes scheduler work after idle's drain, before the offline admission.
+/// The owner must service that work before attempting the lifecycle transition.
+pub fn request_idle_cpu_round_trip_after_work(cpu: usize) -> Result<(), TaskError> {
+    request_idle_probe(cpu, IDLE_AFTER_DRAIN)
 }
 
 fn request_idle_probe(cpu: usize, phase: u64) -> Result<(), TaskError> {
@@ -174,11 +181,20 @@ pub(super) fn service_idle_cpu_round_trip() {
     // Called only by the idle loop, after its normal scheduler-work drain.
     // SAFETY: idle is permanently bound to this CPU for its entire lifetime.
     let cpu = unsafe { ax_task::runtime::task_runtime::current_cpu_id() }.as_u32();
-    if IDLE_TARGET.load(Ordering::Acquire) != u64::from(cpu) + 1 {
+    let target = u64::from(cpu) + 1;
+    let state = IDLE_TARGET.load(Ordering::Acquire);
+    if state != target && state != (target | IDLE_AFTER_DRAIN) {
         return;
     }
-    let result = match ax_task::runtime::cpu::probe_idle_cpu_round_trip() {
+    let publish_work = state & IDLE_AFTER_DRAIN != 0;
+    if publish_work {
+        IDLE_TARGET.store(target, Ordering::Release);
+    }
+    let result = match ax_task::runtime::cpu::probe_idle_cpu_round_trip(publish_work) {
         Ok(()) => IDLE_SUCCESS,
+        // No offline transition committed. Preserve the request so the idle
+        // loop drains newly published work at its next safe point.
+        Err(TaskError::NotReady) => return,
         Err(TaskError::CpuNotQuiescent(_)) => {
             warn!(
                 "idle CPU {cpu} offline rejection: {:?}",
@@ -216,5 +232,8 @@ pub(super) fn idle_probe_pending() -> bool {
     let cpu = unsafe { ax_task::runtime::task_runtime::current_cpu_id() }.as_u32();
     let state = IDLE_TARGET.load(Ordering::Acquire);
     let target = u64::from(cpu) + 1;
-    state == target || state == (target | IDLE_ARMING) || state == (target | IDLE_AT_WAIT)
+    state == target
+        || state == (target | IDLE_ARMING)
+        || state == (target | IDLE_AT_WAIT)
+        || state == (target | IDLE_AFTER_DRAIN)
 }

--- a/test-suit/arceos/rust/Cargo.toml
+++ b/test-suit/arceos/rust/Cargo.toml
@@ -18,7 +18,7 @@ sched-rr = ["task-runtime", "ax-std/alloc"]
 sched-cfs = ["task-runtime", "ax-std/alloc"]
 task-affinity = ["task-runtime"]
 # Kept outside `all`: device workers have no CPU hotplug park contract.
-task-cpu-lifecycle = ["task-runtime", "dep:ax-runtime", "ax-runtime/fault-injection", "ax-std/paging", "dep:ax-mm"]
+task-cpu-lifecycle = ["dep:ax-task", "task-runtime", "dep:ax-runtime", "ax-runtime/fault-injection", "ax-std/paging", "dep:ax-mm"]
 task-fair-idle-pull = ["task-runtime", "ax-std/alloc"]
 task-fair-wake-idle-sibling = ["task-runtime"]
 task-wait-queue = ["task-runtime", "dep:ax-runtime", "ax-runtime/fault-injection", "ax-std/tls"]

--- a/test-suit/arceos/rust/src/task/cpu_lifecycle.rs
+++ b/test-suit/arceos/rust/src/task/cpu_lifecycle.rs
@@ -120,7 +120,7 @@ fn idle_cpu_reservation_round_trip() {
 
 fn offline_does_not_lock_global_mm() {
     use ax_runtime::thread::creation_probe::{
-        request_idle_cpu_round_trip, take_idle_cpu_round_trip_result,
+        request_idle_cpu_round_trip_after_work, take_idle_cpu_round_trip_result,
     };
     use ax_std::os::arceos::task::sched::{CpuId, CpuSet};
     let held = Arc::new(AtomicBool::new(false));
@@ -140,7 +140,7 @@ fn offline_does_not_lock_global_mm() {
         })
         .unwrap();
     wait_for(|| held.load(Ordering::Acquire));
-    request_idle_cpu_round_trip(1).unwrap();
+    request_idle_cpu_round_trip_after_work(1).unwrap();
     let started = std::time::Instant::now();
     let mut result = None;
     while result.is_none() && started.elapsed() < Duration::from_secs(2) {

--- a/test-suit/arceos/rust/src/task/cpu_lifecycle.rs
+++ b/test-suit/arceos/rust/src/task/cpu_lifecycle.rs
@@ -59,6 +59,7 @@ fn idle_cpu_reservation_round_trip() {
     current::set_current_thread_affinity(coordinator).unwrap();
     let mut target = CpuSet::empty(ax_hal::cpu_num());
     target.insert(CpuId::new(1));
+    offline_waits_for_owner_publication();
     for activate in [false, true] {
         let prepared = ax_runtime::thread::builder("hotplug-reservation".into())
             .affinity(target.clone())
@@ -82,7 +83,8 @@ fn idle_cpu_reservation_round_trip() {
         request_idle_cpu_round_trip(1).unwrap();
         assert!(
             wait_for_idle_cycle(),
-            "released reservation must permit idle CPU cycle"
+            "released reservation must permit idle CPU cycle: {:?}",
+            ax_task::runtime::cpu::idle_offline_rejection()
         );
         let resumed = ax_runtime::thread::builder("after-reonline".into())
             .affinity(target.clone())
@@ -160,4 +162,41 @@ fn offline_does_not_lock_global_mm() {
         Some(true),
         "CPU offline must not acquire the global kernel MM lock"
     );
+}
+
+fn offline_waits_for_owner_publication() {
+    use ax_runtime::thread::creation_probe::{
+        request_idle_cpu_round_trip, take_idle_cpu_round_trip_result,
+    };
+    use ax_task::runtime::cpu::{
+        IdleOfflineReader, IdleOfflineRejection, RuntimeCpuId, idle_offline_rejection,
+        with_idle_offline_reader,
+    };
+
+    // CPU 0 retains the real publication guard until CPU 1 has attempted
+    // admission. No command is republished and no offline result is retried.
+    for reader in [
+        IdleOfflineReader::OwnerDelivery,
+        IdleOfflineReader::IdleBalance,
+    ] {
+        with_idle_offline_reader(RuntimeCpuId::new(1), reader, |remote| {
+            request_idle_cpu_round_trip(1).unwrap();
+            wait_for(|| !matches!(idle_offline_rejection(), IdleOfflineRejection::Unclassified));
+            assert_eq!(
+                remote.lifecycle_state(),
+                ax_task::runtime::cpu::CpuLifecycleState::Inactive,
+                "new placement must be closed while the existing publisher is retained"
+            );
+            assert_eq!(
+                take_idle_cpu_round_trip_result(),
+                None,
+                "an in-flight owner publication must not complete the offline request"
+            );
+        })
+        .unwrap();
+        assert!(
+            wait_for_idle_cycle(),
+            "offline must complete after the publisher releases its lease"
+        );
+    }
 }


### PR DESCRIPTION
## 问题与 Linux 依据

修复以下两处 ArceOS `task-cpu-lifecycle` 失败：

- [dev LoongArch job 103196581524](https://github.com/rcore-os/tgoskits/actions/runs/34575871076/job/103196581524)：MM 锁隔离回归得到 `Some(false)`，诊断为 `CpuState`。
- [PR #2376 x86_64 job 103203677862](https://github.com/rcore-os/tgoskits/actions/runs/34580265039/job/103203677862)：预约释放后下线仍被 `CpuState` 拒绝。

原实现要求发布计数先为零才关闭 placement，普通在途发布因此可能被当作最终失败。另一个缺口是源 CPU 的 `IdlePullClaim` 没有覆盖完整使用周期的目标 CPU 租约；迁移投递完成不代表源端 claim 已经退出，目标可能提前进入最终排空检查。仅让探针等待已有 work bit，不能补齐这些读者窗口。

对照本地 Linux v7.1 提交 `8cd9520d35a6c38db6567e97dd93b1f11f185dc6`：`sched_cpu_deactivate` 先清 active，再等待旧读者；`sched_cpu_wait_empty/balance_hotplug_wait` 等待调度和迁移禁止引用排空；`sched_cpu_dying` 最后检查并提交下线。当前 Linux `.config` 未启用 RT，不将本地构建作为 RT 验证结果。

## 改动与顺序

1. 登记表锁下检查 `ThreadRecord::activation`。真实 staged 预约仍立即阻止下线，不能被当作短暂读者无限等待。
2. `Online → Inactive` 保留已有发布计数，同时禁止新 placement。租约尚未释放时返回 `NotReady` 并保持 `Inactive`；调用者释放 IRQ/owner 借用，通过正常调度继续排空。
3. 发布计数归零后，原子关闭 owner delivery、进入 `Draining`。仍有待调度工作时退回 `Inactive`，不重新开放 placement；终止性错误恢复 `Online`，成功才提交 `Offline`。
4. `IdlePullClaim` 持有目标的 placement 租约直到 claim 清理完成。建立 idle-pull 预约也取得租约并重检 active 状态，防止关闭准入后又建立新的负载均衡请求。
5. 探针直接处理生产下线接口的结果，诊断枚举只用于定位，不再决定下线流程。

本改动不增加 Linux 完整 smpboot、stopper、设备停放或物理断电能力；普通线程、迁移 pin、计时器等最终静止检查仍保留。没有修改 CI、增加超时、清除 work bit 伪造静止或加入测试失败重跑。

具体租约、阶段和 Linux 源码对照见 [CPU 下线发布协议](docs/design/cpu-offline-publication.md)。

## 回归和验证

增强现有真实 SMP `task-cpu-lifecycle`，由另一核分别持有 owner-publication 租约和已提交的 idle-balance claim，要求目标保持 `Inactive`、不发布完成结果，读者退出后原请求完成真实 offline/online。原 staged 预约、取消/激活、执行资源回收、WFI 边界及全局 MM 锁断言保持。

- 旧零发布计数准入逻辑在受控 owner-reader 回归中失败，状态为 `Online` 而不是 `Inactive`；修复后通过。
- 尚未给 idle-balance claim 加租约时，同一受控场景发现目标过早进入 `Draining`；补齐完整 claim 生命周期租约后通过。
- 两类读者与原生命周期用例的 LoongArch QEMU 回归通过。
- `cargo xtask clippy --package ax-task --package ax-runtime --package arceos-test-suit`：74/74 通过。
- `cargo fmt` 和差异检查通过；没有运行本地完整工作区 clippy。

已变基到 `dev` 的 `9168dde236`。当前提交 `7ef4af6724` 的 LoongArch/x86_64 完整 Rust 组各 3/3 通过，AArch64/RISC-V 生命周期回归通过，实际选中的 15 包增量 std 全部通过。

[CI 34585218250](https://github.com/rcore-os/tgoskits/actions/runs/34585218250) 的第二次运行已 completed/success，41/41 全部通过。两条原始 ArceOS 调度失败对应的完整任务在第一次运行就已通过；第二次仅重跑 OrangePi 板卡组。

第一次 OrangePi 组另有串口 NUL/截断后的 exec-cache 超时，以及内核启动前的 U-Boot DHCP 超时。物理串口接收依赖 HTTP executor 的独立缺口，已用真实 PTY 取得确定性红绿证据，修补在 [ostool #186](https://github.com/drivercraft/ostool/pull/186)，其两轮 CI 均通过并已部署共享服务器。部署后原 OrangePi 全组分别在 2/3/1 号板通过 3/3，日志 0 NUL，监测区间的串口错误计数没有增加。U-Boot 单次 DHCP 超时尚未建立独立因果证明，不归因于 CPU 下线修补。
