### PR TITLE
test(starry): cover nested epoll wakeups after returned inner waits

### DIFF
--- a/test-suit/starryos/qemu/system/bugfix-epoll-nested-stale-waiter/CMakeLists.txt
+++ b/test-suit/starryos/qemu/system/bugfix-epoll-nested-stale-waiter/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.20)
+project(bugfix-epoll-nested-stale-waiter C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
+add_executable(bugfix-epoll-nested-stale-waiter src/main.c)
+target_include_directories(bugfix-epoll-nested-stale-waiter PRIVATE ../common)
+target_compile_options(bugfix-epoll-nested-stale-waiter PRIVATE -Wall -Wextra -Werror)
+
+install(TARGETS bugfix-epoll-nested-stale-waiter RUNTIME DESTINATION usr/bin/starry-test-suit)

--- a/test-suit/starryos/qemu/system/bugfix-epoll-nested-stale-waiter/src/main.c
+++ b/test-suit/starryos/qemu/system/bugfix-epoll-nested-stale-waiter/src/main.c
@@ -1,0 +1,104 @@
+#define _GNU_SOURCE
+#include "test_framework.h"
+
+#include <stdint.h>
+#include <sys/epoll.h>
+#include <sys/eventfd.h>
+#include <time.h>
+#include <unistd.h>
+
+static long monotonic_ms(void)
+{
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return ts.tv_sec * 1000L + ts.tv_nsec / 1000000L;
+}
+
+static int watch(int epfd, int fd)
+{
+    struct epoll_event event = {
+        .events = EPOLLIN,
+        .data.fd = fd,
+    };
+    return epoll_ctl(epfd, EPOLL_CTL_ADD, fd, &event);
+}
+
+static void make_readable(int efd, const char *msg)
+{
+    uint64_t one = 1;
+    CHECK_RET(write(efd, &one, sizeof(one)), sizeof(one), msg);
+}
+
+static void expect_outer_wakes(int outer, int inner, const char *msg)
+{
+    struct epoll_event event = {0};
+    long start = monotonic_ms();
+    int n = epoll_wait(outer, &event, 1, 1000);
+    long waited = monotonic_ms() - start;
+    printf("  INFO | outer epoll_wait returned %d after %ld ms\n", n, waited);
+    CHECK(n == 1 && event.data.fd == inner, msg);
+    CHECK(waited < 500, "outer wake is not held back until its timeout");
+}
+
+/*
+ * The compositor/libinput shape: libinput waits on its own epoll on every
+ * dispatch and returns without sleeping, while the compositor's main loop
+ * watches that epoll fd. A waiter that has already returned must not stay
+ * registered on the inner epoll where it can take the one wakeup meant for
+ * the outer epoll, or input stops reaching the compositor.
+ */
+static void test_returned_inner_waiters_do_not_take_nested_wakeup(void)
+{
+    int efd = eventfd(0, EFD_NONBLOCK | EFD_CLOEXEC);
+    int inner = epoll_create1(EPOLL_CLOEXEC);
+    CHECK(efd >= 0 && inner >= 0, "create eventfd and inner epoll");
+    CHECK_RET(watch(inner, efd), 0, "inner epoll watches the eventfd");
+
+    struct epoll_event event;
+    for (int i = 0; i < 4; i++)
+        CHECK_RET(epoll_wait(inner, &event, 1, 0), 0,
+                  "idle inner wait with zero timeout returns nothing");
+    for (int i = 0; i < 4; i++)
+        CHECK_RET(epoll_wait(inner, &event, 1, 10), 0,
+                  "idle inner wait with short timeout returns nothing");
+
+    int outer = epoll_create1(EPOLL_CLOEXEC);
+    CHECK(outer >= 0, "create outer epoll");
+    CHECK_RET(watch(outer, inner), 0, "outer epoll watches the inner epoll");
+
+    make_readable(efd, "make the inner epoll ready");
+    expect_outer_wakes(outer, inner, "outer epoll reports the ready inner epoll");
+
+    make_readable(efd, "publish again while the inner entry is still queued");
+    expect_outer_wakes(outer, inner, "outer epoll still reports the inner epoll");
+
+    close(outer);
+    close(inner);
+    close(efd);
+}
+
+/* Same edges without returned inner waiters: the nested wakeup must work here too. */
+static void test_nested_wakeup_without_prior_inner_waits(void)
+{
+    int efd = eventfd(0, EFD_NONBLOCK | EFD_CLOEXEC);
+    int inner = epoll_create1(EPOLL_CLOEXEC);
+    int outer = epoll_create1(EPOLL_CLOEXEC);
+    CHECK(efd >= 0 && inner >= 0 && outer >= 0, "create eventfd and both epolls");
+    CHECK_RET(watch(inner, efd), 0, "inner epoll watches the eventfd");
+    CHECK_RET(watch(outer, inner), 0, "outer epoll watches the inner epoll");
+
+    make_readable(efd, "make the inner epoll ready");
+    expect_outer_wakes(outer, inner, "outer epoll reports the ready inner epoll");
+
+    close(outer);
+    close(inner);
+    close(efd);
+}
+
+int main(void)
+{
+    TEST_START("nested epoll wakeup survives returned inner waiters");
+    test_nested_wakeup_without_prior_inner_waits();
+    test_returned_inner_waiters_do_not_take_nested_wakeup();
+    TEST_DONE();
+}


### PR DESCRIPTION
## 要解决的问题

外层 epoll 监听内层 epoll 时,内层就绪只给一个等待者一次独占唤醒,并且挑最早登记的那一个。若内层之前经历过已经返回的 `epoll_wait`(超时 0 或短超时),而这些等待登记的唤醒项在返回时没有撤销,这次唤醒就会被旧项消耗,外层等满超时才返回 0;该内层条目此后一直留在就绪队列里,新的就绪不再触发唤醒,外层会持续卡住。

这条路径在基于较早 dev 的浏览器分支上实际命中:weston 的事件循环用外层 epoll 监听 libinput 的内层 epoll,libinput 每次分派都会调用 `epoll_wait(内层, 0)`,久置后鼠标不再跟随,按一次键才恢复。

当前 dev 通过 `PollRegistrar` / `OwnedRegistration` 在注册对象析构时撤销登记(超时丢弃等待也会撤销),已从结构上消除该问题,但仓库里没有用例覆盖这条路径,后续重构一旦退回"返回后不撤销",现有 epoll 用例都不会失败。

## 改动

新增系统测试 `test-suit/starryos/qemu/system/bugfix-epoll-nested-stale-waiter`,只加测试,不改内核。

对照用例:内层 epoll 监听 eventfd,外层 epoll 监听内层,写 eventfd,要求 `epoll_wait(外层, 1000)` 在 500ms 内返回 1 且事件指向内层。用它确认嵌套唤醒本身可用,避免把基础路径的问题误判成旧唤醒项问题。

复现用例:在建立外层监听之前,先让内层做 4 次超时 0 和 4 次 10ms 超时的空闲 `epoll_wait`,留下已经返回的等待;之后同样写 eventfd,要求外层 500ms 内返回 1。随后在内层条目仍在就绪队列时再写一次,要求外层仍能返回,覆盖"卡住后持续卡住"的后半段。

500ms 的上限远大于正常唤醒延迟,又明显小于 1000ms 的等待超时,能区分"被事件唤醒"与"等到超时"。

## 验证

| 环境 | 结果 |
| :--: | :--: |
| Linux x86_64 原生(6.6.87,gcc 15.2) | 24 通过 / 0 失败,两次嵌套唤醒均 0ms |
| dev 9168dde2 + 本提交,x86_64 | 24 / 0,三次外层唤醒 3ms / 0ms / 0ms |
| dev 9168dde2 + 本提交,aarch64 | 24 / 0,三次外层唤醒 2ms / 0ms / 0ms |
| dev 9168dde2 + 本提交,riscv64 | 本机未验证:grouped runner `starry-run-system-tests` 自身在本机 riscv64 上触发 Illegal instruction(status=132),测试未开始;换成现有用例 `syscall-test-epoll` 结果相同,属本机环境问题。CI 的 `Starry / QEMU riscv64 · qemu/bugfix-epoll-nested-stale-waiter` 已通过 |
| dev 9168dde2 + 本提交,loongarch64 | `STARRY_SYSTEM_TEST_PASSED`(测试二进制退出码 0;该架构的串口日志未回显逐项检查输出) |
| 基于较早 dev 的浏览器分支内核,修复前 | 20 / 4,外层等满 1001ms 返回 0 |
| 同一内核补上返回时撤销登记后 | 24 / 0,外层 0 到 6ms 返回 |

上表在 dev 9168dde2 上验证;提交后已 rebase 到 dev 621202fd,期间新增的两个提交(#2376、#2377)不涉及 epoll、poll 与系统测试公共代码,本提交内容未变。

运行命令:`cargo xtask starry test qemu --arch <arch> -c qemu/system/bugfix-epoll-nested-stale-waiter`。
