### PR TITLE
fix(ax-task): allow per-CPU timer wakes during CPU deactivation

### DIFF
--- a/components/ax-task/src/runtime/cpu.rs
+++ b/components/ax-task/src/runtime/cpu.rs
@@ -258,7 +258,8 @@ pub fn idle_offline_rejection() -> IdleOfflineRejection {
 /// borrow across both transitions. It never returns to scheduling while offline
 /// and does not implement platform power-off or an externally parked CPU.
 /// Returns `NotReady` while ordinary scheduler work must be drained first.
-/// `publish_work_after_drain` injects that real publication once for a regression.
+/// `publish_work_after_drain` injects scheduler work, then a timer notification
+/// after placement closes, to verify that the per-CPU worker can still drain.
 #[cfg(feature = "fault-injection")]
 pub fn probe_idle_cpu_round_trip(publish_work_after_drain: bool) -> Result<(), TaskError> {
     use crate::runtime::context::{RuntimeIrqGuard, runtime_current_cpu_mut, runtime_task_system};
@@ -275,7 +276,18 @@ pub fn probe_idle_cpu_round_trip(publish_work_after_drain: bool) -> Result<(), T
         cpu.request_scheduler_work();
     }
     record_idle_offline_rejection(IdleOfflineRejection::Unclassified);
-    system.take_cpu_offline(cpu.as_mut())?;
+    let offline = system.take_cpu_offline(cpu.as_mut());
+    if publish_work_after_drain {
+        assert!(
+            matches!(offline, Err(TaskError::NotReady)),
+            "owner work must defer CPU offline: {offline:?}"
+        );
+        assert_eq!(cpu.remote().lifecycle_state(), CpuLifecycleState::Inactive);
+        // A timer IRQ may publish soft work after placement closes. The fixed
+        // worker must still wake, drain the event, and park before final offline.
+        cpu.remote().publish_ktimer_work();
+    }
+    offline?;
     assert_eq!(cpu.remote().lifecycle_state(), CpuLifecycleState::Offline);
     assert!(system.cpu_remote(cpu.owner()).is_none());
     // Returning an error here would strand the executing idle owner offline.

--- a/components/ax-task/src/sched/system/task_system/dispatch/wake/placement.rs
+++ b/components/ax-task/src/sched/system/task_system/dispatch/wake/placement.rs
@@ -16,7 +16,14 @@ impl TaskSystem {
                 return self
                     .cpu_remotes
                     .get(target.as_usize())
-                    .filter(|remote| remote.accepts_placement())
+                    .filter(|remote| {
+                        // Linux is_cpu_allowed() keeps per-CPU kthreads on an
+                        // online but inactive CPU until hotplug parks them.
+                        // Only the registered timer worker may finish soft
+                        // work here; ordinary pinned tasks need active placement.
+                        remote.accepts_placement()
+                            || (remote.is_online() && remote.ktimer_worker() == Some(wakee.id()))
+                    })
                     .map(|_| target);
             }
             WakeTargetSelection::SchedulerClass => {}

--- a/os/arceos/modules/axruntime/src/thread/creation_probe.rs
+++ b/os/arceos/modules/axruntime/src/thread/creation_probe.rs
@@ -133,8 +133,8 @@ pub fn request_idle_cpu_round_trip(cpu: usize) -> Result<(), TaskError> {
     request_idle_probe(cpu, 0)
 }
 
-/// Publishes scheduler work after idle's drain, before the offline admission.
-/// The owner must service that work before attempting the lifecycle transition.
+/// Publishes scheduler work after idle's drain, then timer work once inactive.
+/// The owner must still wake its fixed timer worker and park it before offline.
 pub fn request_idle_cpu_round_trip_after_work(cpu: usize) -> Result<(), TaskError> {
     request_idle_probe(cpu, IDLE_AFTER_DRAIN)
 }

--- a/scripts/axbuild/src/axvisor/test/initramfs.rs
+++ b/scripts/axbuild/src/axvisor/test/initramfs.rs
@@ -29,6 +29,9 @@ const X86_PCI_MEMORY_APERTURE_END: &str = "0xd0000000";
 const INIT_SCRIPT_TEMPLATE: &str = r#"#!/bin/busybox sh
 /bin/busybox mount -t devtmpfs devtmpfs /dev 2>/dev/null || true
 /bin/busybox mount -t proc proc /proc 2>/dev/null || true
+# Keep informational printk output in dmesg rather than the assertion stream.
+# Warnings and errors remain visible, and panic restores verbose console output.
+echo 5 > /proc/sys/kernel/printk || exit 1
 /bin/busybox mount -t sysfs sysfs /sys 2>/dev/null || true
 export HOME=/root
 export PATH=/bin

--- a/test-suit/arceos/rust/src/task/cpu_lifecycle.rs
+++ b/test-suit/arceos/rust/src/task/cpu_lifecycle.rs
@@ -160,7 +160,8 @@ fn offline_does_not_lock_global_mm() {
     assert_eq!(
         result,
         Some(true),
-        "CPU offline must not acquire the global kernel MM lock"
+        "CPU offline must drain owner work while the global kernel MM lock is held: {:?}",
+        ax_task::runtime::cpu::idle_offline_rejection()
     );
 }
 


### PR DESCRIPTION
LoongArch 的 `task-cpu-lifecycle` 在 CPU 下线阶段偶发返回 `CpuState / Some(false)`，导致“持有全局内核 MM 锁时仍应完成下线”的断言失败。原始日志见 [ArceOS / QEMU loongarch64 · Suites](https://github.com/rcore-os/tgoskits/actions/runs/34616669942/job/103329076089)。

CPU 进入 `Inactive` 后，如果软定时器工作唤醒已阻塞的 `ktimers`，原来的单核 affinity 放置逻辑会因为 `accepts_placement() == false` 返回 `Unavailable`。IRQ 事件保留 pending，但工作线程无法运行并消费它，最终静止检查拒绝下线。对照本地 Linux v7.1 的 `kernel/sched/core.c::is_cpu_allowed()`、`sched_cpu_deactivate()` 与 `kernel/softirq.c::timer_thread`：普通任务停止放置后，已登记的每 CPU 内核线程仍可在 online CPU 上运行，直到完成停驻。

- 唤醒放置只为目标 CPU 已登记的 `ktimers` 保留 `Online/Inactive` 许可，继续拒绝普通任务以及 `Draining/Offline` CPU；完整 `ThreadId` 匹配保留代际身份校验。
- 增强已有 CPU 生命周期回归：先发布 scheduler work，确认下线返回 `NotReady` 且进入 `Inactive`，再直接发布真实 timer worker 事件。最终仍要求在另一 CPU 持有全局 MM 锁期间完成下线/上线；未清理待处理状态、放宽断言或添加失败重试。
- 断言附带实际下线拒绝原因，避免诊断只指向 MM 锁。

AxVisor 的 SVM/OVMF ACPI 客体还存在输出竞争：Linux `kernel/exit.c` 的 `pr_info()` 可能插入成功标记与换行之间，形成 `PASSED[时间戳]...`，导致严格整行匹配失败，见 [失败日志](https://github.com/rcore-os/tgoskits/actions/runs/34656135355/job/103450247673)。生成的 `/init` 现在在挂载 `/proc` 后将 console 日志等级设为 5；依照 Linux `suppress_message_printing()` 的语义，普通信息仍保留在 `dmesg`，warning/error/panic 继续可见。写入失败终止 init，避免在未建立输出条件时继续报告成功；客体断言及成功/失败正则不变。

验证：

- 同一最终回归在仅恢复旧唤醒放置逻辑时，稳定失败于 `CpuState / Some(false)`，外层 `xtask` 返回 1。
- 恢复修复后，`cargo xtask arceos test qemu --arch loongarch64 --test-group rust --test-case task-cpu-lifecycle` 通过（`1/1`）。
- 原 LoongArch CI 套件及四架构 ArceOS 套件在首个提交上全部通过；LoongArch 日志确认增强后的 `task-cpu-lifecycle` 实际执行并通过。
- SVM 输出竞争使用临时故障注入验证：在成功标记与换行之间写入真实 `/dev/kmsg` informational 记录，旧逻辑稳定失败，修复后相同注入通过。移除注入后，最终 `cargo xtask axvisor test qemu --arch x86_64 --test-case ovmf-acpi-svm` 通过（`1/1`）。
- `cargo xtask test --since 974a9ffff` 仅选择 `axbuild`，745 项测试通过。
- `cargo fmt`、`git diff --check` 通过。
- 最终提交 `fc8a1feea` 的 [CI #34657700490](https://github.com/rcore-os/tgoskits/actions/runs/34657700490) 全部通过，41 项执行检查均为 success，包含远端 clippy、标准库测试、四架构 QEMU 和板卡测试。
- 按请求未在本地运行 clippy 或全量测试。
