### PR TITLE
fix(ax-task): inspect offline timer state under one base lock

### DIFF
--- a/components/ax-task/src/sched/system/cpu/local/owner_dispatch.rs
+++ b/components/ax-task/src/sched/system/cpu/local/owner_dispatch.rs
@@ -33,16 +33,18 @@ impl CpuLocal {
 
     pub(crate) fn is_quiescent_for_offline(&self) -> bool {
         let run_queue = self.remote.lock_run_queue(RunQueueGuardSource::Lifecycle);
+        // Inspect the complete task/kernel timer base under one guard.
+        // Re-entering it through the remote check would self-lock when a
+        // kernel timer keeps the active-base snapshot set.
         let deadlines = self
             .remote
-            .read_deadline_base(DeadlineBaseGuardSource::Lifecycle);
+            .read_active_deadline_base(DeadlineBaseGuardSource::Lifecycle);
         (run_queue.current_thread().is_none() || run_queue.current_thread() == run_queue.idle())
             && run_queue.nr_running() == 0
             && run_queue.deadline_members_are_empty()
-            && deadlines.queue.is_empty()
-            && deadlines.expired_count == 0
-            && !deadlines.has_claimed_task_expiration()
-            && !deadlines.softirq_activated
+            && deadlines
+                .as_ref()
+                .is_none_or(|base| !base.has_active_work())
             && self.dispatch.switch_handoff.is_none()
             && self.remote.is_quiescent_for_offline()
     }

--- a/components/ax-task/src/sched/system/cpu/remote/deadline.rs
+++ b/components/ax-task/src/sched/system/cpu/remote/deadline.rs
@@ -473,13 +473,6 @@ fn expiration_matches_registration(
         && event.kind() == Some(registration.kind())
 }
 
-impl CpuRemote {
-    pub(in crate::sched::system::cpu) fn deadline_is_quiescent_for_offline(&self) -> bool {
-        self.read_active_deadline_base(DeadlineBaseGuardSource::Lifecycle)
-            .is_none_or(|deadlines| !deadlines.has_active_work())
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/components/ax-task/src/sched/system/cpu/remote/deadline.rs
+++ b/components/ax-task/src/sched/system/cpu/remote/deadline.rs
@@ -400,10 +400,6 @@ impl CpuDeadlineState {
         true
     }
 
-    pub(crate) const fn has_claimed_task_expiration(&self) -> bool {
-        self.claimed_task_expiration.is_some()
-    }
-
     pub(crate) fn select_service_claim_class(
         &mut self,
         kernel_pending: bool,
@@ -514,7 +510,7 @@ mod tests {
 
         assert!(state.cancel_expired_task_deadline(&registration));
         assert_eq!(state.complete_claimed_task_expiration(event), Some(true));
-        assert!(!state.has_claimed_task_expiration());
+        assert!(!state.has_active_work());
     }
 
     #[test]

--- a/components/ax-task/src/sched/system/cpu/remote/lifecycle.rs
+++ b/components/ax-task/src/sched/system/cpu/remote/lifecycle.rs
@@ -254,7 +254,6 @@ impl CpuRemote {
     pub(crate) fn is_quiescent_for_offline(&self) -> bool {
         self.publication.state.load(Ordering::Acquire) == CPU_LIFECYCLE_DRAINING
             && self.ktimer_is_quiescent_for_offline()
-            && self.deadline_is_quiescent_for_offline()
             && !self.needs_reschedule()
             && !self.has_remote_work()
             && !self.is_idle_polling()

--- a/components/ax-task/src/sched/system/cpu/remote/mod.rs
+++ b/components/ax-task/src/sched/system/cpu/remote/mod.rs
@@ -115,20 +115,11 @@ impl CpuRemote {
         unsafe { self.run_queue.lock_irq_disabled() }
     }
 
-    /// Locks this CPU's hrtimer-style task-deadline base.
-    ///
-    /// The rq lock precedes this lock when both are required. Timer IRQ code
-    /// takes only this lock; soft-timer callbacks release it before acquiring a
-    /// task control lock or rq lock.
-    pub(crate) fn read_deadline_base(
-        &self,
-        source: DeadlineBaseGuardSource,
-    ) -> CpuDeadlineReadGuard<'_> {
-        self.deadline.read(source)
-    }
-
     /// Skips the IRQ-disabled deadline-base read when no timer, expiration, or
     /// softirq ownership has been published.
+    /// The rq lock precedes this lock when both are required. Timer IRQ code
+    /// takes only this lock; soft-timer callbacks release it before acquiring
+    /// a task control lock or rq lock.
     pub(crate) fn read_active_deadline_base(
         &self,
         source: DeadlineBaseGuardSource,

--- a/test-suit/arceos/rust/src/task/cpu_lifecycle.rs
+++ b/test-suit/arceos/rust/src/task/cpu_lifecycle.rs
@@ -19,10 +19,13 @@ pub fn run() -> crate::TestResult {
 
 fn wait_for(condition: impl Fn() -> bool) {
     let started = std::time::Instant::now();
-    while !condition() && started.elapsed() < Duration::from_secs(2) {
+    while !condition() {
+        assert!(
+            started.elapsed() < Duration::from_secs(2),
+            "CPU lifecycle event must complete"
+        );
         thread::yield_now();
     }
-    assert!(condition(), "CPU lifecycle event must complete");
 }
 
 fn wait_for_idle_cycle() -> bool {
@@ -59,7 +62,7 @@ fn idle_cpu_reservation_round_trip() {
     current::set_current_thread_affinity(coordinator).unwrap();
     let mut target = CpuSet::empty(ax_hal::cpu_num());
     target.insert(CpuId::new(1));
-    offline_waits_for_owner_publication();
+    offline_waits_for_owner_publication(&target);
     for activate in [false, true] {
         let prepared = ax_runtime::thread::builder("hotplug-reservation".into())
             .affinity(target.clone())
@@ -165,27 +168,58 @@ fn offline_does_not_lock_global_mm() {
     );
 }
 
-fn offline_waits_for_owner_publication() {
+fn offline_waits_for_owner_publication(target: &ax_task::sched::CpuSet) {
     use ax_runtime::thread::creation_probe::{
         request_idle_cpu_round_trip, take_idle_cpu_round_trip_result,
     };
-    use ax_task::runtime::cpu::{
-        IdleOfflineReader, IdleOfflineRejection, RuntimeCpuId, idle_offline_rejection,
-        with_idle_offline_reader,
+    use ax_task::{
+        runtime::cpu::{
+            CpuLifecycleState, IdleOfflineReader, RuntimeCpuId, with_idle_offline_reader,
+        },
+        time::{
+            MonotonicDeadline,
+            timer::{KernelTimerCancelOutcome, cancel_kernel_timer, register_kernel_timer},
+        },
     };
 
-    // CPU 0 retains the real publication guard until CPU 1 has attempted
-    // admission. No command is republished and no offline result is retried.
+    // This is the scheduler's final offline transaction, not Linux's full
+    // hotplug orchestration: it cannot migrate an outstanding kernel timer.
+    // Establish a known veto instead of assuming reader release alone makes
+    // every task and timer on the target quiescent.
+    let (sender, receiver) = std::sync::mpsc::sync_channel(1);
+    let registrar = ax_runtime::thread::builder("offline-timer-owner".into())
+        .affinity(target.clone())
+        .spawn(move || {
+            let deadline = MonotonicDeadline::from_duration(
+                ax_std::os::arceos::api::time::ax_monotonic_time() + Duration::from_secs(60),
+            );
+            let timer = register_kernel_timer(
+                deadline,
+                Box::new(|_| panic!("offline test must cancel its timer")),
+            )
+            .unwrap();
+            sender.send(timer).unwrap();
+        })
+        .unwrap();
+    registrar.wait().unwrap();
+    wait_for(|| registrar.execution_reclaimed());
+    registrar.join().unwrap();
+    let timer = receiver.recv().unwrap();
+
+    // Retain the reader until placement closes. Inactive is stable while
+    // this reader exists; the last diagnostic rejection is only a snapshot.
+    // Like Linux cpu-on-off-test.sh, check the resulting state after each
+    // operation, then remove the veto before expecting a successful cycle.
     for reader in [
         IdleOfflineReader::OwnerDelivery,
         IdleOfflineReader::IdleBalance,
     ] {
         with_idle_offline_reader(RuntimeCpuId::new(1), reader, |remote| {
             request_idle_cpu_round_trip(1).unwrap();
-            wait_for(|| !matches!(idle_offline_rejection(), IdleOfflineRejection::Unclassified));
+            wait_for(|| remote.lifecycle_state() == CpuLifecycleState::Inactive);
             assert_eq!(
                 remote.lifecycle_state(),
-                ax_task::runtime::cpu::CpuLifecycleState::Inactive,
+                CpuLifecycleState::Inactive,
                 "new placement must be closed while the existing publisher is retained"
             );
             assert_eq!(
@@ -196,8 +230,26 @@ fn offline_waits_for_owner_publication() {
         })
         .unwrap();
         assert!(
-            wait_for_idle_cycle(),
-            "offline must complete after the publisher releases its lease"
+            !wait_for_idle_cycle(),
+            "reader release must not bypass an outstanding kernel timer"
         );
+        // A rejected offline operation must restore placement admission.
+        with_idle_offline_reader(
+            RuntimeCpuId::new(1),
+            IdleOfflineReader::OwnerDelivery,
+            |remote| {
+                assert_eq!(remote.lifecycle_state(), CpuLifecycleState::Online);
+            },
+        )
+        .unwrap();
     }
+    assert_eq!(
+        cancel_kernel_timer(timer),
+        Ok(KernelTimerCancelOutcome::Cancelled)
+    );
+    request_idle_cpu_round_trip(1).unwrap();
+    assert!(
+        wait_for_idle_cycle(),
+        "removing the timer veto must permit offline after both readers were released"
+    );
 }


### PR DESCRIPTION
CPU 下线检查已经持有 deadline base 锁，却经 `CpuRemote::is_quiescent_for_offline()` 再次获取同一把锁。原检查只提前判断 task timer，目标存在未来 kernel timer、且 ktimer worker 已静止时，会进入递归加锁并挂起。现在在一次 base 读取中用 `has_active_work()` 统一检查 task/kernel timer、到期事件及执行状态，删除重复检查和失去调用者的入口；有未清理定时器时正常拒绝下线并恢复 Online。

[原始 x86_64 CI](https://github.com/rcore-os/tgoskits/actions/runs/34667520408/job/103485136917) 在 reader 释放后返回 `CpuState`，而测试直接要求成功。这里的内部接口要求调用者先清理任务和定时器；释放 reader 只结束发布事务，不能证明整个 CPU 已静止。另外，测试等待的是每轮尝试都会清空的诊断快照，并在条件成立后重复读取，可能产生假失败。改为等待持有 reader 期间稳定的 `Inactive` 状态，等待函数首次观察条件成立即返回。

对照本地 Linux v7.1 的 `kernel/sched/core.c::sched_cpu_deactivate()`、`sched_cpu_wait_empty()` 和 `kernel/time/hrtimer.c::hrtimers_cpu_dying()`：Linux 先关闭 active placement、等待 reader，经过每 CPU 线程停驻及队列排空，再执行最终下线；hrtimer 迁移只获取一次旧 base 锁，嵌套锁属于另一 CPU 的新 base。当前内部接口没有完整的设备停驻或通用 timer 迁移编排，不能直接套用完整 sysfs 下线操作的成功前提。

现有回归按 Linux `tools/testing/selftests/cpu-hotplug/cpu-on-off-test.sh` 的操作后状态验证方式调整：

- 在目标 CPU 注册真实的未来 kernel timer，并等待注册线程退出及执行资源回收，建立明确的下线限制。
- 分别持有 owner-delivery reader 和 idle-balance claim，要求 placement 关闭且原请求不能完成。
- 释放 reader 后，要求保留定时器使下线被拒绝、CPU 恢复 Online；取消定时器后，重新发起一次下线/上线并要求成功。

这是对内部事务的适配，不表示 Linux 完整 CPU 热拔插会因未来定时器而失败。没有增加失败重试或放宽匹配规则；取消资源后再发起操作是不同前置条件的验证。最后的成功断言仍检查 reader 和 idle-balance 状态全部释放。

验证：

- 同一个最终测试，修复前因递归加锁在 `idle owner did not service CPU cycle` 失败，外层 xtask 返回 1；修复后通过，`1/1`。
- 临时移除 `IdlePullClaim::drop()` 的 claim 清理后，同一测试在取消 timer 后的成功断言失败；恢复后通过，证明没有掩盖 reader 清理遗漏。临时修改已移除。
- 最终执行 `cargo xtask arceos test qemu --arch x86_64 --test-group rust --test-case task-cpu-lifecycle`：通过，`1/1`。
- `cargo fmt`、`git diff --check`、`cargo xtask sync-lint --since 3651c52aa775c062018021e1dae2066dac0302eb`：通过；同步检查实际覆盖 5 个变更文件。
- 最终提交 `6be3323d7` 的窄测和同步检查已通过，删除旧路径后失去调用者的访问器也已清理。
- 最终提交 `6be3323d7` 的 [CI #34670518307](https://github.com/rcore-os/tgoskits/actions/runs/34670518307) 全部通过，41 项实际执行检查均为 success，包含远端 clippy、标准库测试、四架构 ArceOS/Starry QEMU、AxVisor 和板卡测试。四架构 ArceOS 日志均确认 `task-cpu-lifecycle` 实际执行并通过。
- 按请求未在本地运行 clippy 或全量 QEMU。

证据边界：原 CI 仅记录汇总的 `CpuState`，没有保留具体未静止资源，不能证明其返回与这里确定复现的递归锁是同一触发。此改动修正测试缺失的前置条件，并修复确定场景揭示的实际锁错误。
